### PR TITLE
Expose sqs queue's name

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -102,7 +102,7 @@ module.exports = function(config) {
 
       // Handle each finished task
       status.forEach(function(finishedTask) {
-        log.info('[%s] finished | outcome: %s | reason: %s', finishedTask.env.MessageId, finishedTask.outcome, finishedTask.reason);
+        log.info('[%s] finished | outcome: %s | reason: %s', finishedTask.env.MessageId, tasks.report(finishedTask.outcome), finishedTask.reason);
         queue.defer(messages.complete, finishedTask);
       });
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -94,6 +94,15 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, s
     retry: 'return & notify'
   };
 
+  tasks.report = function(outcome) {
+    switch(outcome) {
+    case tasks.outcome.success: return 'success';
+    case tasks.outcome.noop: return 'no-op, will retry';
+    case tasks.outcome.fail: return 'failed, removed from queue';
+    case tasks.outcome.retry: return 'failed, will retry';
+    }
+  };
+
   /**
    * Checks the status of all pending tasks
    *

--- a/lib/template.js
+++ b/lib/template.js
@@ -137,7 +137,8 @@ module.exports = function(options) {
     logGroup: cf.ref(prefixed('LogGroup')),
     topic: cf.ref(prefixed('Topic')),
     queueUrl: cf.ref(prefixed('Queue')),
-    queueArn: cf.getAtt(prefixed('Queue'), 'Arn')
+    queueArn: cf.getAtt(prefixed('Queue'), 'Arn'),
+    queueName: cf.getAtt(prefixed('Queue'), 'QueueName')
   };
 
   if (options.user) user(prefixed, resources, references);

--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,7 @@ Name | Description
 .ref.topic | the SNS topic that you can publish messages to in order to have them processed by Watchbot
 .ref.queueUrl | the URL of the SQS Queue Watchbot built
 .ref.queueArn | the ARN of the SQS Queue Watchbot built
+.ref.queueName | the name of the SQS Queue Watchbot built
 .ref.webhookEnpoint | [conditional] if requested, the URL for the webhook endpoint
 .ref.webhookKey | [conditional] if requested, the access token for making webhook requests
 .ref.accessKeyId | [conditional] if requested, an AccessKeyId with permission to publish to Watchbot's SNS topic

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -58,6 +58,7 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.deepEqual(watch.ref.topic, cf.ref('WatchbotTopic'), 'topic ref');
   assert.deepEqual(watch.ref.queueUrl, cf.ref('WatchbotQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('WatchbotQueue', 'Arn'), 'queueArn ref');
+  assert.deepEqual(watch.ref.queueName, cf.getAtt('WatchbotQueue', 'QueueName'), 'queueName ref');
   assert.notOk(watch.ref.accessKeyId, 'accessKeyId ref');
   assert.notOk(watch.ref.secretAccessKey, 'secretAccessKey ref');
   assert.notOk(watch.ref.webhookKey, 'webhookKey ref');
@@ -124,6 +125,7 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.deepEqual(watch.ref.topic, cf.ref('testTopic'), 'topic ref');
   assert.deepEqual(watch.ref.queueUrl, cf.ref('testQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('testQueue', 'Arn'), 'queueArn ref');
+  assert.deepEqual(watch.ref.queueName, cf.getAtt('testQueue', 'QueueName'), 'queueName ref');
   assert.deepEqual(watch.ref.accessKeyId, cf.ref('testUserKey'), 'accessKeyId ref');
   assert.deepEqual(watch.ref.secretAccessKey, cf.getAtt('testUserKey', 'SecretAccessKey'), 'secretAccessKey ref');
   assert.notOk(watch.ref.webhookKey, 'webhookKey ref');
@@ -200,6 +202,7 @@ test('[template] include all resources, no references', function(assert) {
   assert.deepEqual(watch.ref.topic, cf.ref('testTopic'), 'topic ref');
   assert.deepEqual(watch.ref.queueUrl, cf.ref('testQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('testQueue', 'Arn'), 'queueArn ref');
+  assert.deepEqual(watch.ref.queueName, cf.getAtt('testQueue', 'QueueName'), 'queueName ref');
   assert.deepEqual(watch.ref.accessKeyId, cf.ref('testUserKey'), 'accessKeyId ref');
   assert.deepEqual(watch.ref.secretAccessKey, cf.getAtt('testUserKey', 'SecretAccessKey'), 'secretAccessKey ref');
   assert.deepEqual(watch.ref.webhookKey, cf.ref('testWebhookKey'), 'webhookKey ref');
@@ -277,6 +280,7 @@ test('[template] include all resources, all references', function(assert) {
   assert.deepEqual(watch.ref.topic, cf.ref('testTopic'), 'topic ref');
   assert.deepEqual(watch.ref.queueUrl, cf.ref('testQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('testQueue', 'Arn'), 'queueArn ref');
+  assert.deepEqual(watch.ref.queueName, cf.getAtt('testQueue', 'QueueName'), 'queueName ref');
   assert.deepEqual(watch.ref.accessKeyId, cf.ref('testUserKey'), 'accessKeyId ref');
   assert.deepEqual(watch.ref.secretAccessKey, cf.getAtt('testUserKey', 'SecretAccessKey'), 'secretAccessKey ref');
   assert.deepEqual(watch.ref.webhookKey, cf.ref('testWebhookKey'), 'webhookKey ref');


### PR DESCRIPTION
Downstream alarms based on SQS metrics require the queue's name as a metric dimension.