### PR TITLE
Use container exit reason when available

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
-### 1.6.0
+### unreleased
 
+- removes cluster resource polling - workers will try to be placed and fail instead of avoiding placement attempts
+- collects CloudWatch metrics for worker errors (non-zero exit codes), and for failed task placements
 - adds ephemeral, or non-persistent, volume compatibility (see [AWS's task data volume documentation](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html))
+- returns `task.container[n].reason` as `reason` when task finishes, if available
 
 ### 1.4.0
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -132,12 +132,26 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, s
         }).map(function(task) {
 
           /**
-           * An task's environment used as a reference for the {@link finishedTask}
+           * A task's environment used as a reference for the {@link finishedTask}
            */
           var taskEnvironment = task.overrides.containerOverrides[0].environment.reduce(function(env, item) {
             env[item.name] = item.value;
             return env;
           }, {});
+
+          /**
+           * A task's reason for finishing
+           * If exit code is 0, return success. If exit code does not equal 0 and
+           * stopped container reason is provided return that. Otherwise, return
+           * stopped task reason.
+           */
+          var success = task.containers.every(function(c) { return c.exitCode === 0; });
+          var containerReason = task.containers.find(function(c) { return c.reason; });
+
+          var taskReason;
+          if (task.stoppedReason) taskReason = task.stoppedReason;
+          if (containerReason) taskReason = containerReason.reason;
+          if (success) taskReason = 'success';
 
           /**
            * An object providing information about the outcome of a task
@@ -158,7 +172,7 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, s
               instance: task.containerInstanceArn,
               task: task.taskArn
             },
-            reason: task.stoppedReason,
+            reason: taskReason,
             env: taskEnvironment,
             duration: task.stoppedAt - task.startedAt,
             outcome: task.containers.reduce(function(outcome, container) {

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -196,7 +196,8 @@ util.mock('[tasks] poll - one of each outcome', function(assert) {
     { exit: '2', MessageId: 'exit-2', ApproximateReceiveCount: 1 },
     { exit: '3', MessageId: 'exit-3', ApproximateReceiveCount: 1 },
     { exit: '4', MessageId: 'exit-4', ApproximateReceiveCount: 1 },
-    { exit: 'mismatch', MessageId: 'exit-mismatch', ApproximateReceiveCount: 1 },
+    { exit: 'mismatch1', MessageId: 'exit-mismatch-1', ApproximateReceiveCount: 1 },
+    { exit: 'mismatch2', MessageId: 'exit-mismatch-2', ApproximateReceiveCount: 1 },
     { exit: 'match', MessageId: 'exit-match', ApproximateReceiveCount: 1 },
     { exit: 'pending', MessageId: 'pending', ApproximateReceiveCount: 1 }
   ];
@@ -227,7 +228,8 @@ util.mock('[tasks] poll - one of each outcome', function(assert) {
             'fc36323938489380babaf87c56568d7f',
             '107e1fc31e0ad9b0e0d2304411596e05',
             'e7336cab2c12be8aacef9718acb7cdb5',
-            'ea5ebf4778bd7a4b37ed63052ad252fe',
+            '17b5c230e1addcea9df11cc53006d89a',
+            '83488f33b1ed6ff1801d7f71b8c02b8b',
             '248fbdf3d00d30cce9353e1e6ee9fbd6',
             '6d8e580ee61b2fcb24bb9317d212a404'
           ]
@@ -235,13 +237,14 @@ util.mock('[tasks] poll - one of each outcome', function(assert) {
       ], 'expected ecs.describeTasks request');
 
       var expectedTaskStatus = [
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'bb8e8e7405617c973ceac2a9076ae19d' }, env: { ApproximateReceiveCount: 1, exit: '0', MessageId: 'exit-0' }, outcome: 'delete', reason: '0', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '762676041b682bcea049706185d13ac6' }, env: { ApproximateReceiveCount: 1, exit: '1', MessageId: 'exit-1' }, outcome: 'return & notify', reason: '1', duration: 7973 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'bb8e8e7405617c973ceac2a9076ae19d' }, env: { ApproximateReceiveCount: 1, exit: '0', MessageId: 'exit-0' }, outcome: 'delete', reason: 'success', duration: 7973 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '762676041b682bcea049706185d13ac6' }, env: { ApproximateReceiveCount: 1, exit: '1', MessageId: 'exit-1' }, outcome: 'return & notify', reason: 'some container reason', duration: 7973 },
         { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'fc36323938489380babaf87c56568d7f' }, env: { ApproximateReceiveCount: 1, exit: '2', MessageId: 'exit-2' }, outcome: 'return & notify', reason: '2', duration: 7973 },
         { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '107e1fc31e0ad9b0e0d2304411596e05' }, env: { ApproximateReceiveCount: 1, exit: '3', MessageId: 'exit-3' }, outcome: 'delete & notify', reason: '3', duration: 7973 },
         { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'e7336cab2c12be8aacef9718acb7cdb5' }, env: { ApproximateReceiveCount: 1, exit: '4', MessageId: 'exit-4' }, outcome: 'immediate', reason: '4', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'ea5ebf4778bd7a4b37ed63052ad252fe' }, env: { ApproximateReceiveCount: 1, exit: 'mismatch', MessageId: 'exit-mismatch' }, outcome: 'return & notify', reason: 'mismatched', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '248fbdf3d00d30cce9353e1e6ee9fbd6' }, env: { ApproximateReceiveCount: 1, exit: 'match', MessageId: 'exit-match' }, outcome: 'delete', reason: 'match', duration: 7973 }
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '17b5c230e1addcea9df11cc53006d89a' }, env: { ApproximateReceiveCount: 1, exit: 'mismatch1', MessageId: 'exit-mismatch-1' }, outcome: 'return & notify', reason: 'mismatched', duration: 7973 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '83488f33b1ed6ff1801d7f71b8c02b8b' }, env: { ApproximateReceiveCount: 1, exit: 'mismatch2', MessageId: 'exit-mismatch-2' }, outcome: 'return & notify', reason: 'some container reason', duration: 7973 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '248fbdf3d00d30cce9353e1e6ee9fbd6' }, env: { ApproximateReceiveCount: 1, exit: 'match', MessageId: 'exit-match' }, outcome: 'delete', reason: 'success', duration: 7973 }
       ];
       expectedTaskStatus.free = 9;
 

--- a/test/util.js
+++ b/test/util.js
@@ -144,7 +144,7 @@ module.exports.mock = function(name, callback) {
           return item.name === 'MessageId';
         });
 
-        if (exitCode && exitCode.value === 'mismatch') {
+        if (exitCode && exitCode.value === 'mismatch1') {
           status.push({
             clusterArn: 'cluster-arn',
             containerInstanceArn: 'instance-arn',
@@ -153,6 +153,20 @@ module.exports.mock = function(name, callback) {
             stoppedReason: 'mismatched',
             overrides: { containerOverrides: [{ environment: env }] },
             containers: [{ exitCode: 0 }, { exitCode: 1 }],
+            startedAt: 1484155849718,
+            stoppedAt: 1484155857691
+          });
+
+          delete tasks[arn];
+        } else if (exitCode && exitCode.value === 'mismatch2') {
+          status.push({
+            clusterArn: 'cluster-arn',
+            containerInstanceArn: 'instance-arn',
+            taskArn: arn,
+            lastStatus: 'STOPPED',
+            stoppedReason: 'mismatched',
+            overrides: { containerOverrides: [{ environment: env }] },
+            containers: [{ exitCode: 0 }, { exitCode: 1, reason: 'some container reason' }],
             startedAt: 1484155849718,
             stoppedAt: 1484155857691
           });
@@ -171,6 +185,7 @@ module.exports.mock = function(name, callback) {
             stoppedAt: 1484155857691
           });
         } else if (exitCode && exitCode.value !== 'pending') {
+          var containers = (exitCode.value === '1') ? [{ exitCode: Number(exitCode.value), reason: 'some container reason' }] : [{ exitCode: Number(exitCode.value) }];
           status.push({
             clusterArn: 'cluster-arn',
             containerInstanceArn: 'instance-arn',
@@ -178,7 +193,7 @@ module.exports.mock = function(name, callback) {
             lastStatus: 'STOPPED',
             stoppedReason: exitCode.value,
             overrides: { containerOverrides: [{ environment: env }] },
-            containers: [{ exitCode: Number(exitCode.value) }],
+            containers: containers,
             startedAt: 1484155849718,
             stoppedAt: 1484155857691
           });


### PR DESCRIPTION
Refs https://github.com/mapbox/ecs-watchbot/issues/108

This PR adds some handling around the `reason` provided when a task finishes:

* If all of the containers have `task.containers[n].exitCode: 0`, return the string `success`.
* If any of the containers have `task.containers[n].exitCode: !0` and a `task.containers[n].reason`, return the container `task.containers[n].reason`. In the event that multiple containers exit with non-0, return the first `task.containers[n].reason` encountered.
* If any of the containers have `task.containers[n].exitCode: !0` and do not have a `task.containers[n].reason`, return `task.stoppedReason`.
* Updates changelog, assuming this will roll out with a few other updates in version 1.5.0

@rclark any gotchas and/or recommendations for staging?