### PR TITLE
LogForwarding subscription creation can fail without a DependsOn

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -455,6 +455,7 @@ function logAggregator(prefixed, resources, options) {
   resources[prefixed('LogForwarding')] = {
     Type: 'AWS::Logs::SubscriptionFilter',
     Description: 'Sends log events from CloudWatch Logs to a Lambda function',
+    DependsOn: prefixed('LogGroup'),
     Properties: {
       DestinationArn: options.logAggregationFunction,
       LogGroupName: cf.join('-', [cf.stackName, cf.region, options.serviceVersion]),


### PR DESCRIPTION
Doubletap.