### PR TITLE
notifyAfterRetries back to the watcher

### DIFF
--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -13,7 +13,8 @@ var required = [
   'NotificationTopic',
   'StackName',
   'ExponentialBackoff',
-  'LogGroupArn'
+  'LogGroupArn',
+  'NotifyAfterRetries'
 ];
 
 var missing = _.difference(required, Object.keys(process.env));

--- a/lib/main.js
+++ b/lib/main.js
@@ -102,6 +102,10 @@ module.exports = function(config) {
 
       // Handle each finished task
       status.forEach(function(finishedTask) {
+
+        // retry before notifying, if it's been set in options.notifyAfterRetries
+        if (finishedTask.env.ApproximateReceiveCount <= process.env.NotifyAfterRetries) finishedTask.outcome = tasks.outcome.noop;
+
         log.info(
           '[%s] finished | outcome: %s | reason: %s | duration: %ss',
           finishedTask.env.MessageId,

--- a/lib/template.js
+++ b/lib/template.js
@@ -369,7 +369,7 @@ module.exports = function(options) {
           Memory: options.reservation.memory,
           Cpu: options.reservation.cpu,
           Privileged: options.privileged,
-          Environment: unpackEnv(prefixed, options.env, options.notifyAfterRetries),
+          Environment: unpackEnv(prefixed, options.env),
           MountPoints: mounts.mountPoints,
           Command: options.command,
           LogConfiguration: {
@@ -405,6 +405,7 @@ module.exports = function(options) {
             { Name: 'NotificationTopic', Value: cf.ref(prefixed('NotificationTopic')) },
             { Name: 'StackName', Value: cf.stackName },
             { Name: 'ExponentialBackoff', Value: typeof options.backoff === 'object' ? options.backoff : options.backoff.toString() },
+            { Name: 'NotifyAfterRetries', Value: options.notifyAfterRetries },
             { Name: 'LogGroupArn', Value: cf.getAtt(prefixed('LogGroup'), 'Arn') },
             { Name: 'LogLevel', Value: options.debugLogs ? 'debug' : 'info' }
           ],
@@ -705,14 +706,13 @@ function mount(mountStrs) {
   return mounts;
 }
 
-function unpackEnv(prefixed, env, notifyAfterRetries) {
+function unpackEnv(prefixed, env) {
   return Object.keys(env).reduce(function(unpacked, key) {
     unpacked.push({ Name: key, Value: env[key] });
     return unpacked;
   }, [
     { Name: 'WorkTopic', Value: cf.ref(prefixed('Topic')) },
-    { Name: 'LogGroup', Value: cf.ref(prefixed('LogGroup')) },
-    { Name: 'NotifyAfterRetries', Value: notifyAfterRetries }
+    { Name: 'LogGroup', Value: cf.ref(prefixed('LogGroup')) }
   ]);
 }
 

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -212,15 +212,14 @@ util.mock('[tasks] poll - one of each outcome', function(assert) {
   var containerName = 'container';
   var concurrency = 10;
   var envs = [
-    { exit: '0', MessageId: 'exit-0', ApproximateReceiveCount: 1, NotifyAfterRetries: 0 },
-    { exit: '1', MessageId: 'exit-1', ApproximateReceiveCount: 1, NotifyAfterRetries: 0 },
-    { exit: '2', MessageId: 'exit-2', ApproximateReceiveCount: 1, NotifyAfterRetries: 0 },
-    { exit: '3', MessageId: 'exit-3', ApproximateReceiveCount: 1, NotifyAfterRetries: 0 },
-    { exit: '4', MessageId: 'exit-4', ApproximateReceiveCount: 1, NotifyAfterRetries: 0 },
-    { exit: 'mismatch', MessageId: 'exit-mismatch', ApproximateReceiveCount: 1, NotifyAfterRetries: 0 },
-    { exit: 'match', MessageId: 'exit-match', ApproximateReceiveCount: 1, NotifyAfterRetries: 0 },
-    { exit: 'pending', MessageId: 'pending', ApproximateReceiveCount: 1, NotifyAfterRetries: 0 },
-    { exit: '999', MessageId: 'exit-999-retry', ApproximateReceiveCount: 3, NotifyAfterRetries: 3 }
+    { exit: '0', MessageId: 'exit-0', ApproximateReceiveCount: 1 },
+    { exit: '1', MessageId: 'exit-1', ApproximateReceiveCount: 1 },
+    { exit: '2', MessageId: 'exit-2', ApproximateReceiveCount: 1 },
+    { exit: '3', MessageId: 'exit-3', ApproximateReceiveCount: 1 },
+    { exit: '4', MessageId: 'exit-4', ApproximateReceiveCount: 1 },
+    { exit: 'mismatch', MessageId: 'exit-mismatch', ApproximateReceiveCount: 1 },
+    { exit: 'match', MessageId: 'exit-match', ApproximateReceiveCount: 1 },
+    { exit: 'pending', MessageId: 'pending', ApproximateReceiveCount: 1 },
   ];
   var tasks = watchbot.tasks(cluster, taskDef, containerName, concurrency);
   var queue = d3.queue();
@@ -244,28 +243,26 @@ util.mock('[tasks] poll - one of each outcome', function(assert) {
       util.collectionsEqual(assert, context.ecs.describeTasks, [
         {
           tasks: [
-            '6af469055df92c00ec48413701bc597d',
-            'de147c077f2e2a250cc36fd278eb273f',
-            '19d6305fad7d8c4270f6471435b9f7b9',
-            'da9731cd84877400f43ff61f0ab5fc16',
-            'a4b92a31a8467969f3116c78f6fddda0',
-            '5a8f3f0ed983ca3d723501255fcc6827',
-            'b2eae332b8c9e32e8d2f63b4c6603ba0',
-            '7972a24206b8e3d7dbaf7e43932b4ff8',
-            'f366f0be48ce37c584ea740a54ecb9fe'
+            'bb8e8e7405617c973ceac2a9076ae19d',
+            '762676041b682bcea049706185d13ac6',
+            'fc36323938489380babaf87c56568d7f',
+            '107e1fc31e0ad9b0e0d2304411596e05',
+            'e7336cab2c12be8aacef9718acb7cdb5',
+            'ea5ebf4778bd7a4b37ed63052ad252fe',
+            '248fbdf3d00d30cce9353e1e6ee9fbd6',
+            '6d8e580ee61b2fcb24bb9317d212a404'
           ]
         }
       ], 'expected ecs.describeTasks request');
 
       var expectedTaskStatus = [
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '6af469055df92c00ec48413701bc597d' }, env: { ApproximateReceiveCount: 1, NotifyAfterRetries: 0, exit: '0', MessageId: 'exit-0' }, outcome: 'delete', reason: '0', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'de147c077f2e2a250cc36fd278eb273f' }, env: { ApproximateReceiveCount: 1, NotifyAfterRetries: 0, exit: '1', MessageId: 'exit-1' }, outcome: 'return & notify', reason: '1', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '19d6305fad7d8c4270f6471435b9f7b9' }, env: { ApproximateReceiveCount: 1, NotifyAfterRetries: 0, exit: '2', MessageId: 'exit-2' }, outcome: 'return & notify', reason: '2', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'da9731cd84877400f43ff61f0ab5fc16' }, env: { ApproximateReceiveCount: 1, NotifyAfterRetries: 0, exit: '3', MessageId: 'exit-3' }, outcome: 'delete & notify', reason: '3', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'a4b92a31a8467969f3116c78f6fddda0' }, env: { ApproximateReceiveCount: 1, NotifyAfterRetries: 0, exit: '4', MessageId: 'exit-4' }, outcome: 'immediate', reason: '4', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '5a8f3f0ed983ca3d723501255fcc6827' }, env: { ApproximateReceiveCount: 1, NotifyAfterRetries: 0, exit: 'mismatch', MessageId: 'exit-mismatch' }, outcome: 'return & notify', reason: 'mismatched', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'b2eae332b8c9e32e8d2f63b4c6603ba0' }, env: { ApproximateReceiveCount: 1, NotifyAfterRetries: 0, exit: 'match', MessageId: 'exit-match' }, outcome: 'delete', reason: 'match', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'f366f0be48ce37c584ea740a54ecb9fe' }, env: { ApproximateReceiveCount: 3, NotifyAfterRetries: 3, exit: '999', MessageId: 'exit-999-retry' }, outcome: 'immediate', reason: '999', duration: 7973 }
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'bb8e8e7405617c973ceac2a9076ae19d' }, env: { ApproximateReceiveCount: 1, exit: '0', MessageId: 'exit-0' }, outcome: 'delete', reason: '0', duration: 7973 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '762676041b682bcea049706185d13ac6' }, env: { ApproximateReceiveCount: 1, exit: '1', MessageId: 'exit-1' }, outcome: 'return & notify', reason: '1', duration: 7973 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'fc36323938489380babaf87c56568d7f' }, env: { ApproximateReceiveCount: 1, exit: '2', MessageId: 'exit-2' }, outcome: 'return & notify', reason: '2', duration: 7973 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '107e1fc31e0ad9b0e0d2304411596e05' }, env: { ApproximateReceiveCount: 1, exit: '3', MessageId: 'exit-3' }, outcome: 'delete & notify', reason: '3', duration: 7973 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'e7336cab2c12be8aacef9718acb7cdb5' }, env: { ApproximateReceiveCount: 1, exit: '4', MessageId: 'exit-4' }, outcome: 'immediate', reason: '4', duration: 7973 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'ea5ebf4778bd7a4b37ed63052ad252fe' }, env: { ApproximateReceiveCount: 1, exit: 'mismatch', MessageId: 'exit-mismatch' }, outcome: 'return & notify', reason: 'mismatched', duration: 7973 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '248fbdf3d00d30cce9353e1e6ee9fbd6' }, env: { ApproximateReceiveCount: 1, exit: 'match', MessageId: 'exit-match' }, outcome: 'delete', reason: 'match', duration: 7973 },
       ];
       expectedTaskStatus.free = 9;
 

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -34,8 +34,8 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotTopic, 'topic');
   assert.ok(watch.Resources.WatchbotQueuePolicy, 'queue policy');
   assert.ok(watch.Resources.WatchbotQueueSizeAlarm, 'queue alarm');
-  assert.ok(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Environment.slice(2), 'notify after retry');
-  assert.deepEqual(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Environment.slice(2), [{ Name: 'NotifyAfterRetries', Value: 0 }], 'notify after retry default value');
+  assert.ok(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
+  assert.deepEqual(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), [{ Name: 'NotifyAfterRetries', Value: 0 }], 'notify after retry default value');
   assert.notOk(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is false');
   assert.ok(watch.Resources.WatchbotWorkerRole, 'worker role');
   assert.equal(watch.Resources.WatchbotWorkerRole.Properties.Policies.length, 1, 'default worker permissions');
@@ -112,8 +112,8 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.ok(watch.Resources.testTopic, 'topic');
   assert.ok(watch.Resources.testQueuePolicy, 'queue policy');
   assert.ok(watch.Resources.testQueueSizeAlarm, 'queue alarm');
-  assert.ok(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
-  assert.deepEqual(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), [{ Name: 'NotifyAfterRetries', Value: 2 }], 'notify after retry default value');
+  assert.ok(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
+  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), [{ Name: 'NotifyAfterRetries', Value: 2 }], 'notify after retry default value');
   assert.ok(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is true');
   assert.ok(watch.Resources.testWorkerRole, 'worker role');
   assert.equal(watch.Resources.testWorkerRole.Properties.Policies.length, 1, 'default worker permissions');


### PR DESCRIPTION
Third time's a charm. This moves the notifyAfterRetries parameter back into the watcher to be handled within main.js instead of the workers.

* removes leftover task tests
* adds new logic to main.js that munges the `taskDefinition.outcome` based on the parameter

Need to add tests into tasks.test.js still - might need some spirit guidance from @rclark though.