### PR TITLE
Fix cases where messages are received twice.

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -54,9 +54,11 @@ module.exports = function(queue, topic, stackName, backoff) {
       if (!data.Messages || !data.Messages.length)
         return callback(null, []);
 
-      var envs = data.Messages.map(function(message) {
+      var envs = data.Messages.filter(function(message) {
+        var notInFlight = !messagesInFlight[message.MessageId];
         messagesInFlight[message.MessageId] = message.ReceiptHandle;
-
+        return notInFlight;
+      }).map(function(message) {
         var snsMessage = JSON.parse(message.Body);
 
         /**
@@ -100,6 +102,8 @@ module.exports = function(queue, topic, stackName, backoff) {
     var receives = Number(finishedTask.env.ApproximateReceiveCount);
     var handle = messagesInFlight[messageId];
 
+    if (!handle) return allDone();
+
     function messageMissing(err) {
       return /Message does not exist or is not available for visibility timeout change/.test(err.message);
     }
@@ -138,10 +142,12 @@ module.exports = function(queue, topic, stackName, backoff) {
       }
     });
 
-    queue.awaitAll(function(err) {
+    function allDone(err) {
       delete messagesInFlight[messageId];
       callback(err);
-    });
+    }
+
+    queue.awaitAll(allDone);
   };
 
   return messages;


### PR DESCRIPTION
Fixes #9 

This fix is for the case where a single watcher receives a single message twice. The multi-watcher case was actually already covered: a second attempt to delete the message from the queue will fail silently.