### PR TITLE
underscore from devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "dyno": "^1.2.0",
     "fastlog": "^1.0.0",
     "meow": "^3.7.0",
-    "stream-combiner": "^0.2.2"
+    "stream-combiner": "^0.2.2",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "documentation": "^4.0.0-beta2",
@@ -47,7 +48,6 @@
     "opener": "^1.4.1",
     "sinon": "^1.17.5",
     "tap-spec": "^4.1.1",
-    "tape": "^4.5.1",
-    "underscore": "^1.8.3"
+    "tape": "^4.5.1"
   }
 }


### PR DESCRIPTION
Looks like the `underscore` dependency made its way from `dependencies` to `devDependencies`. This means that the underscore module wasn't available to `bin/watchbot.js`, causing a stack using ecs-watchbot to fail to create the WatchbotService resource.

cc @rclark @jakepruitt 