### PR TITLE
If mounts are empty, don't add crap

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -613,6 +613,8 @@ function mount(mountStrs) {
   };
 
   mountStrs.split(',').forEach(function(mountStr, i) {
+    if (!mountStr.length) return;
+
     var host = mountStr.split(':')[0];
     var container = mountStr.split(':')[1];
     var name = 'mnt-' + i;
@@ -620,6 +622,11 @@ function mount(mountStrs) {
     mounts.volumes.push({ Name: name, Host: { SourcePath: host } });
   });
 
+  if (!mounts.mountPoints.length) {
+    mounts.mountPoints = undefined;
+    mounts.volumes = undefined;
+  }
+  
   return mounts;
 }
 

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -38,6 +38,8 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotWorkerPolicy, 'worker policy');
   assert.ok(watch.Resources.WatchbotWatcherPolicy, 'watcher policy');
   assert.ok(watch.Resources.WatchbotWorker, 'worker');
+  assert.notOk(watch.Resources.WatchbotWorker.Properties.Volumes, 'no mounts, no volumes');
+  assert.notOk(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].MountPoints, 'no mounts, no mount points');
   assert.ok(watch.Resources.WatchbotWatcher, 'watcher');
   var image = watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Image;
   var tag = image['Fn::Join'][1].slice(-2).join(''); // phew


### PR DESCRIPTION
Fixes a bug in template generation for workers that do not specify any mount points.