### PR TITLE
Adds cloudformation conditional check on log forwarding

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -132,6 +132,7 @@ module.exports = function(options) {
   options.writeCapacityUnits = options.writeCapacityUnits || 30;
 
   var resources = {};
+  var conditions = {};
   var references = {
     logGroup: cf.ref(prefixed('LogGroup')),
     topic: cf.ref(prefixed('Topic')),
@@ -141,7 +142,7 @@ module.exports = function(options) {
 
   if (options.user) user(prefixed, resources, references);
   if (options.webhook) webhook(prefixed, !!options.webhookKey, resources, references);
-  if (options.logAggregationFunction) logAggregator(prefixed, resources, options);
+  if (options.logAggregationFunction) logAggregator(prefixed, resources, conditions, options);
   if (options.reduce) reduce(prefixed, resources, options, references);
   var mounts = mount(options.mounts);
 
@@ -459,6 +460,7 @@ module.exports = function(options) {
    */
   return {
     Resources: resources,
+    Conditions: conditions,
     Metadata: {
       EcsWatchbotVersion: require('../package.json').version
     },
@@ -469,7 +471,7 @@ module.exports = function(options) {
   };
 };
 
-function logAggregator(prefixed, resources, options) {
+function logAggregator(prefixed, resources, conditions, options) {
   resources[prefixed('LogForwarding')] = {
     Type: 'AWS::Logs::SubscriptionFilter',
     Description: 'Sends log events from CloudWatch Logs to a Lambda function',
@@ -480,6 +482,11 @@ function logAggregator(prefixed, resources, options) {
       FilterPattern: ''
     }
   };
+
+  if (typeof options.logAggregationFunction !== 'string') {
+    conditions[prefixed('UseLogForwarding')] = cf.notEquals(options.logAggregationFunction, '');
+    resources[prefixed('LogForwarding')].Condition = prefixed('UseLogForwarding');
+  }
 }
 
 function user(prefixed, resources, references) {

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -252,6 +252,8 @@ test('[template] include all resources, all references', function(assert) {
   assert.ok(watch.Resources.testNotificationTopic, 'notification topic');
   assert.ok(watch.Resources.testLogGroup, 'log group');
   assert.ok(watch.Resources.testLogForwarding, 'log forwarding function');
+  assert.equal(watch.Resources.testLogForwarding.Condition, 'testUseLogForwarding', 'log forwarding function is conditional');
+  assert.deepEqual(watch.Conditions.testUseLogForwarding, cf.notEquals(cf.ref('LogAggregationFunction'), ''), 'log forwarding condition provided');
   assert.ok(watch.Resources.testQueue, 'queue');
   assert.ok(watch.Resources.testTopic, 'topic');
   assert.ok(watch.Resources.testQueuePolicy, 'queue policy');


### PR DESCRIPTION
If a reference for a log forwarding ARN is provided (e.g. reference to a parameter value), then we need to evaluate a condition in CloudFormation to determine whether or not the subscription filter should be created. See https://github.com/mapbox/ecs-conex/issues/82