### PR TITLE
Handling for >50kb logs

### DIFF
--- a/lib/logs.js
+++ b/lib/logs.js
@@ -66,8 +66,7 @@ function fetch(logGroup, messageId, callback) {
     } else {
       var drop = writable.buffer.shift();
       if (!drop) {
-        var truncate = line.substring(0, 50 * 1024 - 5);
-        truncate += '...';
+        var truncate = line.substring(0, 50 * 1024 - 5) + '...';
         writable.buffer.add(truncate);
       } else {
         writable.buffer.current -= drop.length;

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -65,8 +65,14 @@ function fetch(logGroup, messageId, callback) {
       writable.buffer.push(line);
     } else {
       var drop = writable.buffer.shift();
-      writable.buffer.current -= drop.length;
-      writable.buffer.add(line);
+      if (!drop) {
+        var truncate = line.substring(0, 50 * 1024 - 5);
+        truncate += '...';
+        writable.buffer.add(truncate);
+      } else {
+        writable.buffer.current -= drop.length;
+        writable.buffer.add(line);
+      }
     }
   };
 

--- a/test/logs.test.js
+++ b/test/logs.test.js
@@ -103,6 +103,7 @@ test('[logs] fetch a ton of logs', function(assert) {
 
   var logs = '';
   for (var i = 0; i < 70; i++) logs += crypto.randomBytes(512).toString('hex') + '\n';
+  logs += '\n' + crypto.randomBytes(25 * 1024).toString('hex') + '\n';
 
   sinon.stub(cwlogs, 'readable', function(options) {
     assert.deepEqual(options, {
@@ -127,7 +128,9 @@ test('[logs] fetch a ton of logs', function(assert) {
     assert.ok(data.length < 50 * 1024, 'output limited to 50kb');
     var lastFound = data.split('\n').slice(-2)[0];
     var lastExpected = logs.split('\n').slice(-2)[0];
-    assert.equal(lastFound, lastExpected, 'returned most recent log');
+
+    // returns either whole or truncated log
+    assert.ok(lastFound === lastExpected || lastExpected.includes(lastFound.match(/(.*)...$/)[1]), 'returned most recent log');
 
     cwlogs.readable.restore();
     assert.end();


### PR DESCRIPTION
Refs https://github.com/mapbox/ecs-watchbot/issues/36

This PR adds handling around scenarios where an empty line is followed by a line >50kb. In the event that happens, the >50kb line is truncated with ellipses.

cc @rclark @jacquestardie 