### PR TITLE
cloudformation-kms

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -260,6 +260,11 @@ module.exports = function(options) {
                 Effect: 'Allow',
                 Action: ['logs:CreateLogStream', 'logs:PutLogEvents', 'logs:FilterLogEvents'],
                 Resource: '*'
+              },
+              {
+                Effect: 'Allow',
+                Action: ['kms:Decrypt'],
+                Resource: [cf.importValue('cloudformation-kms-production')]
               }
             ]
           }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "aws-sdk": "^2.4.11",
     "binary-split": "^1.0.2",
-    "cloudfriend": "^1.5.0",
+    "cloudfriend": "^1.6.0",
     "cwlogs": "^1.0.2",
     "d3-queue": "^2.0.3",
     "dyno": "^1.2.0",

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,10 @@ A library to help run a highly-scalable AWS service that performs data processin
 - a docker image representing your task, housed in [an ECR repository](http://docs.aws.amazon.com/AmazonECR/latest/userguide/Repositories.html) and tagged with a git sha or a git tag
 - a CloudFormation template defining any configuration Parameters, Resources, and Outputs that your service needs in order to perform its processing.
 
+**:lightbulb: Other prerequisites:**
+
+- `cloudformation-kms-production` deployed according to the instructions in [cloudformation-kms](https://github.com/mapbox/cloudformation-kms). Makes encryption of sensitive environment variables that need to be passed to ECS simple using [cfn-config](https://github.com/mapbox/cfn-config).
+
 ## What Watchbot provides:
 
 - a queue for you to send messages to in order to trigger your tasks to run

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,14 @@ Name | Description
 WorkTopic | the ARN of the SNS topic that provides messages to SQS
 LogGroup | the name of the CloudWatch LogGroup where logs are sent
 
+**:lock: Encrypting & decrypting environment variables**
+
+The recommended flow for deploying `watchbot` stacks is to use `cfn-config` which provides a `--kms` option for automatically encrypting CloudFormation parameters marked with `[secure]`. To decrypt at runtime, install [decrypt-kms-env](https://github.com/mapbox/decrypt-kms-env) as a dependency in your Dockerfile and invoke it in your `CMD`. Example:
+
+```Dockerfile
+RUN eval $(./node_modules/.bin/decrypt-kms-env) && npm start
+```
+
 ## Task completion
 
 The exit code from your task determines what the watcher will do with the message that was being processed. Your options are:

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ A library to help run a highly-scalable AWS service that performs data processin
 - a docker image representing your task, housed in [an ECR repository](http://docs.aws.amazon.com/AmazonECR/latest/userguide/Repositories.html) and tagged with a git sha or a git tag
 - a CloudFormation template defining any configuration Parameters, Resources, and Outputs that your service needs in order to perform its processing.
 
-**:lightbulb: Other prerequisites:**
+**:bulb: Other prerequisites:**
 
 - `cloudformation-kms-production` deployed according to the instructions in [cloudformation-kms](https://github.com/mapbox/cloudformation-kms). Makes encryption of sensitive environment variables that need to be passed to ECS simple using [cfn-config](https://github.com/mapbox/cfn-config).
 


### PR DESCRIPTION
Let all ecs-watchbot stacks do encryption/decryption of CF params. Requires prerequisite [cloudformation-kms](https://github.com/mapbox/cloudformation-kms) to be deployed.

- [x] integration test
- [x] review

cc @rclark @emilymcafee @aarthykc 