### PR TITLE
Fix ref to WorkerRole for ProgressTablePermission

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -695,7 +695,7 @@ function reduce(prefixed, resources, options, references) {
   resources[prefixed('ProgressTablePermission')] = {
     Type: 'AWS::IAM::Policy',
     Properties: {
-      Roles: [prefixed('WorkerRole')],
+      Roles: [cf.ref(prefixed('WorkerRole'))],
       PolicyName: 'watchbot-progress',
       PolicyDocument: {
         Statement: [


### PR DESCRIPTION
This will fix `WatchbotProgressTablePermission: The role with name WatchbotWorkerRole cannot be found` when creating a stack with reduce mode enabled.