### PR TITLE
Allow Concurrency, ExponentialBackoff env vars to be provided from refs

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -378,11 +378,11 @@ module.exports = function(options) {
             { Name: 'Cluster', Value: options.cluster },
             { Name: 'TaskDefinition', Value: cf.ref(prefixed('Worker')) },
             { Name: 'ContainerName', Value: prefixed('-worker-' + options.service) },
-            { Name: 'Concurrency', Value: options.workers.toString() },
+            { Name: 'Concurrency', Value: typeof options.workers === 'object' ? options.workers : options.workers.toString() },
             { Name: 'QueueUrl', Value: cf.ref(prefixed('Queue')) },
             { Name: 'NotificationTopic', Value: cf.ref(prefixed('NotificationTopic')) },
             { Name: 'StackName', Value: cf.stackName },
-            { Name: 'ExponentialBackoff', Value: options.backoff.toString() },
+            { Name: 'ExponentialBackoff', Value: typeof options.backoff === 'object' ? options.backoff : options.backoff.toString() },
             { Name: 'LogGroupArn', Value: cf.getAtt(prefixed('LogGroup'), 'Arn') }
           ],
           LogConfiguration: {

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -252,6 +252,8 @@ test('[template] include all resources, all references', function(assert) {
   assert.ok(watch.Resources.testProgressTable, 'progress table');
   assert.ok(watch.Resources.testProgressTablePermission, 'progress table permission');
   assert.deepEqual(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'ProgressTable', Value: cf.join(['arn:aws:dynamodb:', cf.region, ':', cf.accountId, ':table/', cf.ref('testProgressTable')]) }], 'progress table env var');
+  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment[3], { Name: 'Concurrency', Value: cf.ref('NumWorkers') });
+  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment[7], { Name: 'ExponentialBackoff', Value: cf.ref('UseBackoff') });
 
   assert.deepEqual(watch.ref.logGroup, cf.ref('testLogGroup'), 'logGroup ref');
   assert.deepEqual(watch.ref.topic, cf.ref('testTopic'), 'topic ref');


### PR DESCRIPTION
Let through Refs for these options.

cc @rclark