### PR TITLE
Resource polling issues

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -51,9 +51,9 @@ module.exports = function(cluster, taskDef) {
         wrapper();
       } else if (status.instances.length === 0 && attempts === 5) {
         clearInterval(poller);
-        callback(new Error('No instances available after 5 polling attempts 3 seconds apart'));
+        callback(new Error('No instances available after 5 polling attempts 1 second apart'));
       }
-    }, 3000);
+    }, 1000);
 
     function wrapper() {
       ecs.describeContainerInstances({ containerInstances: status.instances, cluster: cluster }, function(err, data) {

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -43,29 +43,43 @@ module.exports = function(cluster, taskDef) {
   })();
 
   resources.available = function(callback) {
-    ecs.describeContainerInstances({ containerInstances: status.instances, cluster: cluster }, function(err, data) {
-      if (err) return callback(err);
+    var attempts = 0;
+    var poller = setInterval(function() {
+      attempts++;
+      if (status.instances.length !== 0) {
+        clearInterval(poller);
+        wrapper();
+      } else if (status.instances.length === 0 && attempts === 5) {
+        clearInterval(poller);
+        callback(new Error('No instances available after 5 polling attempts 3 seconds apart'));
+      }
+    }, 3000);
 
-      status.registered = { cpu: 0, memory: 0 };
-      status.available = { cpu: 0, memory: 0 };
-      data.containerInstances.forEach(function(instance) {
-        status.registered.cpu += instance.registeredResources.find(function(resource) {
-          return resource.name === 'CPU';
-        }).integerValue;
-        status.registered.memory += instance.registeredResources.find(function(resource) {
-          return resource.name === 'MEMORY';
-        }).integerValue;
-        status.available.cpu += instance.remainingResources.find(function(resource) {
-          return resource.name === 'CPU';
-        }).integerValue;
-        status.available.memory += instance.remainingResources.find(function(resource) {
-          return resource.name === 'MEMORY';
-        }).integerValue;
+    function wrapper() {
+      ecs.describeContainerInstances({ containerInstances: status.instances, cluster: cluster }, function(err, data) {
+        if (err) return callback(err);
+
+        status.registered = { cpu: 0, memory: 0 };
+        status.available = { cpu: 0, memory: 0 };
+        data.containerInstances.forEach(function(instance) {
+          status.registered.cpu += instance.registeredResources.find(function(resource) {
+            return resource.name === 'CPU';
+          }).integerValue;
+          status.registered.memory += instance.registeredResources.find(function(resource) {
+            return resource.name === 'MEMORY';
+          }).integerValue;
+          status.available.cpu += instance.remainingResources.find(function(resource) {
+            return resource.name === 'CPU';
+          }).integerValue;
+          status.available.memory += instance.remainingResources.find(function(resource) {
+            return resource.name === 'MEMORY';
+          }).integerValue;
+        });
+
+        resources.emit('update');
+        callback();
       });
-
-      resources.emit('update');
-      callback();
-    });
+    }
   };
 
   resources.adequate = function(tasks) {

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -28,6 +28,8 @@ module.exports = function(cluster, taskDef) {
     status.instances = [];
     listInstances(undefined, function(err) {
       if (err) return resources.emit('error', err);
+      if (!status.instances.length) return resources.emit('error', 'No instances found in the cluster');
+      resources.emit('HasInstances');
       setTimeout(update, 10000).unref();
     });
   })();
@@ -43,43 +45,30 @@ module.exports = function(cluster, taskDef) {
   })();
 
   resources.available = function(callback) {
-    var attempts = 0;
-    var poller = setInterval(function() {
-      attempts++;
-      if (status.instances.length !== 0) {
-        clearInterval(poller);
-        wrapper();
-      } else if (status.instances.length === 0 && attempts === 5) {
-        clearInterval(poller);
-        callback(new Error('No instances available after 5 polling attempts 1 second apart'));
-      }
-    }, 1000);
+    if (!status.instances.length) return resources.once('HasInstances', resources.available.bind(null, callback));
+    ecs.describeContainerInstances({ containerInstances: status.instances, cluster: cluster }, function(err, data) {
+      if (err) return callback(err);
 
-    function wrapper() {
-      ecs.describeContainerInstances({ containerInstances: status.instances, cluster: cluster }, function(err, data) {
-        if (err) return callback(err);
-
-        status.registered = { cpu: 0, memory: 0 };
-        status.available = { cpu: 0, memory: 0 };
-        data.containerInstances.forEach(function(instance) {
-          status.registered.cpu += instance.registeredResources.find(function(resource) {
-            return resource.name === 'CPU';
-          }).integerValue;
-          status.registered.memory += instance.registeredResources.find(function(resource) {
-            return resource.name === 'MEMORY';
-          }).integerValue;
-          status.available.cpu += instance.remainingResources.find(function(resource) {
-            return resource.name === 'CPU';
-          }).integerValue;
-          status.available.memory += instance.remainingResources.find(function(resource) {
-            return resource.name === 'MEMORY';
-          }).integerValue;
-        });
-
-        resources.emit('update');
-        callback();
+      status.registered = { cpu: 0, memory: 0 };
+      status.available = { cpu: 0, memory: 0 };
+      data.containerInstances.forEach(function(instance) {
+        status.registered.cpu += instance.registeredResources.find(function(resource) {
+          return resource.name === 'CPU';
+        }).integerValue;
+        status.registered.memory += instance.registeredResources.find(function(resource) {
+          return resource.name === 'MEMORY';
+        }).integerValue;
+        status.available.cpu += instance.remainingResources.find(function(resource) {
+          return resource.name === 'CPU';
+        }).integerValue;
+        status.available.memory += instance.remainingResources.find(function(resource) {
+          return resource.name === 'MEMORY';
+        }).integerValue;
       });
-    }
+
+      resources.emit('update');
+      callback();
+    });
   };
 
   resources.adequate = function(tasks) {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -18,7 +18,7 @@ util.mock('[main] message polling error', function(assert) {
     { MessageId: 'error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0 } }
   ];
 
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -39,7 +39,7 @@ util.mock('[main] message polling error', function(assert) {
 util.mock('[main] nothing to do', function(assert) {
   var context = this;
 
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -54,7 +54,7 @@ util.mock('[main] run a task', function(assert) {
     { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 1, 'one ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -90,7 +90,7 @@ util.mock('[main] task running error', function(assert) {
     { MessageId: 'ecs-error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -119,7 +119,7 @@ util.mock('[main] task running failure (out of memory)', function(assert) {
     { MessageId: 'ecs-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 1, 'one sqs.receiveMessage requests');
@@ -137,7 +137,7 @@ util.mock('[main] task running failure (unrecognized reason)', function(assert) 
     { MessageId: 'ecs-unrecognized', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -157,7 +157,7 @@ util.mock('[main] message completion error after task run failure', function(ass
     { MessageId: 'ecs-error', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -185,7 +185,7 @@ util.mock('[main] task polling error', function(assert) {
     { MessageId: 'task-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 1, 'one ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 1, 'one sqs.receiveMessage requests');
@@ -213,7 +213,7 @@ util.mock('[main] no free tasks', function(assert) {
     { MessageId: '4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.sqs.receiveMessage.length, 1, 'one sqs.receiveMessage requests');
     assert.equal(context.ecs.runTask.length, 3, 'three ecs.runTask requests');
@@ -240,7 +240,7 @@ util.mock('[main] manage messages for completed tasks', function(assert) {
     { MessageId: 'finish-4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
   config.Concurrency = 4;
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 1, 'one ecs.describeTasks request');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -275,7 +275,7 @@ util.mock('[main] message completion error', function(assert) {
     { MessageId: 'finish-0', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject0', Message: 'message0' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 1, 'one ecs.describeTasks request');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -299,7 +299,7 @@ util.mock('[main] message completion error', function(assert) {
 util.mock('[main] LogLevel', function(assert){
   config.LogLevel = 'debug';
   var context = this;
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.ok(context.logs.find(function(log) {
       return /\[debug\]/.test(log);
@@ -312,7 +312,7 @@ util.mock('[main] LogLevel', function(assert){
 util.mock('[main] resource polling error', function(assert) {
   var context = this;
   context.ecs.fail = true;
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.ok(context.logs.find(function(log) {
       return /Error polling cluster resources: Mock ECS error/.test(log);
@@ -330,7 +330,7 @@ util.mock('[main] insufficient resources available', function(assert) {
 
   // No memory left to run new tasks
   context.ecs.memory = 1;
-  setTimeout(watchbot.main.end, 1800);
+  setTimeout(watchbot.main.end, 2500);
   watchbot.main(config).on('finish', function() {
     assert.deepEqual(context.sqs.receiveMessage, [], 'prevented from getting SQS messages');
     assert.deepEqual(context.ecs.runTask, [], 'did not run any tasks');

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -18,7 +18,7 @@ util.mock('[main] message polling error', function(assert) {
     { MessageId: 'error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0 } }
   ];
 
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -39,7 +39,7 @@ util.mock('[main] message polling error', function(assert) {
 util.mock('[main] nothing to do', function(assert) {
   var context = this;
 
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -54,7 +54,7 @@ util.mock('[main] run a task', function(assert) {
     { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 1, 'one ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -90,7 +90,7 @@ util.mock('[main] task running error', function(assert) {
     { MessageId: 'ecs-error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -119,7 +119,7 @@ util.mock('[main] task running failure (out of memory)', function(assert) {
     { MessageId: 'ecs-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 1, 'one sqs.receiveMessage requests');
@@ -137,7 +137,7 @@ util.mock('[main] task running failure (unrecognized reason)', function(assert) 
     { MessageId: 'ecs-unrecognized', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -157,7 +157,7 @@ util.mock('[main] message completion error after task run failure', function(ass
     { MessageId: 'ecs-error', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 0, 'no ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -185,7 +185,7 @@ util.mock('[main] task polling error', function(assert) {
     { MessageId: 'task-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 1, 'one ecs.describeTasks requests');
     assert.equal(context.sqs.receiveMessage.length, 1, 'one sqs.receiveMessage requests');
@@ -213,7 +213,7 @@ util.mock('[main] no free tasks', function(assert) {
     { MessageId: '4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.sqs.receiveMessage.length, 1, 'one sqs.receiveMessage requests');
     assert.equal(context.ecs.runTask.length, 3, 'three ecs.runTask requests');
@@ -240,7 +240,7 @@ util.mock('[main] manage messages for completed tasks', function(assert) {
     { MessageId: 'finish-4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
   config.Concurrency = 4;
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 1, 'one ecs.describeTasks request');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -275,7 +275,7 @@ util.mock('[main] message completion error', function(assert) {
     { MessageId: 'finish-0', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject0', Message: 'message0' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.equal(context.ecs.describeTasks.length, 1, 'one ecs.describeTasks request');
     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
@@ -299,7 +299,7 @@ util.mock('[main] message completion error', function(assert) {
 util.mock('[main] LogLevel', function(assert){
   config.LogLevel = 'debug';
   var context = this;
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.ok(context.logs.find(function(log) {
       return /\[debug\]/.test(log);
@@ -312,7 +312,7 @@ util.mock('[main] LogLevel', function(assert){
 util.mock('[main] resource polling error', function(assert) {
   var context = this;
   context.ecs.fail = true;
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.ok(context.logs.find(function(log) {
       return /Error polling cluster resources: Mock ECS error/.test(log);
@@ -330,7 +330,7 @@ util.mock('[main] insufficient resources available', function(assert) {
 
   // No memory left to run new tasks
   context.ecs.memory = 1;
-  setTimeout(watchbot.main.end, 2500);
+  setTimeout(watchbot.main.end, 1800);
   watchbot.main(config).on('finish', function() {
     assert.deepEqual(context.sqs.receiveMessage, [], 'prevented from getting SQS messages');
     assert.deepEqual(context.ecs.runTask, [], 'did not run any tasks');

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -47,6 +47,20 @@ util.mock('[resources] listInstances pagination', function(assert) {
   }, 1000);
 });
 
+util.mock('[resources] update error: no instances', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var context = this;
+
+  context.ecs.instances = [];
+
+  watchbot.resources(cluster, taskDef)
+    .on('error', function(err) {
+      assert.equal(err, 'No instances found in the cluster', 'expected error emitted');
+      assert.end();
+    });
+});
+
 util.mock('[resources] available', function(assert) {
   var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
   var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';


### PR DESCRIPTION
Refs https://github.com/mapbox/ecs-watchbot/issues/17

Here's my first pass at addressing the resource polling issues we've been seeing. I believe this was happening because [`update` clears out the status.instances array](https://github.com/mapbox/ecs-watchbot/blob/c24e9a6d9363c58138ef0ec314de5b95cbd0b5f9/lib/resources.js#L27-L33), which resources.available [consumes](https://github.com/mapbox/ecs-watchbot/blob/c24e9a6d9363c58138ef0ec314de5b95cbd0b5f9/lib/resources.js#L46) before the [update function runs](https://github.com/mapbox/ecs-watchbot/blob/c24e9a6d9363c58138ef0ec314de5b95cbd0b5f9/lib/resources.js#L31).

This PR places an interval in the resources.available function that checks the status.instances array every second up to 5 times, after which it returns the callback with an error message if the array never becomes populated.

@rclark, would love your thoughts on this 🙏 