### PR TITLE
retries to the worker, not the watcher

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### 1.3.1
 
 - adds duration (in seconds) to watcher log output when tasks complete
+- fix bug with `NotifyAfterRetries` where the environment variable was set in the watcher container, not the worker.
 
 ### 1.3.0
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -142,8 +142,6 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, s
             return env;
           }, {});
 
-          console.log('Task environment', taskEnvironment);
-
           /**
            * An object providing information about the outcome of a task
            *

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -142,6 +142,8 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, s
             return env;
           }, {});
 
+          console.log('Task environment', taskEnvironment);
+
           /**
            * An object providing information about the outcome of a task
            *

--- a/lib/template.js
+++ b/lib/template.js
@@ -369,7 +369,7 @@ module.exports = function(options) {
           Memory: options.reservation.memory,
           Cpu: options.reservation.cpu,
           Privileged: options.privileged,
-          Environment: unpackEnv(prefixed, options.env),
+          Environment: unpackEnv(prefixed, options.env, options.notifyAfterRetries),
           MountPoints: mounts.mountPoints,
           Command: options.command,
           LogConfiguration: {
@@ -405,7 +405,6 @@ module.exports = function(options) {
             { Name: 'NotificationTopic', Value: cf.ref(prefixed('NotificationTopic')) },
             { Name: 'StackName', Value: cf.stackName },
             { Name: 'ExponentialBackoff', Value: typeof options.backoff === 'object' ? options.backoff : options.backoff.toString() },
-            { Name: 'NotifyAfterRetries', Value: options.notifyAfterRetries },
             { Name: 'LogGroupArn', Value: cf.getAtt(prefixed('LogGroup'), 'Arn') },
             { Name: 'LogLevel', Value: options.debugLogs ? 'debug' : 'info' }
           ],
@@ -706,13 +705,14 @@ function mount(mountStrs) {
   return mounts;
 }
 
-function unpackEnv(prefixed, env) {
+function unpackEnv(prefixed, env, notifyAfterRetries) {
   return Object.keys(env).reduce(function(unpacked, key) {
     unpacked.push({ Name: key, Value: env[key] });
     return unpacked;
   }, [
     { Name: 'WorkTopic', Value: cf.ref(prefixed('Topic')) },
-    { Name: 'LogGroup', Value: cf.ref(prefixed('LogGroup')) }
+    { Name: 'LogGroup', Value: cf.ref(prefixed('LogGroup')) },
+    { Name: 'NotifyAfterRetries', Value: notifyAfterRetries }
   ]);
 }
 

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -34,8 +34,8 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotTopic, 'topic');
   assert.ok(watch.Resources.WatchbotQueuePolicy, 'queue policy');
   assert.ok(watch.Resources.WatchbotQueueSizeAlarm, 'queue alarm');
-  assert.ok(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
-  assert.deepEqual(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), [{ Name: 'NotifyAfterRetries', Value: 0 }], 'notify after retry default value');
+  assert.ok(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Environment.slice(2), 'notify after retry');
+  assert.deepEqual(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Environment.slice(2), [{ Name: 'NotifyAfterRetries', Value: 0 }], 'notify after retry default value');
   assert.notOk(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is false');
   assert.ok(watch.Resources.WatchbotWorkerRole, 'worker role');
   assert.equal(watch.Resources.WatchbotWorkerRole.Properties.Policies.length, 1, 'default worker permissions');
@@ -112,8 +112,8 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.ok(watch.Resources.testTopic, 'topic');
   assert.ok(watch.Resources.testQueuePolicy, 'queue policy');
   assert.ok(watch.Resources.testQueueSizeAlarm, 'queue alarm');
-  assert.ok(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
-  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), [{ Name: 'NotifyAfterRetries', Value: 2 }], 'notify after retry default value');
+  assert.ok(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
+  assert.deepEqual(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), [{ Name: 'NotifyAfterRetries', Value: 2 }], 'notify after retry default value');
   assert.ok(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is true');
   assert.ok(watch.Resources.testWorkerRole, 'worker role');
   assert.equal(watch.Resources.testWorkerRole.Properties.Policies.length, 1, 'default worker permissions');


### PR DESCRIPTION
Moves the `NotifyAfterRetries` environment variable to the worker containers, not the watcher.

refs: #89 

cc @rclark 