### PR TITLE
Prevent permission thrashing during deploys

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -372,7 +372,18 @@ module.exports = function(taskEnv) {
               {
                 Effect: 'Allow',
                 Action: ['ecs:RunTask'],
-                Resource: { Ref: 'WatchbotTask' },
+                Resource: {
+                  'Fn::Join': [
+                    '', [
+                      'arn:aws:ecs:',
+                      { Ref: 'AWS::Region' }, ':',
+                      { Ref: 'AWS::AccountId' },
+                      ':task-definition/',
+                      { Ref: 'AWS::StackName' },
+                      '*'
+                    ]
+                  ]
+                },
                 Condition: {
                   StringEquals: { 'ecs:cluster': { Ref: 'WatchbotCluster' } }
                 }


### PR DESCRIPTION
If the watcher is not given a `*` permission on the tasks that its allowed to run, an update to the stack can create a new TaskDefinition and lead to lots of failed jobs while the watcher service rolls over onto the new task.