### PR TITLE
Improved task failure notifications

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -99,7 +99,7 @@ module.exports = function(config) {
 
       // Handle each finished task
       status.forEach(function(finishedTask) {
-        log.info('[%s] finished | outcome: %s', finishedTask.env.MessageId, finishedTask.outcome);
+        log.info('[%s] finished | outcome: %s | reason: %s', finishedTask.env.MessageId, finishedTask.outcome, finishedTask.reason);
         queue.defer(messages.complete, finishedTask);
       });
 
@@ -165,6 +165,7 @@ module.exports = function(config) {
             log.warn('[%s] task did not run: %s', env.MessageId, err.message);
 
             messages.complete({
+              arns: {},
               reason: err.message,
               env: env,
               outcome: err.code === 'NotRun' ? tasks.outcome.noop : tasks.outcome.retry

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -134,11 +134,24 @@ module.exports = function(queue, topic, stackName, backoff) {
       }
 
       if (toDo === 'notify') {
-        queue.defer(
-          sendNotification,
-          '[watchbot] failed job',
-          util.format('At %s, job %s failed on %s', (new Date()).toUTCString(), messageId, stackName)
-        );
+        var subject = util.format('%s failed processing message %s', stackName, messageId);
+        if (subject.length > 100) subject = util.format('%s failed task', stackName);
+        if (subject.length > 100) subject = util.format('Watchbot task failure: %s', messageId);
+
+        var message = util.format('At %s, processing message %s failed on %s\n\n', (new Date()).toUTCString(), messageId, stackName);
+        message += util.format('Reported reason: %s\n\n', finishedTask.reason);
+
+        message += 'Message information:\n';
+        Object.keys(finishedTask.env).forEach(function(key) {
+          message += util.format('%s: %s\n', key, finishedTask.env[key]);
+        });
+
+        message += '\nRuntime resources:\n';
+        message += util.format('Cluster ARN: %s\n', finishedTask.arns.cluster);
+        message += util.format('Instance ARN: %s\n', finishedTask.arns.instance);
+        message += util.format('Task ARN: %s\n', finishedTask.arns.task);
+
+        queue.defer(sendNotification, subject, message);
       }
     });
 

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -139,7 +139,9 @@ module.exports = function(queue, topic, stackName, backoff) {
         if (subject.length > 100) subject = util.format('Watchbot task failure: %s', messageId);
 
         var message = util.format('At %s, processing message %s failed on %s\n\n', (new Date()).toUTCString(), messageId, stackName);
-        message += util.format('Reported reason: %s\n\n', finishedTask.reason);
+
+        message += util.format('Task outcome: %s\n\n', finishedTask.outcome);
+        message += util.format('Task stopped reason: %s\n\n', finishedTask.reason);
 
         message += 'Message information:\n';
         Object.keys(finishedTask.env).forEach(function(key) {

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -122,12 +122,21 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency) {
          * An object providing information about the outcome of a task
          *
          * @name finishedTask
+         * @property {object} arns - indentifiers for resources involved in running the task
+         * @property {string} arns.cluster - the ECS cluster's ARN
+         * @property {string} arns.instance - the EC2's ARN (use in ecs.describeContainerInstances requests)
+         * @property {string} arns.task - the tasks ARN (use in ecs.describeTasks requests)
          * @property {string} reason - the ECS-provided reason that the task ended
          * @property {object} env - key-value pairs indicating the task's
          * environment variables
          * @property {string} outcome - one of the outcomes defined by {@link tasks.outcome}
          */
         var finishedTask = {
+          arns: {
+            cluster: task.clusterArn,
+            instance: task.instanceArn,
+            task: task.taskArn
+          },
           reason: task.stoppedReason,
           env: task.overrides.containerOverrides[0].environment.reduce(function(env, item) {
             env[item.name] = item.value;

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -134,7 +134,7 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency) {
         var finishedTask = {
           arns: {
             cluster: task.clusterArn,
-            instance: task.instanceArn,
+            instance: task.containerInstanceArn,
             task: task.taskArn
           },
           reason: task.stoppedReason,

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -98,10 +98,11 @@ util.mock('[main] task running error', function(assert) {
     assert.ok(context.logs.find(function(log) {
       return /Mock ECS error/.test(log);
     }), 'printed error message');
+
     util.collectionsEqual(assert, context.sns.publish, [
       {
-        Subject: '[watchbot] failed job',
-        Message: 'At ${date}, job ecs-error failed on watchbot-testing'
+        Subject: config.StackName + ' failed processing message ecs-error',
+        Message: 'At ${date}, processing message ecs-error failed on ' + config.StackName + '\n\nReported reason: Mock ECS error\n\nMessage information:\nMessageId: ecs-error\nSubject: subject1\nMessage: message1\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: undefined\nInstance ARN: undefined\nTask ARN: undefined\n'
       }
     ], 'sent expected error notification');
     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
@@ -254,12 +255,12 @@ util.mock('[main] manage messages for completed tasks', function(assert) {
     ], 'expected sqs.changeMessageVisibility requests');
     util.collectionsEqual(assert, context.sns.publish, [
       {
-        Subject: '[watchbot] failed job',
-        Message: 'At ${date}, job finish-2 failed on watchbot-testing'
+        Subject: config.StackName + ' failed processing message finish-2',
+        Message: 'At ${date}, processing message finish-2 failed on ' + config.StackName + '\n\nReported reason: 2\n\nMessage information:\nMessageId: finish-2\nSubject: subject2\nMessage: message2\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: d20ddb7be4a5f242623d59188d8f5c34\n'
       },
       {
-        Subject: '[watchbot] failed job',
-        Message: 'At ${date}, job finish-3 failed on watchbot-testing'
+        Subject: config.StackName + ' failed processing message finish-3',
+        Message: 'At ${date}, processing message finish-3 failed on ' + config.StackName + '\n\nReported reason: 3\n\nMessage information:\nMessageId: finish-3\nSubject: subject3\nMessage: message3\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 3b397ad2b4cd1154e7558efc6b16e018\n'
       }
     ], 'expected sns.publish requests');
     config.Concurrency = 3;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -102,7 +102,7 @@ util.mock('[main] task running error', function(assert) {
     util.collectionsEqual(assert, context.sns.publish, [
       {
         Subject: config.StackName + ' failed processing message ecs-error',
-        Message: 'At ${date}, processing message ecs-error failed on ' + config.StackName + '\n\nReported reason: Mock ECS error\n\nMessage information:\nMessageId: ecs-error\nSubject: subject1\nMessage: message1\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: undefined\nInstance ARN: undefined\nTask ARN: undefined\n'
+        Message: 'At ${date}, processing message ecs-error failed on ' + config.StackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: Mock ECS error\n\nMessage information:\nMessageId: ecs-error\nSubject: subject1\nMessage: message1\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: undefined\nInstance ARN: undefined\nTask ARN: undefined\n'
       }
     ], 'sent expected error notification');
     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
@@ -256,11 +256,11 @@ util.mock('[main] manage messages for completed tasks', function(assert) {
     util.collectionsEqual(assert, context.sns.publish, [
       {
         Subject: config.StackName + ' failed processing message finish-2',
-        Message: 'At ${date}, processing message finish-2 failed on ' + config.StackName + '\n\nReported reason: 2\n\nMessage information:\nMessageId: finish-2\nSubject: subject2\nMessage: message2\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: d20ddb7be4a5f242623d59188d8f5c34\n'
+        Message: 'At ${date}, processing message finish-2 failed on ' + config.StackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: 2\n\nMessage information:\nMessageId: finish-2\nSubject: subject2\nMessage: message2\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: d20ddb7be4a5f242623d59188d8f5c34\n'
       },
       {
         Subject: config.StackName + ' failed processing message finish-3',
-        Message: 'At ${date}, processing message finish-3 failed on ' + config.StackName + '\n\nReported reason: 3\n\nMessage information:\nMessageId: finish-3\nSubject: subject3\nMessage: message3\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 3b397ad2b4cd1154e7558efc6b16e018\n'
+        Message: 'At ${date}, processing message finish-3 failed on ' + config.StackName + '\n\nTask outcome: delete & notify\n\nTask stopped reason: 3\n\nMessage information:\nMessageId: finish-3\nSubject: subject3\nMessage: message3\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 3b397ad2b4cd1154e7558efc6b16e018\n'
       }
     ], 'expected sns.publish requests');
     config.Concurrency = 3;

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -257,11 +257,11 @@ util.mock('[messages] complete - no backoff', function(assert) {
       util.collectionsEqual(assert, context.sns.publish, [
         {
           Subject: stackName + ' failed processing message 2',
-          Message: 'At ${date}, processing message 2 failed on ' + stackName + '\n\nReported reason: fail\n\nMessage information:\nMessageId: 2\nSubject: subject2\nMessage: message2\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: task-arn\n'
+          Message: 'At ${date}, processing message 2 failed on ' + stackName + '\n\nTask outcome: delete & notify\n\nTask stopped reason: fail\n\nMessage information:\nMessageId: 2\nSubject: subject2\nMessage: message2\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: task-arn\n'
         },
         {
           Subject: stackName + ' failed processing message 4',
-          Message: 'At ${date}, processing message 4 failed on ' + stackName + '\n\nReported reason: retry\n\nMessage information:\nMessageId: 4\nSubject: subject4\nMessage: message4\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: task-arn\n'
+          Message: 'At ${date}, processing message 4 failed on ' + stackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: retry\n\nMessage information:\nMessageId: 4\nSubject: subject4\nMessage: message4\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: task-arn\n'
         }
       ], 'expected notifications sent');
       assert.end();

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -161,6 +161,11 @@ util.mock('[messages] complete - no backoff', function(assert) {
     // Then generate fake finishedTask objects for each message
     var finishedTasks = [
       {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
         reason: 'success',
         env: {
           MessageId: '1',
@@ -173,6 +178,11 @@ util.mock('[messages] complete - no backoff', function(assert) {
         outcome: 'delete'
       },
       {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
         reason: 'fail',
         env: {
           MessageId: '2',
@@ -185,6 +195,11 @@ util.mock('[messages] complete - no backoff', function(assert) {
         outcome: 'delete & notify'
       },
       {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
         reason: 'noop',
         env: {
           MessageId: '3',
@@ -197,6 +212,11 @@ util.mock('[messages] complete - no backoff', function(assert) {
         outcome: 'return'
       },
       {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
         reason: 'retry',
         env: {
           MessageId: '4',
@@ -235,8 +255,14 @@ util.mock('[messages] complete - no backoff', function(assert) {
         { ReceiptHandle: '4', VisibilityTimeout: 0 }
       ], 'expected messages returned to queue');
       util.collectionsEqual(assert, context.sns.publish, [
-        { Subject: '[watchbot] failed job', Message: 'At ${date}, job 2 failed on ' + stackName },
-        { Subject: '[watchbot] failed job', Message: 'At ${date}, job 4 failed on ' + stackName }
+        {
+          Subject: stackName + ' failed processing message 2',
+          Message: 'At ${date}, processing message 2 failed on ' + stackName + '\n\nReported reason: fail\n\nMessage information:\nMessageId: 2\nSubject: subject2\nMessage: message2\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: task-arn\n'
+        },
+        {
+          Subject: stackName + ' failed processing message 4',
+          Message: 'At ${date}, processing message 4 failed on ' + stackName + '\n\nReported reason: retry\n\nMessage information:\nMessageId: 4\nSubject: subject4\nMessage: message4\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: task-arn\n'
+        }
       ], 'expected notifications sent');
       assert.end();
     });
@@ -264,6 +290,11 @@ util.mock('[messages] complete - with backoff', function(assert) {
     // Then generate fake finishedTask objects for each message
     var finishedTasks = [
       {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
         reason: 'noop',
         env: {
           MessageId: '3',
@@ -276,6 +307,11 @@ util.mock('[messages] complete - with backoff', function(assert) {
         outcome: 'return'
       },
       {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
         reason: 'retry',
         env: {
           MessageId: '4',
@@ -326,6 +362,11 @@ util.mock('[messages] complete - message not found in sqs', function(assert) {
     // Then generate fake finishedTask objects for each message
     var finishedTasks = [
       {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
         reason: 'noop',
         env: {
           MessageId: '1',
@@ -338,6 +379,11 @@ util.mock('[messages] complete - message not found in sqs', function(assert) {
         outcome: 'return'
       },
       {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
         reason: 'success',
         env: {
           MessageId: '2',
@@ -389,6 +435,11 @@ util.mock('[messages] complete - message cannot backoff anymore', function(asser
     // Then generate fake finishedTask objects for each message
     var finishedTasks = [
       {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
         reason: 'noop',
         env: {
           MessageId: '1',
@@ -412,6 +463,110 @@ util.mock('[messages] complete - message cannot backoff anymore', function(asser
 
       // make assertions
       util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [], 'message allowed to timeout');
+      assert.end();
+    });
+  });
+});
+
+util.mock('[messages] complete - stack name is long', function(assert) {
+  var queueUrl = 'https://fake.us-east-1/sqs/url';
+  var topic = 'arn:aws:sns:us-east-1:123456789:fake-topic';
+  var stackName = 'test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-';
+  var messages = watchbot.messages(queueUrl, topic, stackName, true);
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 1, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  // first poll in order to get the messages in flight
+  messages.poll(4, function(err) {
+    if (err) return assert.end(err);
+
+    // Then generate fake finishedTask objects for each message
+    var finishedTasks = [
+      {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
+        reason: 'failed',
+        env: {
+          MessageId: '1',
+          Subject: 'subject1',
+          Message: 'message1',
+          SentTimestamp: '10',
+          ApproximateFirstReceiveTimestamp: '20',
+          ApproximateReceiveCount: '1'
+        },
+        outcome: 'return & notify'
+      }
+    ];
+
+    // complete each finishedTask
+    var queue = d3.queue();
+    finishedTasks.forEach(function(finishedTask) {
+      queue.defer(messages.complete, finishedTask);
+    });
+    queue.awaitAll(function(err) {
+      if (err) return assert.end(err);
+
+      // make assertions
+      assert.equal(context.sns.publish.length, 1, 'one notification sent', 'subject was shortened');
+      assert.equal(context.sns.publish[0].Subject, stackName + ' failed task');
+      assert.end();
+    });
+  });
+});
+
+util.mock('[messages] complete - stack name is way too long', function(assert) {
+  var queueUrl = 'https://fake.us-east-1/sqs/url';
+  var topic = 'arn:aws:sns:us-east-1:123456789:fake-topic';
+  var stackName = 'test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-test-';
+  var messages = watchbot.messages(queueUrl, topic, stackName, true);
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 1, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  // first poll in order to get the messages in flight
+  messages.poll(4, function(err) {
+    if (err) return assert.end(err);
+
+    // Then generate fake finishedTask objects for each message
+    var finishedTasks = [
+      {
+        arns: {
+          cluster: 'cluster-arn',
+          instance: 'instance-arn',
+          task: 'task-arn'
+        },
+        reason: 'failed',
+        env: {
+          MessageId: '1',
+          Subject: 'subject1',
+          Message: 'message1',
+          SentTimestamp: '10',
+          ApproximateFirstReceiveTimestamp: '20',
+          ApproximateReceiveCount: '1'
+        },
+        outcome: 'return & notify'
+      }
+    ];
+
+    // complete each finishedTask
+    var queue = d3.queue();
+    finishedTasks.forEach(function(finishedTask) {
+      queue.defer(messages.complete, finishedTask);
+    });
+    queue.awaitAll(function(err) {
+      if (err) return assert.end(err);
+
+      // make assertions
+      assert.equal(context.sns.publish.length, 1, 'one notification sent', 'subject was shortened');
+      assert.equal(context.sns.publish[0].Subject, 'Watchbot task failure: 1');
       assert.end();
     });
   });

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -194,13 +194,13 @@ util.mock('[tasks] poll - one of each outcome', function(assert) {
       ], 'expected ecs.describeTasks request');
 
       util.collectionsEqual(assert, taskStatus, [
-        { reason: '0', env: { exit: '0', MessageId: 'exit-0' }, outcome: 'delete' },
-        { reason: '1', env: { exit: '1', MessageId: 'exit-1' }, outcome: 'return & notify' },
-        { reason: '2', env: { exit: '2', MessageId: 'exit-2' }, outcome: 'return & notify' },
-        { reason: '3', env: { exit: '3', MessageId: 'exit-3' }, outcome: 'delete & notify' },
-        { reason: '4', env: { exit: '4', MessageId: 'exit-4' }, outcome: 'immediate' },
-        { reason: 'match', env: { exit: 'match', MessageId: 'exit-match' }, outcome: 'delete' },
-        { reason: 'mismatched', env: { exit: 'mismatch', MessageId: 'exit-mismatch' }, outcome: 'return & notify' }
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '51132ba12780cd8e8ca20f2b370014a7' }, reason: '0', env: { exit: '0', MessageId: 'exit-0' }, outcome: 'delete' },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '3b173b3134d614ddacb14a1cbd5c404f' }, reason: '1', env: { exit: '1', MessageId: 'exit-1' }, outcome: 'return & notify' },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'e084e0cd00585de1ab8ed22f9572b81a' }, reason: '2', env: { exit: '2', MessageId: 'exit-2' }, outcome: 'return & notify' },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '3168cb93242f95b0e63aaca9605b9681' }, reason: '3', env: { exit: '3', MessageId: 'exit-3' }, outcome: 'delete & notify' },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '21650064140c25de55653663f6cb3be1' }, reason: '4', env: { exit: '4', MessageId: 'exit-4' }, outcome: 'immediate' },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '66f3dbb2f4f36c060a47d23bab3ddf7e' }, reason: 'match', env: { exit: 'match', MessageId: 'exit-match' }, outcome: 'delete' },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '056e67721ac63a57e291dac9d5302787' }, reason: 'mismatched', env: { exit: 'mismatch', MessageId: 'exit-mismatch' }, outcome: 'return & notify' }
       ], 'expected taskStatus reported');
 
       assert.equal(taskStatus.free, 9, 'correctly reports free workers');

--- a/test/util.js
+++ b/test/util.js
@@ -137,6 +137,8 @@ module.exports.mock = function(name, callback) {
 
         if (exitCode && exitCode.value === 'mismatch') {
           status.push({
+            clusterArn: 'cluster-arn',
+            instanceArn: 'instance-arn',
             taskArn: arn,
             lastStatus: 'STOPPED',
             stoppedReason: 'mismatched',
@@ -147,6 +149,8 @@ module.exports.mock = function(name, callback) {
           delete tasks[arn];
         } else if (exitCode && exitCode.value === 'match') {
           status.push({
+            clusterArn: 'cluster-arn',
+            instanceArn: 'instance-arn',
             taskArn: arn,
             lastStatus: 'STOPPED',
             stoppedReason: 'match',
@@ -155,6 +159,8 @@ module.exports.mock = function(name, callback) {
           });
         } else if (exitCode && exitCode.value !== 'pending') {
           status.push({
+            clusterArn: 'cluster-arn',
+            instanceArn: 'instance-arn',
             taskArn: arn,
             lastStatus: 'STOPPED',
             stoppedReason: exitCode.value,
@@ -165,6 +171,8 @@ module.exports.mock = function(name, callback) {
         } else if (messageId && /^finish/.test(messageId.value)) {
           var exit = messageId.value.match(/^finish-(\d)$/)[1];
           status.push({
+            clusterArn: 'cluster-arn',
+            instanceArn: 'instance-arn',
             taskArn: arn,
             lastStatus: 'STOPPED',
             stoppedReason: exit,

--- a/test/util.js
+++ b/test/util.js
@@ -138,7 +138,7 @@ module.exports.mock = function(name, callback) {
         if (exitCode && exitCode.value === 'mismatch') {
           status.push({
             clusterArn: 'cluster-arn',
-            instanceArn: 'instance-arn',
+            containerInstanceArn: 'instance-arn',
             taskArn: arn,
             lastStatus: 'STOPPED',
             stoppedReason: 'mismatched',
@@ -150,7 +150,7 @@ module.exports.mock = function(name, callback) {
         } else if (exitCode && exitCode.value === 'match') {
           status.push({
             clusterArn: 'cluster-arn',
-            instanceArn: 'instance-arn',
+            containerInstanceArn: 'instance-arn',
             taskArn: arn,
             lastStatus: 'STOPPED',
             stoppedReason: 'match',
@@ -160,7 +160,7 @@ module.exports.mock = function(name, callback) {
         } else if (exitCode && exitCode.value !== 'pending') {
           status.push({
             clusterArn: 'cluster-arn',
-            instanceArn: 'instance-arn',
+            containerInstanceArn: 'instance-arn',
             taskArn: arn,
             lastStatus: 'STOPPED',
             stoppedReason: exitCode.value,
@@ -172,7 +172,7 @@ module.exports.mock = function(name, callback) {
           var exit = messageId.value.match(/^finish-(\d)$/)[1];
           status.push({
             clusterArn: 'cluster-arn',
-            instanceArn: 'instance-arn',
+            containerInstanceArn: 'instance-arn',
             taskArn: arn,
             lastStatus: 'STOPPED',
             stoppedReason: exit,


### PR DESCRIPTION
Adds more information to the body of the notification sent to the SNS topic when a task fails. Ideally, this would include at least a snippet of the logs produced by the task, but that's not actually possible via ECS -- the task may have run on a different EC2 than the watcher container who is doing the reporting. That watcher has no way to gain access to the logs produced by the processing container.

Ideally, the message information and MessageId information provides a starting point for a user to search logs sent to some external backend (e.g. CloudWatch logs).

TODO:
- truncate the Message information --> Message line -- this could potentially push the limits of what can fit into a single SNS message.

```
At Mon Jul 25 2016 17:02:17 GMT-0700 (MST), processing message 65ab7f70-7faf-4cfc-9096-de66e4254c63 failed on my-watchbot-stack

Task outcome: delete & notify
Task stopped reason: ECS reported some failure

Message information:
MessageId: 65ab7f70-7faf-4cfc-9096-de66e4254c63
Subject: sns-subject
Message: sns-message-body
SentTimestamp: 1469491447565
ApproximateFirstReceiveTimestamp: 1469491447566
ApproximateReceiveCount: 1

Runtime resources:
Cluster ARN: cluster-arn
Instance ARN: instance-arn
Task ARN: task-arn
```

refs #4 

