### PR TITLE
Utilize log group name, stream prefix

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -152,6 +152,7 @@ module.exports = function(options) {
   resources[prefixed('LogGroup')] = {
     Type: 'AWS::Logs::LogGroup',
     Properties: {
+      LogGroupName: cf.join('-', [cf.stackName, cf.region, options.serviceVersion]),
       RetentionInDays: 14
     }
   };
@@ -355,7 +356,8 @@ module.exports = function(options) {
             LogDriver: 'awslogs',
             Options: {
               'awslogs-group': cf.ref(prefixed('LogGroup')),
-              'awslogs-region': cf.region
+              'awslogs-region': cf.region,
+              'awslogs-stream-prefix': options.prefix
             }
           }
         }
@@ -448,7 +450,7 @@ function logAggregator(prefixed, resources, options) {
     Description: 'Sends log events from CloudWatch Logs to a Lambda function',
     Properties: {
       DestinationArn: options.logAggregationFunction,
-      LogGroupName: cf.ref(prefixed('LogGroup')),
+      LogGroupName: cf.join('-', [cf.stackName, cf.region, options.serviceVersion]),
       FilterPattern: ''
     }
   };

--- a/lib/template.js
+++ b/lib/template.js
@@ -357,7 +357,7 @@ module.exports = function(options) {
             Options: {
               'awslogs-group': cf.ref(prefixed('LogGroup')),
               'awslogs-region': cf.region,
-              'awslogs-stream-prefix': options.prefix
+              'awslogs-stream-prefix': cf.stackName
             }
           }
         }
@@ -391,7 +391,8 @@ module.exports = function(options) {
             LogDriver: 'awslogs',
             Options: {
               'awslogs-group': cf.ref(prefixed('LogGroup')),
-              'awslogs-region': cf.region
+              'awslogs-region': cf.region,
+              'awslogs-stream-prefix': cf.stackName
             }
           }
         }


### PR DESCRIPTION
- Names log groups using `{stackname}-{region}-{version}`
- Utilizes `awslogs-stream-prefix` which makes it a lot easier to distinguish logs from workers and watchers (ECS suffixes these automatically)