### PR TITLE
add privileged parameter to TaskDefinition

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### 1.2.0
+
+- Adds `.ref.queueName` to the output from `watchbot.template()`
+- Clarifies watcher log messages conveying outcome when tasks finish
+
 ### 1.1.1
 
 - Fixes a bug where task launching could fail due to a `startedBy` name longer than 36 characters

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 1.1.0
+
+- Adds support for us-east-2 (Ohio)
+
 ### 1.0.4
 
 - Allows `options.logAggregationFunction` to reference a potentially empty stack parameter

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 1.3.0
+
+- adds `options.privileged` parameter to watchbot's template
+
 ### 1.2.0
 
 - Adds `.ref.queueName` to the output from `watchbot.template()`

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 1.1.1
+
+- Fixes a bug where task launching could fail due to a `startedBy` name longer than 36 characters
+
 ### 1.1.0
 
 - Adds support for us-east-2 (Ohio)

--- a/lib/main.js
+++ b/lib/main.js
@@ -102,7 +102,7 @@ module.exports = function(config) {
 
       // Handle each finished task
       status.forEach(function(finishedTask) {
-        log.info('[%s] finished | outcome: %s | reason: %s', finishedTask.env.MessageId, finishedTask.outcome, finishedTask.reason);
+        log.info('[%s] finished | outcome: %s | reason: %s', finishedTask.env.MessageId, tasks.report(finishedTask.outcome), finishedTask.reason);
         queue.defer(messages.complete, finishedTask);
       });
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -42,7 +42,7 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, s
     }
 
     ecs.runTask({
-      startedBy: startedBy || 'watchbot',
+      startedBy: startedBy ? startedBy.slice(0, 36) : 'watchbot',
       taskDefinition: taskDefinition,
       overrides: {
         containerOverrides: [

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -94,6 +94,15 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, s
     retry: 'return & notify'
   };
 
+  tasks.report = function(outcome) {
+    switch(outcome) {
+    case tasks.outcome.success: return 'success';
+    case tasks.outcome.noop: return 'no-op, will retry';
+    case tasks.outcome.fail: return 'failed, removed from queue';
+    case tasks.outcome.retry: return 'failed, will retry';
+    }
+  };
+
   /**
    * Checks the status of all pending tasks
    *

--- a/lib/template.js
+++ b/lib/template.js
@@ -369,7 +369,6 @@ module.exports = function(options) {
           Memory: options.reservation.memory,
           Cpu: options.reservation.cpu,
           Privileged: options.privileged,
-          ReadonlyRootFilesystem: options.privileged ? false : true,
           Environment: unpackEnv(prefixed, options.env),
           MountPoints: mounts.mountPoints,
           Command: options.command,

--- a/lib/template.js
+++ b/lib/template.js
@@ -137,7 +137,8 @@ module.exports = function(options) {
     logGroup: cf.ref(prefixed('LogGroup')),
     topic: cf.ref(prefixed('Topic')),
     queueUrl: cf.ref(prefixed('Queue')),
-    queueArn: cf.getAtt(prefixed('Queue'), 'Arn')
+    queueArn: cf.getAtt(prefixed('Queue'), 'Arn'),
+    queueName: cf.getAtt(prefixed('Queue'), 'QueueName')
   };
 
   if (options.user) user(prefixed, resources, references);

--- a/lib/template.js
+++ b/lib/template.js
@@ -107,7 +107,7 @@ var table = require('watchbot-progress').table;
  * alarm is triggered. The default is 24 periods, or 2 hours. This parameter
  * can be provided as either a number or a reference, i.e. `{"Ref": "..."}`.
  * @param {boolean} [options.debugLogs=false] - enable verbose watcher logging
- * @param {boolean} [options.privileged=false] - give the container elevated 
+ * @param {boolean} [options.privileged=false] - give the container elevated
  * privileges on the host container instance
  * @returns {@type WatchbotOutput} Watchbot resources and references
  */
@@ -369,6 +369,7 @@ module.exports = function(options) {
           Memory: options.reservation.memory,
           Cpu: options.reservation.cpu,
           Privileged: options.privileged,
+          ReadonlyRootFilesystem: options.privileged ? false : true,
           Environment: unpackEnv(prefixed, options.env),
           MountPoints: mounts.mountPoints,
           Command: options.command,

--- a/lib/template.js
+++ b/lib/template.js
@@ -107,6 +107,8 @@ var table = require('watchbot-progress').table;
  * alarm is triggered. The default is 24 periods, or 2 hours. This parameter
  * can be provided as either a number or a reference, i.e. `{"Ref": "..."}`.
  * @param {boolean} [options.debugLogs=false] - enable verbose watcher logging
+ * @param {boolean} [options.privileged=false] - give the container elevated 
+ * privileges on the host container instance
  * @returns {@type WatchbotOutput} Watchbot resources and references
  */
 module.exports = function(options) {
@@ -130,6 +132,7 @@ module.exports = function(options) {
   options.notifyAfterRetries = options.notifyAfterRetries || 0;
   options.readCapacityUnits = options.readCapacityUnits || 30;
   options.writeCapacityUnits = options.writeCapacityUnits || 30;
+  options.privileged = options.privileged || false;
 
   var resources = {};
   var conditions = {};
@@ -365,6 +368,7 @@ module.exports = function(options) {
           Image: cf.join([cf.accountId, '.dkr.ecr.', cf.findInMap('EcrRegion', cf.region, 'Region'), '.amazonaws.com/', options.service, ':', options.serviceVersion]),
           Memory: options.reservation.memory,
           Cpu: options.reservation.cpu,
+          Privileged: options.privileged,
           Environment: unpackEnv(prefixed, options.env),
           MountPoints: mounts.mountPoints,
           Command: options.command,

--- a/mappings/ecr-region.json
+++ b/mappings/ecr-region.json
@@ -19,5 +19,8 @@
     },
     "ap-southeast-2": {
         "Region": "us-west-2"
+    },
+    "us-east-2": {
+        "Region": "us-east-1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "watchbot",
-  "version": "1.0.5-0",
+  "version": "1.1.0",
   "description": "Build an AWS stack to do your work for you",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "watchbot",
-  "version": "1.0.4",
+  "version": "1.0.5-0",
   "description": "Build an AWS stack to do your work for you",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "watchbot",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Build an AWS stack to do your work for you",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "watchbot",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Build an AWS stack to do your work for you",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,7 @@ Name | Description
 .ref.topic | the SNS topic that you can publish messages to in order to have them processed by Watchbot
 .ref.queueUrl | the URL of the SQS Queue Watchbot built
 .ref.queueArn | the ARN of the SQS Queue Watchbot built
+.ref.queueName | the name of the SQS Queue Watchbot built
 .ref.webhookEnpoint | [conditional] if requested, the URL for the webhook endpoint
 .ref.webhookKey | [conditional] if requested, the access token for making webhook requests
 .ref.accessKeyId | [conditional] if requested, an AccessKeyId with permission to publish to Watchbot's SNS topic

--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,7 @@ alarmThreshold | 40 | number of jobs in SQS to trigger alarm
 alarmPeriods | 24 | number of 5-min intervals SQS must be above threshold to alarm
 debugLogs | false | enable verbose watcher logging
 notifyAfterRetries | 0 | retry on any exit codes other than 0, 3, and 4 before alarm
+privileged | false | give the container elevated privileges on the host container instance
 
 ### watchbot.template references
 

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -37,6 +37,26 @@ util.mock('[tasks] run - below concurrency', function(assert) {
   });
 });
 
+util.mock('[tasks] run - startedBy truncation', function(assert) {
+  var context = this;
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var containerName = 'container';
+  var concurrency = 10;
+  var env = { key: 'value' };
+
+  var tasks = watchbot.tasks(cluster, taskDef, containerName, concurrency, '1234567890123456789012345678901234567890');
+  tasks.run(env, function(err) {
+    if (err) return assert.end(err);
+    assert.deepEqual(context.ecs.config, {
+      region: 'us-east-1',
+      params: { cluster: cluster }
+    }, 'ecs client initialized properly');
+    assert.equal(context.ecs.runTask[0].startedBy, '123456789012345678901234567890123456', 'startedBy truncated to 36 characters');
+    assert.end();
+  });
+});
+
 util.mock('[tasks] run - above concurrency', function(assert) {
   var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
   var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -58,6 +58,7 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.deepEqual(watch.ref.topic, cf.ref('WatchbotTopic'), 'topic ref');
   assert.deepEqual(watch.ref.queueUrl, cf.ref('WatchbotQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('WatchbotQueue', 'Arn'), 'queueArn ref');
+  assert.deepEqual(watch.ref.queueName, cf.getAtt('WatchbotQueue', 'QueueName'), 'queueName ref');
   assert.notOk(watch.ref.accessKeyId, 'accessKeyId ref');
   assert.notOk(watch.ref.secretAccessKey, 'secretAccessKey ref');
   assert.notOk(watch.ref.webhookKey, 'webhookKey ref');
@@ -124,6 +125,7 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.deepEqual(watch.ref.topic, cf.ref('testTopic'), 'topic ref');
   assert.deepEqual(watch.ref.queueUrl, cf.ref('testQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('testQueue', 'Arn'), 'queueArn ref');
+  assert.deepEqual(watch.ref.queueName, cf.getAtt('testQueue', 'QueueName'), 'queueName ref');
   assert.deepEqual(watch.ref.accessKeyId, cf.ref('testUserKey'), 'accessKeyId ref');
   assert.deepEqual(watch.ref.secretAccessKey, cf.getAtt('testUserKey', 'SecretAccessKey'), 'secretAccessKey ref');
   assert.notOk(watch.ref.webhookKey, 'webhookKey ref');
@@ -200,6 +202,7 @@ test('[template] include all resources, no references', function(assert) {
   assert.deepEqual(watch.ref.topic, cf.ref('testTopic'), 'topic ref');
   assert.deepEqual(watch.ref.queueUrl, cf.ref('testQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('testQueue', 'Arn'), 'queueArn ref');
+  assert.deepEqual(watch.ref.queueName, cf.getAtt('testQueue', 'QueueName'), 'queueName ref');
   assert.deepEqual(watch.ref.accessKeyId, cf.ref('testUserKey'), 'accessKeyId ref');
   assert.deepEqual(watch.ref.secretAccessKey, cf.getAtt('testUserKey', 'SecretAccessKey'), 'secretAccessKey ref');
   assert.deepEqual(watch.ref.webhookKey, cf.ref('testWebhookKey'), 'webhookKey ref');
@@ -277,6 +280,7 @@ test('[template] include all resources, all references', function(assert) {
   assert.deepEqual(watch.ref.topic, cf.ref('testTopic'), 'topic ref');
   assert.deepEqual(watch.ref.queueUrl, cf.ref('testQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('testQueue', 'Arn'), 'queueArn ref');
+  assert.deepEqual(watch.ref.queueName, cf.getAtt('testQueue', 'QueueName'), 'queueName ref');
   assert.deepEqual(watch.ref.accessKeyId, cf.ref('testUserKey'), 'accessKeyId ref');
   assert.deepEqual(watch.ref.secretAccessKey, cf.getAtt('testUserKey', 'SecretAccessKey'), 'secretAccessKey ref');
   assert.deepEqual(watch.ref.webhookKey, cf.ref('testWebhookKey'), 'webhookKey ref');

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -36,6 +36,7 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotQueueSizeAlarm, 'queue alarm');
   assert.ok(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
   assert.deepEqual(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), [{ Name: 'NotifyAfterRetries', Value: 0 }], 'notify after retry default value');
+  assert.notOk(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is false');
   assert.ok(watch.Resources.WatchbotWorkerRole, 'worker role');
   assert.equal(watch.Resources.WatchbotWorkerRole.Properties.Policies.length, 1, 'default worker permissions');
   assert.ok(watch.Resources.WatchbotWatcherRole, 'watcher role');
@@ -90,7 +91,8 @@ test('[template] webhooks but no key, no references', function(assert) {
     messageRetention: 3000,
     alarmThreshold: 10,
     alarmPeriods: 6,
-    notifyAfterRetries: 2
+    notifyAfterRetries: 2,
+    privileged: true
   });
 
   assert.ok(watch.Resources.testUser, 'user');
@@ -112,6 +114,7 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.ok(watch.Resources.testQueueSizeAlarm, 'queue alarm');
   assert.ok(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
   assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), [{ Name: 'NotifyAfterRetries', Value: 2 }], 'notify after retry default value');
+  assert.ok(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is true');
   assert.ok(watch.Resources.testWorkerRole, 'worker role');
   assert.equal(watch.Resources.testWorkerRole.Properties.Policies.length, 1, 'default worker permissions');
   assert.ok(watch.Resources.testWatcherRole, 'watcher role');


### PR DESCRIPTION
This adds a watchbot parameter `privileged` that provides an opportunity to run the container with elevated credentials.

cc @emilymdubois @rclark @springmeyer 