### PR TITLE
Adds pagination for describeContainerInstances

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -62,7 +62,7 @@ module.exports = function(config) {
       resources.status.available.cpu, resources.status.registered.cpu,
       resources.status.available.memory, resources.status.registered.memory
     );
-
+    
     timer = setTimeout(status, 30000).unref();
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -62,7 +62,7 @@ module.exports = function(config) {
       resources.status.available.cpu, resources.status.registered.cpu,
       resources.status.available.memory, resources.status.registered.memory
     );
-    
+
     timer = setTimeout(status, 30000).unref();
   }
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -24,7 +24,7 @@ module.exports = function(cluster, taskDef) {
         status.availableInstances = status.availableInstances.concat(available);
         if (data.nextToken) return listInstances(data.nextToken, callback);
         callback();
-      })
+      });
     });
   }
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -19,13 +19,24 @@ module.exports = function(cluster, taskDef) {
     ecs.listContainerInstances({ nextToken: next, cluster: cluster }, function(err, data) {
       if (err) return callback(err);
       status.instances = status.instances.concat(data.containerInstanceArns);
-      if (data.nextToken) return listInstances(data.nextToken, callback);
-      callback();
+      availablePaginated(data.containerInstanceArns, function(err, available) {
+        if (err) return callback(err);
+        status.availableInstances = status.availableInstances.concat(available);
+        if (data.nextToken) return listInstances(data.nextToken, callback);
+        callback();
+      })
+    });
+  }
+
+  function availablePaginated(instances, callback) {
+    ecs.describeContainerInstances({ containerInstances: instances, cluster: cluster }, function(err, data) {
+      if (err) return callback(err);
+      return callback(null, data.containerInstances);
     });
   }
 
   (function update() {
-    status.instances = [];
+    status.instances = status.availableInstances = [];
     listInstances(undefined, function(err) {
       if (err) return resources.emit('error', err);
       if (!status.instances.length) return resources.emit('error', 'No instances found in the cluster');
@@ -46,29 +57,25 @@ module.exports = function(cluster, taskDef) {
 
   resources.available = function(callback) {
     if (!status.instances.length) return resources.once('HasInstances', resources.available.bind(null, callback));
-    ecs.describeContainerInstances({ containerInstances: status.instances, cluster: cluster }, function(err, data) {
-      if (err) return callback(err);
-
-      status.registered = { cpu: 0, memory: 0 };
-      status.available = { cpu: 0, memory: 0 };
-      data.containerInstances.forEach(function(instance) {
-        status.registered.cpu += instance.registeredResources.find(function(resource) {
-          return resource.name === 'CPU';
-        }).integerValue;
-        status.registered.memory += instance.registeredResources.find(function(resource) {
-          return resource.name === 'MEMORY';
-        }).integerValue;
-        status.available.cpu += instance.remainingResources.find(function(resource) {
-          return resource.name === 'CPU';
-        }).integerValue;
-        status.available.memory += instance.remainingResources.find(function(resource) {
-          return resource.name === 'MEMORY';
-        }).integerValue;
-      });
-
-      resources.emit('update');
-      callback();
+    status.registered = { cpu: 0, memory: 0 };
+    status.available = { cpu: 0, memory: 0 };
+    status.availableInstances.forEach(function(instance) {
+      status.registered.cpu += instance.registeredResources.find(function(resource) {
+        return resource.name === 'CPU';
+      }).integerValue;
+      status.registered.memory += instance.registeredResources.find(function(resource) {
+        return resource.name === 'MEMORY';
+      }).integerValue;
+      status.available.cpu += instance.remainingResources.find(function(resource) {
+        return resource.name === 'CPU';
+      }).integerValue;
+      status.available.memory += instance.remainingResources.find(function(resource) {
+        return resource.name === 'MEMORY';
+      }).integerValue;
     });
+
+    resources.emit('update');
+    callback();
   };
 
   resources.adequate = function(tasks) {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -312,13 +312,14 @@ util.mock('[main] LogLevel', function(assert){
 util.mock('[main] resource polling error', function(assert) {
   var context = this;
   context.ecs.fail = true;
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
+
+  watchbot.main(config);
+  setTimeout(function() {
     assert.ok(context.logs.find(function(log) {
       return /Error polling cluster resources: Mock ECS error/.test(log);
     }), 'resource polling error logged');
     assert.end();
-  });
+  }, 1800);
 });
 
 util.mock('[main] insufficient resources available', function(assert) {

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -50,9 +50,8 @@ util.mock('[resources] listInstances pagination', function(assert) {
 util.mock('[resources] availableInstances', function(assert) {
   var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
   var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
-  var context = this;
 
-  var resources = watchbot.resources(cluster, taskDef).on('HasInstances', function() {
+  watchbot.resources(cluster, taskDef).on('HasInstances', function() {
     assert.pass('emitted hasInstances event');
     assert.end();
   });

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -47,6 +47,31 @@ util.mock('[resources] listInstances pagination', function(assert) {
   }, 1000);
 });
 
+util.mock('[resources] availableInstances', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var context = this;
+
+  var resources = watchbot.resources(cluster, taskDef).on('HasInstances', function() {
+    assert.pass('emitted hasInstances event');
+    assert.end();
+  });
+});
+
+util.mock('[resources] availableInstances error', function(assert) {
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var context = this;
+
+  context.ecs.fail = true;
+
+  watchbot.resources(cluster, taskDef)
+    .on('error', function(err) {
+      assert.equal(err.message, 'Mock ECS error', 'expected error emitted');
+      assert.end();
+    });
+});
+
 util.mock('[resources] update error: no instances', function(assert) {
   var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
   var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
@@ -74,25 +99,23 @@ util.mock('[resources] available', function(assert) {
 
     assert.deepEqual(resources.status, {
       instances: ['arn:aws:ecs:us-east-1:1234567890:some/fake'],
+      availableInstances: [
+        {
+          registeredResources: [
+            { integerValue: 100, name: 'CPU' },
+            { integerValue: 100, name: 'MEMORY' }
+          ],
+          remainingResources: [
+            { integerValue: 100, name: 'CPU' },
+            { integerValue: 100, name: 'MEMORY' }
+          ]
+        }
+      ],
       registered: { cpu: 100, memory: 100 },
       available: { cpu: 100, memory: 100 },
       required: { cpu: 0, memory: 5 }
     }, 'collected expected resource info');
 
-    assert.end();
-  });
-});
-
-util.mock('[resources] available error', function(assert) {
-  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
-  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
-  var context = this;
-
-  context.ecs.fail = true;
-
-  watchbot.resources(cluster, taskDef).available(function(err) {
-    if (!err) assert.end('expected function to fail');
-    assert.equal(err.message, 'Mock ECS error', 'expected error message');
     assert.end();
   });
 });

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -53,8 +53,8 @@ util.mock('[resources] availableInstances', function(assert) {
 
   watchbot.resources(cluster, taskDef).on('HasInstances', function() {
     assert.pass('emitted hasInstances event');
-    assert.end();
   });
+  assert.end();
 });
 
 util.mock('[resources] availableInstances error', function(assert) {


### PR DESCRIPTION
Refs https://github.com/mapbox/ecs-watchbot/issues/62

This PR adds pagination for describeContainerInstances by [piggy-backing off the pagination already occurring for listContainerInstances](https://github.com/mapbox/ecs-watchbot/blob/93a3c4b59b51d87beb1baeb06b4cc572289a036e/lib/resources.js#L19-L28).

The test that's causing the 🏄  of errors is the [resource polling error test](https://github.com/mapbox/ecs-watchbot/blob/93a3c4b59b51d87beb1baeb06b4cc572289a036e/test/main.test.js#L312-L322). I can't quite figure out what's preventing the [finish event](https://github.com/mapbox/ecs-watchbot/blob/93a3c4b59b51d87beb1baeb06b4cc572289a036e/test/main.test.js#L316) from firing, since it looks like the [end function](https://github.com/mapbox/ecs-watchbot/blob/93a3c4b59b51d87beb1baeb06b4cc572289a036e/lib/main.js#L202-L204) is being called. Nothing jumps out to me immediately, but perhaps some seasoned eyes can spot something I'm missing.

cc @rclark 
