### PR TITLE
Truncate startedBy to 36 characters

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -42,7 +42,7 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, s
     }
 
     ecs.runTask({
-      startedBy: startedBy || 'watchbot',
+      startedBy: startedBy ? startedBy.slice(0, 36) : 'watchbot',
       taskDefinition: taskDefinition,
       overrides: {
         containerOverrides: [

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -37,6 +37,26 @@ util.mock('[tasks] run - below concurrency', function(assert) {
   });
 });
 
+util.mock('[tasks] run - startedBy truncation', function(assert) {
+  var context = this;
+  var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
+  var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';
+  var containerName = 'container';
+  var concurrency = 10;
+  var env = { key: 'value' };
+
+  var tasks = watchbot.tasks(cluster, taskDef, containerName, concurrency, '1234567890123456789012345678901234567890');
+  tasks.run(env, function(err) {
+    if (err) return assert.end(err);
+    assert.deepEqual(context.ecs.config, {
+      region: 'us-east-1',
+      params: { cluster: cluster }
+    }, 'ecs client initialized properly');
+    assert.equal(context.ecs.runTask[0].startedBy, '123456789012345678901234567890123456', 'startedBy truncated to 36 characters');
+    assert.end();
+  });
+});
+
 util.mock('[tasks] run - above concurrency', function(assert) {
   var cluster = 'arn:aws:ecs:us-east-1:123456789012:cluster/fake';
   var taskDef = 'arn:aws:ecs:us-east-1:123456789012:task-definition/fake:1';


### PR DESCRIPTION
This limit is imposed by ECS -- just truncate the input with Excessive Brutality.