### PR TITLE
RunTask failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,6 @@ module.exports = {
   notifications: require('./lib/notifications'),
   messages: require('./lib/messages'),
   tasks: require('./lib/tasks'),
-  template: require('./lib/template')
+  template: require('./lib/template'),
+  resources: require('./lib/resources')
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -114,7 +114,7 @@ module.exports = function(config) {
           tasks.run(env, function(err) {
             if (!err) return next();
 
-            log.error(err);
+            log.warn(err.message);
 
             messages.complete({
               reason: err.message,

--- a/lib/main.js
+++ b/lib/main.js
@@ -112,6 +112,12 @@ module.exports = function(config) {
         queue.defer(function(next) {
           tasks.run(env, function(err) {
             if (!err) {
+              log.info(
+                '[status] in-flight: tasks %s | messages %s | concurrency %s',
+                Object.keys(tasks.inFlight).length,
+                Object.keys(messages.inFlight).length,
+                config.Concurrency
+              );
               log.info('[%s] started task for %s: %s', env.MessageId, env.Subject, env.Message);
               return next();
             }

--- a/lib/main.js
+++ b/lib/main.js
@@ -109,12 +109,14 @@ module.exports = function(config) {
 
       // Run a task for each message
       envs.forEach(function(env) {
-        log.info('[%s] received %s: %s', env.MessageId, env.Subject, env.Message);
         queue.defer(function(next) {
           tasks.run(env, function(err) {
-            if (!err) return next();
+            if (!err) {
+              log.info('[%s] started task for %s: %s', env.MessageId, env.Subject, env.Message);
+              return next();
+            }
 
-            log.warn(err.message);
+            log.warn('[%s] task did not run: %s', env.MessageId, err.message);
 
             messages.complete({
               reason: err.message,

--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,9 @@ module.exports = function(config) {
       }
 
       // If there are no free tasks, wait a second before polling tasks again
-      log.debug('free tasks: %s', status.free);
+      log.debug('%s in-flight tasks: %s', Object.keys(tasks.inFlight).length, Object.keys(tasks.inFlight).join(', '));
+      log.debug('task polling result: %j', status);
+      log.debug('free tasks: %s/%s', status.free, config.Concurrency);
       if (!status || !status.free)
         return setTimeout(main, 1000, config, emitter);
 
@@ -83,7 +85,7 @@ module.exports = function(config) {
         }
 
         // Poll SQS for up to `status.free` number of messages
-        log.debug('poll messages');
+        log.debug('poll for %s messages', status.free);
         messages.poll(status.free, function(err, envs) {
           if (err) {
             log.error(err);

--- a/lib/main.js
+++ b/lib/main.js
@@ -48,7 +48,9 @@ module.exports = function(config) {
     log.error('Error polling cluster resources: %s', err.message);
   });
 
-  (function status() {
+  var timer;
+
+  function status() {
     log.info(
       '[status] concurrency %s | tasks %s | messages %s | cpu: %s/%s | memory: %s/%s',
       config.Concurrency,
@@ -58,14 +60,17 @@ module.exports = function(config) {
       resources.status.available.memory, resources.status.registered.memory
     );
 
-    setTimeout(status, 30000).unref();
-  })();
+    timer = setTimeout(status, 30000).unref();
+  }
+
+  resources.once('update', status);
 
   (function main() {
     log.debug('starting loop');
     log.debug('should stop: %s', stop);
     if (stop) {
       emitter.emit('finish');
+      clearTimeout(timer);
       return stop = false;
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -41,6 +41,13 @@ module.exports = function(config) {
     Boolean(config.ExponentialBackoff)
   );
 
+  var resources = require('../lib/resources')(
+    config.Cluster,
+    config.TaskDefinition
+  ).on('error', function(err) {
+    log.error('Error polling cluster resources: %s', err.message);
+  });
+
   (function main() {
     log.debug('starting loop');
     log.debug('should stop: %s', stop);
@@ -84,6 +91,16 @@ module.exports = function(config) {
           sendNotification('[watchbot] message completion error', err.message);
         }
 
+        // make sure there are sufficient cluster resources to run anything
+        for (var count = status.free; count >= 0; count--) {
+          if (resources.adequate(count)) {
+            status.free = count;
+            break;
+          }
+        }
+
+        if (!status.free) return setTimeout(main, 1000, config, emitter);
+
         // Poll SQS for up to `status.free` number of messages
         log.debug('poll for %s messages', status.free);
         messages.poll(status.free, function(err, envs) {
@@ -112,13 +129,15 @@ module.exports = function(config) {
         queue.defer(function(next) {
           tasks.run(env, function(err) {
             if (!err) {
+              log.info('[%s] started task for %s: %s', env.MessageId, env.Subject, env.Message);
               log.info(
-                '[status] in-flight: tasks %s | messages %s | concurrency %s',
+                '[status] tasks %s | messages %s | concurrency %s | cpu: %s | memory: %s',
                 Object.keys(tasks.inFlight).length,
                 Object.keys(messages.inFlight).length,
-                config.Concurrency
+                config.Concurrency,
+                resources.available().cpu,
+                resources.available().memory
               );
-              log.info('[%s] started task for %s: %s', env.MessageId, env.Subject, env.Message);
               return next();
             }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -48,6 +48,19 @@ module.exports = function(config) {
     log.error('Error polling cluster resources: %s', err.message);
   });
 
+  (function status() {
+    log.info(
+      '[status] concurrency %s | tasks %s | messages %s | cpu: %s/%s | memory: %s/%s',
+      config.Concurrency,
+      Object.keys(tasks.inFlight).length,
+      Object.keys(messages.inFlight).length,
+      resources.status.available.cpu, resources.status.registered.cpu,
+      resources.status.available.memory, resources.status.registered.memory
+    );
+
+    setTimeout(status, 30000).unref();
+  })();
+
   (function main() {
     log.debug('starting loop');
     log.debug('should stop: %s', stop);
@@ -91,7 +104,15 @@ module.exports = function(config) {
           sendNotification('[watchbot] message completion error', err.message);
         }
 
-        // make sure there are sufficient cluster resources to run anything
+        completedTasks(status);
+      });
+    }
+
+    function completedTasks(status) {
+      log.debug('poll cluster resource reservations');
+      resources.available(function(err) {
+        if (err) resources.emit('error', err);
+
         for (var count = status.free; count >= 0; count--) {
           if (resources.adequate(count)) {
             status.free = count;
@@ -99,24 +120,27 @@ module.exports = function(config) {
           }
         }
 
+        log.debug('resources available to run %s tasks', status.free);
         if (!status.free) return setTimeout(main, 1000, config, emitter);
+        polledResources(status);
+      });
+    }
 
-        // Poll SQS for up to `status.free` number of messages
-        log.debug('poll for %s messages', status.free);
-        messages.poll(status.free, function(err, envs) {
-          if (err) {
-            log.error(err);
-            sendNotification('[watchbot] message polling error', err.message);
-          }
+    function polledResources(status) {
+      log.debug('poll for %s messages', status.free);
+      messages.poll(status.free, function(err, envs) {
+        if (err) {
+          log.error(err);
+          sendNotification('[watchbot] message polling error', err.message);
+        }
 
-          // If there are no messages, wait a second before repeating
-          log.debug('%s messages in flight: %s', Object.keys(messages.inFlight).length, Object.keys(messages.inFlight).join(', '));
-          log.debug('messages received: %s', envs ? envs.length : 0);
-          if (!envs || !envs.length)
-            return setTimeout(main, 1000, config, emitter);
+        // If there are no messages, wait a second before repeating
+        log.debug('%s messages in flight: %s', Object.keys(messages.inFlight).length, Object.keys(messages.inFlight).join(', '));
+        log.debug('messages received: %s', envs ? envs.length : 0);
+        if (!envs || !envs.length)
+          return setTimeout(main, 1000, config, emitter);
 
-          messagesPolled(envs);
-        });
+        messagesPolled(envs);
       });
     }
 
@@ -130,14 +154,6 @@ module.exports = function(config) {
           tasks.run(env, function(err) {
             if (!err) {
               log.info('[%s] started task for %s: %s', env.MessageId, env.Subject, env.Message);
-              log.info(
-                '[status] concurrency %s | tasks %s | messages %s | cpu: %s/%s | memory: %s/%s',
-                config.Concurrency,
-                Object.keys(tasks.inFlight).length,
-                Object.keys(messages.inFlight).length,
-                resources.available().cpu, resources.registered().cpu,
-                resources.available().memory, resources.registered().memory
-              );
               return next();
             }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -131,12 +131,12 @@ module.exports = function(config) {
             if (!err) {
               log.info('[%s] started task for %s: %s', env.MessageId, env.Subject, env.Message);
               log.info(
-                '[status] tasks %s | messages %s | concurrency %s | cpu: %s | memory: %s',
+                '[status] concurrency %s | tasks %s | messages %s | cpu: %s/%s | memory: %s/%s',
+                config.Concurrency,
                 Object.keys(tasks.inFlight).length,
                 Object.keys(messages.inFlight).length,
-                config.Concurrency,
-                resources.available().cpu,
-                resources.available().memory
+                resources.available().cpu, resources.registered().cpu,
+                resources.available().memory, resources.registered().memory
               );
               return next();
             }

--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,7 @@ module.exports = function(config) {
       }
 
       // If there are no free tasks, wait a second before polling tasks again
-      log.debug('%s in-flight tasks: %s', Object.keys(tasks.inFlight).length, Object.keys(tasks.inFlight).join(', '));
+      log.debug('%s tasks in-flight: %s', Object.keys(tasks.inFlight).length, Object.keys(tasks.inFlight).join(', '));
       log.debug('task polling result: %j', status);
       log.debug('free tasks: %s/%s', status.free, config.Concurrency);
       if (!status || !status.free)
@@ -93,6 +93,7 @@ module.exports = function(config) {
           }
 
           // If there are no messages, wait a second before repeating
+          log.debug('%s messages in flight: %s', Object.keys(messages.inFlight).length, Object.keys(messages.inFlight).join(', '));
           log.debug('messages received: %s', envs ? envs.length : 0);
           if (!envs || !envs.length)
             return setTimeout(main, 1000, config, emitter);
@@ -116,9 +117,9 @@ module.exports = function(config) {
             log.error(err);
 
             messages.complete({
-              reason: 'task failed to run',
+              reason: err.message,
               env: env,
-              outcome: tasks.outcome.retry
+              outcome: err.code === 'NotRun' ? tasks.outcome.noop : tasks.outcome.retry
             }, function(err) {
               if (err) {
                 log.error(err);

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -23,13 +23,13 @@ module.exports = function(queue, topic, stackName, backoff) {
     params: { QueueUrl: queue }
   });
 
-  var sendNotification = notifications(topic).send;
-  var messagesInFlight = {};
-
   /**
    * An SQS message tracker
    */
   var messages = {};
+
+  var sendNotification = notifications(topic).send;
+  var messagesInFlight = messages.inFlight = {};
 
   /**
    * Poll SQS to find jobs

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -118,10 +118,10 @@ module.exports = function(queue, topic, stackName, backoff) {
         });
       }
 
-      if (toDo === 'return') {
+      if (toDo === 'return' || toDo === 'immediate') {
         queue.defer(function(next) {
           if (backoff && receives > 14) return next();
-          var timeout = backoff ? Math.pow(2, receives) : 0;
+          var timeout = backoff && toDo === 'return' ? Math.pow(2, receives) : 0;
 
           sqs.changeMessageVisibility({
             ReceiptHandle: handle,

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -70,7 +70,7 @@ module.exports = function(cluster, taskDef) {
     });
   })();
 
-  setTimeout(update, 5000).unref();
+  setInterval(update, 5000).unref();
   update();
 
   resources.available = function() {

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -49,16 +49,17 @@ module.exports = function(cluster, taskDef) {
     });
   }
 
-  function update() {
+  (function update() {
     status.instances = [];
     listInstances(undefined, function(err) {
       if (err) return resources.emit('error', err);
       checkResources(function(err) {
         if (err) return resources.emit('error', err);
         resources.emit('update', status.available);
+        setTimeout(update, 1000).unref();
       });
     });
-  }
+  })();
 
   (function required() {
     ecs.describeTaskDefinition({ taskDefinition: taskDef }, function(err, data) {
@@ -70,8 +71,9 @@ module.exports = function(cluster, taskDef) {
     });
   })();
 
-  setInterval(update, 5000).unref();
-  update();
+  resources.registered = function() {
+    return status.registered;
+  };
 
   resources.available = function() {
     return status.available;

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -1,0 +1,88 @@
+var AWS = require('aws-sdk');
+var events = require('events');
+
+module.exports = function(cluster, taskDef) {
+  var ecs = new AWS.ECS({
+    region: cluster.split(':')[3]
+  });
+
+  var resources = new events.EventEmitter();
+
+  var status = {
+    instances: [],
+    registered: { cpu: 0, memory: 0 },
+    available: { cpu: 0, memory: 0 },
+    required: { cpu: 0, memory: 0 }
+  };
+
+  function listInstances(next, callback) {
+    ecs.listContainerInstances({ nextToken: next, cluster: cluster }, function(err, data) {
+      if (err) return callback(err);
+      status.instances = status.instances.concat(data.containerInstanceArns);
+      if (data.nextToken) return listInstances(data.nextToken, callback);
+      callback();
+    });
+  }
+
+  function checkResources(callback) {
+    ecs.describeContainerInstances({ containerInstances: status.instances, cluster: cluster }, function(err, data) {
+      if (err) return callback(err);
+
+      status.registered = { cpu: 0, memory: 0 };
+      status.available = { cpu: 0, memory: 0 };
+      data.containerInstances.forEach(function(instance) {
+        status.registered.cpu += instance.registeredResources.find(function(resource) {
+          return resource.name === 'CPU';
+        }).integerValue;
+        status.registered.memory += instance.registeredResources.find(function(resource) {
+          return resource.name === 'MEMORY';
+        }).integerValue;
+        status.available.cpu += instance.remainingResources.find(function(resource) {
+          return resource.name === 'CPU';
+        }).integerValue;
+        status.available.memory += instance.remainingResources.find(function(resource) {
+          return resource.name === 'MEMORY';
+        }).integerValue;
+      });
+
+      callback();
+    });
+  }
+
+  function update() {
+    status.instances = [];
+    listInstances(undefined, function(err) {
+      if (err) return resources.emit('error', err);
+      checkResources(function(err) {
+        if (err) return resources.emit('error', err);
+        resources.emit('update', status.available);
+      });
+    });
+  }
+
+  (function required() {
+    ecs.describeTaskDefinition({ taskDefinition: taskDef }, function(err, data) {
+      if (err) return resources.emit('error', err);
+      data.taskDefinition.containerDefinitions.forEach(function(container) {
+        status.required.cpu += container.cpu;
+        status.required.memory += container.memory;
+      });
+    });
+  })();
+
+  setTimeout(update, 5000).unref();
+  update();
+
+  resources.available = function() {
+    return status.available;
+  };
+
+  resources.adequate = function(tasks) {
+    var cpu = status.required.cpu * tasks;
+    var memory = status.required.memory * tasks;
+
+    return status.available.cpu >= cpu && status.available.memory >= memory;
+  };
+
+  return resources;
+};

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -8,7 +8,7 @@ module.exports = function(cluster, taskDef) {
 
   var resources = new events.EventEmitter();
 
-  var status = {
+  var status = resources.status = {
     instances: [],
     registered: { cpu: 0, memory: 0 },
     available: { cpu: 0, memory: 0 },
@@ -24,7 +24,25 @@ module.exports = function(cluster, taskDef) {
     });
   }
 
-  function checkResources(callback) {
+  (function update() {
+    status.instances = [];
+    listInstances(undefined, function(err) {
+      if (err) return resources.emit('error', err);
+      setTimeout(update, 10000).unref();
+    });
+  })();
+
+  (function required() {
+    ecs.describeTaskDefinition({ taskDefinition: taskDef }, function(err, data) {
+      if (err) return resources.emit('error', err);
+      data.taskDefinition.containerDefinitions.forEach(function(container) {
+        status.required.cpu += container.cpu;
+        status.required.memory += container.memory;
+      });
+    });
+  })();
+
+  resources.available = function(callback) {
     ecs.describeContainerInstances({ containerInstances: status.instances, cluster: cluster }, function(err, data) {
       if (err) return callback(err);
 
@@ -47,42 +65,11 @@ module.exports = function(cluster, taskDef) {
 
       callback();
     });
-  }
-
-  (function update() {
-    status.instances = [];
-    listInstances(undefined, function(err) {
-      if (err) return resources.emit('error', err);
-      checkResources(function(err) {
-        if (err) return resources.emit('error', err);
-        resources.emit('update', status.available);
-        setTimeout(update, 1000).unref();
-      });
-    });
-  })();
-
-  (function required() {
-    ecs.describeTaskDefinition({ taskDefinition: taskDef }, function(err, data) {
-      if (err) return resources.emit('error', err);
-      data.taskDefinition.containerDefinitions.forEach(function(container) {
-        status.required.cpu += container.cpu;
-        status.required.memory += container.memory;
-      });
-    });
-  })();
-
-  resources.registered = function() {
-    return status.registered;
-  };
-
-  resources.available = function() {
-    return status.available;
   };
 
   resources.adequate = function(tasks) {
     var cpu = status.required.cpu * tasks;
     var memory = status.required.memory * tasks;
-
     return status.available.cpu >= cpu && status.available.memory >= memory;
   };
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -11,7 +11,7 @@ module.exports = function(cluster, taskDef) {
   var status = resources.status = {
     instances: [],
     registered: { cpu: 0, memory: 0 },
-    available: { cpu: 0, memory: 0 },
+    available: { cpu: Infinity, memory: Infinity },
     required: { cpu: 0, memory: 0 }
   };
 
@@ -63,6 +63,7 @@ module.exports = function(cluster, taskDef) {
         }).integerValue;
       });
 
+      resources.emit('update');
       callback();
     });
   };

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -60,6 +60,9 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency) {
       });
 
       if (data.failures && data.failures.length) {
+        if (data.failures[0].reason === 'RESOURCE:MEMORY')
+          return setTimeout(tasks.run, 5000, env, callback);
+
         err = new Error(data.failures[0].reason);
         err.code = 'NotRun';
         return callback(err);

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -22,7 +22,7 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency) {
    * An ECS task runner and status tracker
    */
   var tasks = {};
-  var tasksInFlight = {};
+  var tasksInFlight = tasks.inFlight = {};
 
   /**
    * Runs a task if currently below desired concurrency

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -84,7 +84,7 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency) {
    */
   tasks.outcome = {
     success: 'delete',
-    noop: 'return',
+    noop: 'immediate',
     fail: 'delete & notify',
     retry: 'return & notify'
   };

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -59,6 +59,12 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency) {
         tasksInFlight[task.taskArn] = true;
       });
 
+      if (data.failures && data.failures.length) {
+        err = new Error(data.failures[0].reason);
+        err.code = 'NotRun';
+        return callback(err);
+      }
+
       callback();
     });
   };

--- a/lib/template.js
+++ b/lib/template.js
@@ -390,11 +390,24 @@ module.exports = function(taskEnv) {
               },
               {
                 Effect: 'Allow',
-                Action: ['ecs:DescribeTasks'],
+                Action: [
+                  'ecs:DescribeTasks',
+                  'ecs:DescribeContainerInstances'
+                ],
                 Resource: '*',
                 Condition: {
                   StringEquals: { 'ecs:cluster': { Ref: 'WatchbotCluster' } }
                 }
+              },
+              {
+                Effect: 'Allow',
+                Action: ['ecs:ListContainerInstances'],
+                Resource: { Ref: 'WatchbotCluster' }
+              },
+              {
+                Effect: 'Allow',
+                Action: ['ecs:DescribeTaskDefinitions'],
+                Resource: '*'
               }
             ]
           }

--- a/lib/template.js
+++ b/lib/template.js
@@ -406,7 +406,7 @@ module.exports = function(taskEnv) {
               },
               {
                 Effect: 'Allow',
-                Action: ['ecs:DescribeTaskDefinitions'],
+                Action: ['ecs:DescribeTaskDefinition'],
                 Resource: '*'
               }
             ]

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -1,0 +1,99 @@
+var util = require('./util');
+var watchbot = require('..');
+
+util.mock('[resources] describeTaskDefinition error', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var context = this;
+
+  context.ecs.failTask = true;
+
+  watchbot.resources(cluster, taskDef)
+    .on('error', function(err) {
+      assert.equal(err.message, 'Mock ECS error', 'expected error emitted');
+      assert.end();
+    });
+});
+
+util.mock('[resources] listInstances error', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var context = this;
+
+  context.ecs.failInstances = true;
+
+  watchbot.resources(cluster, taskDef)
+    .on('error', function(err) {
+      assert.equal(err.message, 'Mock ECS error', 'expected error emitted');
+      assert.end();
+    });
+});
+
+util.mock('[resources] listInstances pagination', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var context = this;
+
+  context.ecs.instances = [
+    'arn:aws:ecs:us-east-1:1234567890:some/fake0',
+    'arn:aws:ecs:us-east-1:1234567890:some/fake1'
+  ];
+
+  var resources = watchbot.resources(cluster, taskDef);
+
+  setTimeout(function() {
+    assert.deepEqual(resources.status.instances, context.ecs.instances, 'returned all instances');
+    assert.end();
+  }, 1000);
+});
+
+util.mock('[resources] available', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+
+  var resources = watchbot.resources(cluster, taskDef).on('update', function() {
+    assert.pass('emitted update event');
+  });
+
+  resources.available(function(err) {
+    if (err) assert.end(err);
+
+    assert.deepEqual(resources.status, {
+      instances: [ 'arn:aws:ecs:us-east-1:1234567890:some/fake' ],
+      registered: { cpu: 100, memory: 100 },
+      available: { cpu: 100, memory: 100 },
+      required: { cpu: 0, memory: 5 }
+    }, 'collected expected resource info');
+
+    assert.end();
+  });
+});
+
+util.mock('[resources] available error', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var context = this;
+
+  context.ecs.fail = true;
+
+  watchbot.resources(cluster, taskDef).available(function(err) {
+    if (!err) assert.end('expected function to fail');
+    assert.equal(err.message, 'Mock ECS error', 'expected error message');
+    assert.end();
+  });
+});
+
+util.mock('[resources] adequate', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+
+  var resources = watchbot.resources(cluster, taskDef);
+
+  resources.available(function(err) {
+    if (err) return assert.end(err);
+
+    assert.ok(resources.adequate(10), 'adequate resources for 10 tasks');
+    assert.notOk(resources.adequate(100), 'inadequate resources for 100 tasks');
+    assert.end();
+  });
+});

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -140,7 +140,7 @@ util.mock('[tasks] poll - one of each outcome', function(assert) {
         { reason: '1', env: { exit: '1', MessageId: 'exit-1' }, outcome: 'return & notify' },
         { reason: '2', env: { exit: '2', MessageId: 'exit-2' }, outcome: 'return & notify' },
         { reason: '3', env: { exit: '3', MessageId: 'exit-3' }, outcome: 'delete & notify' },
-        { reason: '4', env: { exit: '4', MessageId: 'exit-4' }, outcome: 'return' },
+        { reason: '4', env: { exit: '4', MessageId: 'exit-4' }, outcome: 'immediate' },
         { reason: 'match', env: { exit: 'match', MessageId: 'exit-match' }, outcome: 'delete' },
         { reason: 'mismatched', env: { exit: 'mismatch', MessageId: 'exit-mismatch' }, outcome: 'return & notify' }
       ], 'expected taskStatus reported');

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -69,6 +69,21 @@ util.mock('[tasks] run - runTask request error', function(assert) {
   });
 });
 
+util.mock('[tasks] run - runTask failure (out of resources)', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var containerName = 'container';
+  var concurrency = 10;
+  var env = { resources: 'true' };
+
+  var tasks = watchbot.tasks(cluster, taskDef, containerName, concurrency);
+  tasks.run(env, function(err) {
+    if (!err) return assert.end('should have failed');
+    assert.equal(err.code, 'NotRun', 'ecs.runTask failure passed to callback');
+    assert.end();
+  });
+});
+
 util.mock('[tasks] poll - no tasks in progress', function(assert) {
   var context = this;
   var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';

--- a/test/util.js
+++ b/test/util.js
@@ -77,10 +77,20 @@ module.exports.mock = function(name, callback) {
       if (params.overrides.containerOverrides[0].environment[0].name === 'error')
         return callback(new Error('Mock ECS error'));
 
+      if (params.overrides.containerOverrides[0].environment[0].name === 'resources')
+        return callback(null, {
+          tasks: [],
+          failures: [{ reason: 'RESOURCE:MEMORY' }]
+        });
+
       var messageId = params.overrides.containerOverrides[0].environment.find(function(item) {
         return item.name === 'MessageId';
       });
       if (messageId && messageId.value === 'ecs-error') return callback(new Error('Mock ECS error'));
+      if (messageId && messageId.value === 'ecs-failure') return callback(null, {
+        tasks: [],
+        failures: [{ reason: 'RESOURCE:MEMORY' }]
+      });
 
       var arn = crypto.createHash('md5').update(JSON.stringify(params)).digest('hex');
       tasks[arn] = params.overrides.containerOverrides[0].environment;

--- a/test/util.js
+++ b/test/util.js
@@ -21,7 +21,10 @@ module.exports.mock = function(name, callback) {
       },
       ecs: {
         runTask: [],
-        describeTasks: []
+        describeTasks: [],
+        describeTaskDefinition: [],
+        describeContainerInstances: [],
+        listContainerInstances: []
       },
       logs: []
     };
@@ -166,6 +169,39 @@ module.exports.mock = function(name, callback) {
       }, []);
 
       callback(null, data);
+    };
+    AWS.ECS.prototype.describeTaskDefinition = function(params, callback) {
+      context.ecs.describeTaskDefinition.push(params);
+      callback(null, {
+        taskDefinition: {
+          containerDefinitions: [
+            { cpu: 0, memory: 0 }
+          ]
+        }
+      });
+    };
+    AWS.ECS.prototype.listContainerInstances = function(params, callback) {
+      context.ecs.listContainerInstances.push(params);
+      callback(null, {
+        instances: ['arn:aws:ecs:us-east-1:1234567890:some/fake']
+      });
+    };
+    AWS.ECS.prototype.describeContainerInstances = function(params, callback) {
+      context.ecs.describeContainerInstances.push(params);
+      callback(null, {
+        containerInstances: [
+          {
+            registeredResources: [
+              { name: 'CPU', integerValue: Infinity },
+              { name: 'MEMORY', integerValue: Infinity }
+            ],
+            remainingResources: [
+              { name: 'CPU', integerValue: Infinity },
+              { name: 'MEMORY', integerValue: Infinity }
+            ]
+          }
+        ]
+      });
     };
 
     console.log = function() {


### PR DESCRIPTION
When the watcher makes a `runTask` request, the ECS API will respond with a "failure" if there are insufficient resources available in the cluster to run the requested task.

For example, if you've requested to run a task with 1024GB RAM but all of the cluster's RAM is already reserved, the response to the `runTask` request will include a message `RESOURCE:MEMORY`.

What I've done here so far is to:

- adjust the system to return messages to SQS if they were received, and then a task failed to run
- adjust the `tasks.outcome.noop` to return messages immediately, with no visibility timeout, even if the env specifies a desire for exponential backoff. Backoff will only apply to messages returned to the queue as a result of a task that ran and failed, not one that failed to run.

The problem here is that exponential backoff is calculated based on the number of times a message has been received. If messages are being received and dropped back to SQS as a no-op due to resource limitations, then once they are actually processed, if they fail, they may get a far too large timeout applied to them.