### PR TITLE
Also retry on CPU constraint errors

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -62,7 +62,7 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, s
       });
 
       if (data.failures && data.failures.length) {
-        if (data.failures[0].reason === 'RESOURCE:MEMORY')
+        if (/^RESOURCE:(CPU|MEMORY)$/.test(data.failures[0].reason))
           return setTimeout(tasks.run, 5000, env, callback);
 
         err = new Error(data.failures[0].reason);

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -75,7 +75,7 @@ util.mock('[tasks] run - runTask failure (out of memory)', function(assert) {
   var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
   var containerName = 'container';
   var concurrency = 10;
-  var env = { resources: 'true' };
+  var env = { resourceMemory: 'true' };
   var context = this;
 
   var tasks = watchbot.tasks(cluster, taskDef, containerName, concurrency);
@@ -90,7 +90,7 @@ util.mock('[tasks] run - runTask failure (out of memory)', function(assert) {
           containerOverrides: [
             {
               name: containerName,
-              environment: [{ name: 'resources', value: 'true' }]
+              environment: [{ name: 'resourceMemory', value: 'true' }]
             }
           ]
         }
@@ -102,7 +102,49 @@ util.mock('[tasks] run - runTask failure (out of memory)', function(assert) {
           containerOverrides: [
             {
               name: containerName,
-              environment: [{ name: 'resources', value: 'true' }]
+              environment: [{ name: 'resourceMemory', value: 'true' }]
+            }
+          ]
+        }
+      }
+    ], 'expected runTask requestss');
+    assert.end();
+  });
+});
+
+util.mock('[tasks] run - runTask failure (out of cpu)', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var containerName = 'container';
+  var concurrency = 10;
+  var env = { resourceCpu: 'true' };
+  var context = this;
+
+  var tasks = watchbot.tasks(cluster, taskDef, containerName, concurrency);
+  tasks.run(env, function(err) {
+    if (err) return assert.end(err);
+    assert.equal(context.ecs.resourceFail, 1, 'retried runTask request when cluster out of cpu');
+    util.collectionsEqual(assert, context.ecs.runTask, [
+      {
+        startedBy: 'watchbot',
+        taskDefinition: taskDef,
+        overrides: {
+          containerOverrides: [
+            {
+              name: containerName,
+              environment: [{ name: 'resourceCpu', value: 'true' }]
+            }
+          ]
+        }
+      },
+      {
+        startedBy: 'watchbot',
+        taskDefinition: taskDef,
+        overrides: {
+          containerOverrides: [
+            {
+              name: containerName,
+              environment: [{ name: 'resourceCpu', value: 'true' }]
             }
           ]
         }

--- a/test/util.js
+++ b/test/util.js
@@ -86,10 +86,17 @@ module.exports.mock = function(name, callback) {
       if (params.overrides.containerOverrides[0].environment[0].name === 'failure')
         return callback(null, { tasks: [], failures: [{ reason: 'unrecognized' }] });
 
-      if (params.overrides.containerOverrides[0].environment[0].name === 'resources') {
+      if (params.overrides.containerOverrides[0].environment[0].name === 'resourceMemory') {
         if (context.ecs.resourceFail === 0) {
           context.ecs.resourceFail++;
           return callback(null, { tasks: [], failures: [{ reason: 'RESOURCE:MEMORY' }] });
+        }
+      }
+
+      if (params.overrides.containerOverrides[0].environment[0].name === 'resourceCpu') {
+        if (context.ecs.resourceFail === 0) {
+          context.ecs.resourceFail++;
+          return callback(null, { tasks: [], failures: [{ reason: 'RESOURCE:CPU' }] });
         }
       }
 


### PR DESCRIPTION
Ran into watchbot stopping dead in its tracks on a job if it hit a RESOURCE:CPU error. Adds retry for this case as well.