### PR TITLE
Adds readCapacityUnits & writeCapacityUnits configurable params

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -47,6 +47,10 @@ var pkg = require(path.resolve(__dirname, '..', 'package.json'));
  * @param {boolean} [options.reduce=false] - if true, Watchbot will enable the
  * workers to utilize a DynamoDB table to track the progress of a distributed
  * map-reduce operation.
+ * @param {number|ref} [options.readCapacityUnits=30] - approximate number of reads
+ * per second to DynamoDB table in reduce-mode
+ * @param {number|ref} [options.writeCapacityUnits=30] - approximate number of writes
+ * per second to DynamoDB table in reduce-mode
  * @param {number|ref} [options.watchers=1] - the number of watcher containers
  * to run. Each watcher container reads from SQS and spawns worker containers
  * when messages arrive. Each watcher is responsible for spawning and monitoring
@@ -122,6 +126,8 @@ module.exports = function(options) {
   options.workers = options.workers || 1;
   options.backoff = options.backoff === undefined ? true : options.backoff;
   options.mounts = options.mounts || '';
+  options.readCapacityUnits = options.readCapacityUnits || 30;
+  options.writeCapacityUnits = options.writeCapacityUnits || 30;
 
   var resources = {};
   var references = {
@@ -703,8 +709,8 @@ function reduce(prefixed, resources, options, references) {
       AttributeDefinitions: [{ AttributeName: 'id', AttributeType: 'S' }],
       KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],
       ProvisionedThroughput: {
-        ReadCapacityUnits: 30,
-        WriteCapacityUnits: 30
+        ReadCapacityUnits: options.readCapacityUnits,
+        WriteCapacityUnits: options.writeCapacityUnits
       }
     }
   };

--- a/readme.md
+++ b/readme.md
@@ -157,8 +157,8 @@ user | false | create an IAM user with permission to publish
 webhook | false | create an HTTPS endpoint to accept jobs
 webbhookKey | false | require an access token on the webhook endpoint
 reduce | false | enable reduce-mode (see below)
-readCapacityUnits | 30 | approximate reads per second to progress table in reduce mode
-writeCapacityUnits | 30 | approximate writes per second to progress table in reduce mode
+readCapacityUnits | 30 | approximate reads per second to progress table in reduce-mode
+writeCapacityUnits | 30 | approximate writes per second to progress table in reduce-mode
 watchers | 1 | number of watcher containers
 workers | 1 | number of concurrent worker containers per watcher
 backoff | true | retry jobs with exponential backoff

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,8 @@ user | false | create an IAM user with permission to publish
 webhook | false | create an HTTPS endpoint to accept jobs
 webbhookKey | false | require an access token on the webhook endpoint
 reduce | false | enable reduce-mode (see below)
+readCapacityUnits | 30 | approximate reads per second to progress table in reduce mode
+writeCapacityUnits | 30 | approximate writes per second to progress table in reduce mode
 watchers | 1 | number of watcher containers
 workers | 1 | number of concurrent worker containers per watcher
 backoff | true | retry jobs with exponential backoff

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -185,6 +185,8 @@ test('[template] include all resources, no references', function(assert) {
   assert.deepEqual(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Command, ['bash'], 'sets worker command');
   assert.ok(watch.Resources.testService, 'service');
   assert.ok(watch.Resources.testProgressTable, 'progress table');
+  assert.equal(watch.Resources.testProgressTable.Properties.ProvisionedThroughput.ReadCapacityUnits, 30);
+  assert.equal(watch.Resources.testProgressTable.Properties.ProvisionedThroughput.WriteCapacityUnits, 30);
   assert.ok(watch.Resources.testProgressTablePermission, 'progress table permission');
   assert.deepEqual(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'ProgressTable', Value: cf.join(['arn:aws:dynamodb:', cf.region, ':', cf.accountId, ':table/', cf.ref('testProgressTable')]) }], 'progress table env var');
   assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'LogLevel', Value: 'debug' }], 'log level env var');
@@ -208,6 +210,8 @@ test('[template] include all resources, all references', function(assert) {
     webhook: true,
     webhookKey: true,
     reduce: true,
+    readCapacityUnits: 20,
+    writeCapacityUnits: 20,
     notificationEmail: cf.ref('AlarmEmail'),
     cluster: cf.ref('Cluster'),
     watchbotVersion: cf.ref('WatchbotVersion'),
@@ -255,6 +259,8 @@ test('[template] include all resources, all references', function(assert) {
   assert.ok(watch.Resources.testWatcher, 'watcher');
   assert.ok(watch.Resources.testService, 'service');
   assert.ok(watch.Resources.testProgressTable, 'progress table');
+  assert.equal(watch.Resources.testProgressTable.Properties.ProvisionedThroughput.ReadCapacityUnits, 20);
+  assert.equal(watch.Resources.testProgressTable.Properties.ProvisionedThroughput.WriteCapacityUnits, 20);
   assert.ok(watch.Resources.testProgressTablePermission, 'progress table permission');
   assert.deepEqual(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'ProgressTable', Value: cf.join(['arn:aws:dynamodb:', cf.region, ':', cf.accountId, ':table/', cf.ref('testProgressTable')]) }], 'progress table env var');
   assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment[3], { Name: 'Concurrency', Value: cf.ref('NumWorkers') });


### PR DESCRIPTION
Refs https://github.com/mapbox/ecs-watchbot/issues/65

This PR adds `readCapacityUnits` and `writeCapacityUnits` to watchbot.template's options. Users can now made these values a configurable stack param if they'd like, and pass the values into the template configuration through the intrinsic `Ref` function.

cc @rclark 