### PR TITLE
More metrics

### DIFF
--- a/alarms.md
+++ b/alarms.md
@@ -1,0 +1,43 @@
+# Alarms
+
+This document describes CloudWatch alarms that Watchbot configures. If one of these alarms is tripped, a message will be sent from CloudWatch to the stack's configured `NotificationEmail` or `NotificationTopic`. That message will contain a description field, with a URL pointing to this document.
+
+**In all cases**, SQS messages that failed and led to these alarms are put back into SQS to be retried.
+
+## FailedWorkerPlacement
+
+### Why?
+
+There were more than 5 attempts to place a worker container in 60 seconds that could not be placed. The failed placement could be due to:
+
+- insufficient CPU or memory was available on the cluster
+- failure to start a docker container on a host EC2 because of disk I/O exhaustion
+- any other scenario that may have caused the worker not to be placed
+
+### What to do
+
+Most of the time, this is due to a lack of available cluster resources. Use [the provided CLI command](./readme.md#assessing-worker-capacity-in-your-service's cluster) to get a sense of how much space is free in your cluster. If necessary, increase available resources on your cluster by removing other tasks or launching new EC2s.
+
+If resource availability on the cluster does not appear to be the problem, then you'll need to dig into logs in order to understand what the problem is. Check watcher logs for any indication of the reason for job placement failure by searching for `failedPlacement`.
+
+## WorkerErrors
+
+### Why?
+
+There were more than a threshold number of worker containers that failed to process successfully in a 60 second period. The threshold is configured when you create your template via `watchbot.template()` through the `options.errorThreshold` value. The default threshold is 10 errors per minute.
+
+### What to do
+
+These errors represent situations where an SQS message resulted in the launch of a worker container, and that container exited with an exit code of **anything other than** `0` or `4`. See [the readme](./readme.md#task-completion) for more information about how watchbot interprets container's exit codes.
+
+This likely represents an error in your worker's code, or an edge-case that your application is unable to cope with. Most of the time, the solution to this problem is deduced by searching through worker logs in CloudWatch logs.
+
+##  QueueSize
+
+### Why?
+
+There were more than a threshold number of messages in the SQS queue for some period of time. Both the threshold and the alarm period are configured when you create your template via `watchbot.tempalte()` through the `options.alarmThreshold` and `options.alarmPeriod` values. The default threshold is 40, and the default period is 2 hours.
+
+### What to do?
+
+This represents a situation where messages are piling up in SQS faster than they are being processed. You may need to decrease the rate at which messages are being sent to SQS, or investigate whether there is something else preventing workers from processing effectively.

--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -15,7 +15,8 @@ var required = [
   'StackName',
   'ExponentialBackoff',
   'LogGroupArn',
-  'NotifyAfterRetries'
+  'NotifyAfterRetries',
+  'AlarmOnEachFailure'
 ];
 
 var missing = _.difference(required, Object.keys(process.env));

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,18 @@
 ### unreleased
 
-- adds a second SQS queue used for the watcher's internal tracking of CloudWatch task state-change events
-- drops polling of DescribeTasks API to learn when workers are completed
-- removes cluster resource polling - workers will try to be placed and fail instead of avoiding placement attempts
-- collects CloudWatch metrics for worker errors (non-zero exit codes), and for failed task placements
-- adds ephemeral, or non-persistent, volume compatibility (see [AWS's task data volume documentation](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html))
+- fixes a bug that wouldn't have allowed you to disable exponential backoff
 - returns `task.container[n].reason` as `reason` when task finishes, if available
-- adds a `worker-capacity` script to estimate how many additional worker tasks can be placed in your service's cluster at its current capacity
+- adds a second SQS queue used for the watcher's internal tracking of CloudWatch task state-change events
+- adds ephemeral, or non-persistent, volume compatibility (see [AWS's task data volume documentation](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html))
 - adds mount point object compatibility for cloudfriend operators, and any other operators that use semicolons and commas
+- adds a `worker-capacity` script to estimate how many additional worker tasks can be placed in your service's cluster at its current capacity
+- adds CloudWatch metrics for worker errors (non-zero exit codes), failed worker container placement, worker duration, watcher concurrency, and message receive counts
+- adds an alarm for number of worker errors in 60s, configurable through `watchbot.template(options)` `.errorThreshold`. Defaults to alarms after 10 failures per minute.
+- drops polling of DescribeTasks API to learn when workers are completed
+- **BREAKING** removes cluster resource polling - workers will try to be placed and fail instead of avoiding placement attempts
+- **BREAKING** by default, watchbot no longer sends notification emails each time a worker errors. You can opt-in to this behavior by setting `watchbot.template(options)` `.alarmOnEachFailure: true`.
+- **BREAKING** no longer sends notifications on error interacting with SQS. Instead watchbot silently proceeds.
+- **BREAKING** watcher log format has changed. Now watcher logs print JSON objects
 
 ### 1.4.0
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,6 +19,7 @@ var stop = false;
  * @param {string} config.TaskEventQueueUrl - the URL for the SQS queue containing task-state events
  * @param {string} config.StackName - the name of the CFN stack
  * @param {boolean} config.ExponentialBackoff - whether to retry with backoff
+ * @param {boolean} config.AlarmOnEachFailure - whether to send errors when workers fail
  * @param {string} [config.LogLevel=info] - fastlog log level
  * @returns {object} an event emitter that will emit an `finish` event if the
  * main loop is stopped.
@@ -28,7 +29,6 @@ module.exports = function(config) {
   var log = fastlog('watchbot', config.LogLevel || 'info', template);
   var emitter = new events.EventEmitter();
 
-  var sendNotification = require('../lib/notifications')(config.NotificationTopic).send;
   var tasks = require('../lib/tasks')(
     config.Cluster,
     config.TaskDefinition,
@@ -44,7 +44,8 @@ module.exports = function(config) {
     config.QueueUrl,
     config.NotificationTopic,
     config.StackName,
-    Boolean(config.ExponentialBackoff),
+    config.ExponentialBackoff === 'true' || config.ExponentialBackoff === true ? true : false,
+    config.AlarmOnEachFailure === 'true' || config.AlarmOnEachFailure === true ? true : false,
     config.LogGroupArn
   );
 
@@ -72,7 +73,6 @@ module.exports = function(config) {
     tasks.poll(function(err, status) {
       if (err) {
         log.error(err);
-        sendNotification('[watchbot] task polling error', err.message);
         return setTimeout(main, 1000, config, emitter);
       }
 
@@ -112,11 +112,7 @@ module.exports = function(config) {
       });
 
       queue.awaitAll(function(err) {
-        if (err) {
-          log.error(err);
-          sendNotification('[watchbot] message completion error', err.message);
-        }
-
+        if (err) log.error(err);
         completedTasks(status);
       });
     }
@@ -124,10 +120,7 @@ module.exports = function(config) {
     function completedTasks(status) {
       log.debug('[debug] poll for %s messages', status.free);
       messages.poll(status.free, function(err, envs) {
-        if (err) {
-          log.error(err);
-          sendNotification('[watchbot] message polling error', err.message);
-        }
+        if (err) log.error(err);
 
         // If there are no messages, wait a second before repeating
         log.debug('[debug] %s messages in flight: %s', Object.keys(messages.inFlight).length, Object.keys(messages.inFlight).join(', '));
@@ -175,10 +168,7 @@ module.exports = function(config) {
               env: env,
               outcome: err.code === 'NotRun' ? tasks.outcome.noop : tasks.outcome.retry
             }, function(err) {
-              if (err) {
-                log.error(err);
-                sendNotification('[watchbot] message completion error', err.message);
-              }
+              if (err) log.error(err);
               next();
             });
           });

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,12 +49,11 @@ module.exports = function(config) {
   );
 
   (function status() {
-    log.info(
-      '[debug] concurrency %s | tasks %s | messages %s',
-      config.Concurrency,
-      Object.keys(tasks.inFlight).length,
-      Object.keys(messages.inFlight).length
-    );
+    log.info(JSON.stringify({
+      max: config.Concurrency,
+      concurrency: Object.keys(tasks.inFlight).length,
+      messages: Object.keys(messages.inFlight).length
+    }));
 
     setTimeout(status, 60000).unref();
   })();
@@ -101,11 +100,13 @@ module.exports = function(config) {
 
 
         log.info(
-          '[%s] finished | outcome: %s | reason: %s | duration: %ss',
+          '[%s] %s',
           finishedTask.env.MessageId,
-          tasks.report(finishedTask.outcome),
-          finishedTask.reason,
-          Math.ceil(finishedTask.duration / 1000)
+          JSON.stringify({
+            outcome: tasks.report(finishedTask.outcome),
+            reason: finishedTask.reason,
+            duration: Math.ceil(finishedTask.duration / 1000)
+          })
         );
         queue.defer(messages.complete, finishedTask);
       });
@@ -147,11 +148,26 @@ module.exports = function(config) {
         queue.defer(function(next) {
           tasks.run(env, function(err) {
             if (!err) {
-              log.info('[%s] started task for %s: %s', env.MessageId, env.Subject, env.Message.length < 2048 ? env.Message : env.Message.substr(0, 2048));
+              log.info(
+                '[%s] %s',
+                env.MessageId,
+                JSON.stringify({
+                  subject: env.Subject,
+                  message: env.Message.length < 2048 ? env.Message : env.Message.substr(0, 2048),
+                  receives: env.ApproximateReceiveCount
+                })
+              );
               return next();
             }
 
-            log.warn('[%s] task did not run: %s', env.MessageId, err.message);
+            log.warn(
+              '[%s] %s',
+              env.MessageId,
+              JSON.stringify({
+                failedPlacement: 'true',
+                reason: err.message
+              })
+            );
 
             messages.complete({
               arns: {},

--- a/lib/main.js
+++ b/lib/main.js
@@ -98,7 +98,6 @@ module.exports = function(config) {
         if (lessThanConfiguredRetries && finishedTask.outcome === tasks.outcome.retry)
           finishedTask.outcome = tasks.outcome.noop;
 
-
         log.info(
           '[%s] %s',
           finishedTask.env.MessageId,

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -42,11 +42,13 @@ function messageToEnv(message) {
  * @param {string} stackName - the name of the CloudFormation stack
  * @param {boolean} backoff - whether jobs retrying should be returned to SQS
  * with exponential backoff.
+ * @param {boolean} sendNotifications - whether to send a notification email
+ * each time an invocation fails.
  * @param {string} [logGroup] - the ARN of a CloudWatch LogGroup where container
  * logs are written
  * @returns {object} a {@link messages} object
  */
-module.exports = function(queue, topic, stackName, backoff, logGroup) {
+module.exports = function(queue, topic, stackName, backoff, sendNotifications, logGroup) {
   var sqs = new AWS.SQS({
     region: url.parse(queue).host.split('.')[1],
     params: { QueueUrl: queue }
@@ -140,7 +142,7 @@ module.exports = function(queue, topic, stackName, backoff, logGroup) {
         });
       }
 
-      if (toDo === 'notify') {
+      if (toDo === 'notify' && sendNotifications) {
         var subject = util.format('%s failed processing message %s', stackName, messageId);
         if (subject.length > 100) subject = util.format('%s failed task', stackName);
         if (subject.length > 100) subject = util.format('Watchbot task failure: %s', messageId);

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -161,7 +161,7 @@ function getMessages(sqs, callback) {
 
     var finishedTasks = data.Messages.map(function(message) {
       var task = JSON.parse(message.Body).detail;
-      var duration = task.stoppedAt - task.startedAt;
+      var duration = +new Date(task.stoppedAt) - +new Date(task.startedAt);
       if (isNaN(duration)) duration = 0;
 
       /**

--- a/lib/template.js
+++ b/lib/template.js
@@ -31,6 +31,11 @@ var table = require('@mapbox/watchbot-progress').table;
  * notifications when processing fails.
  * @param {string|ref} [options.notificationTopic] - an ARN of the SNS topic to receive
  * notifications when processing fails.
+ * @param {boolean|ref} [options.alarmOnEachFailure=false] - if set to `true`,
+ * the provided notificationEmail or notificationTopic will be sent a message
+ * every time any single worker fails. When `false`, the email or topic will
+ * only receive a message when there have been more than some threshold number
+ * of errors in a 60s period. See `options.errorThreshold` for more information.
  * @param {string} [options.prefix='Watchbot'] - a prefix that will be applied
  * to the logical names of all the resources Watchbot creates. If you're
  * building a template that includes more than one Watchbot system, you'll need
@@ -104,6 +109,10 @@ var table = require('@mapbox/watchbot-progress').table;
  * that a message will exist in SQS until it is deleted. The default value is the
  * maximum time that SQS allows, 14 days. This parameter can be provided as
  * either a number or a reference, i.e. `{"Ref": "..."}`.
+ * @param {number|ref} [options.errorThreshold=10] - Watchbot creates a
+ * CloudWatch alarm that will fire if there have been more than this number
+ * of failed worker invocations in a 60 second period. This parameter can be provided as
+ * either a number or a reference, i.e. `{"Ref": "..."}`.
  * @param {number|ref} [options.alarmThreshold=40] - Watchbot creates a
  * CloudWatch alarm that will go off when there have been too many messages in
  * SQS for a certain period of time. Use this parameter to adjust the Threshold
@@ -133,6 +142,8 @@ module.exports = function(options) {
     options.reservation.memory = options.reservation.memory || 64;
 
   options.env = options.env || {};
+  options.alarmOnEachFailure = options.alarmOnEachFailure || false;
+  options.errorThreshold = options.errorThreshold || 10;
   options.alarmThreshold = options.alarmThreshold || 40;
   options.alarmPeriods = options.alarmPeriods || 24;
   options.messageTimeout = options.messageTimeout || 600;
@@ -235,20 +246,20 @@ module.exports = function(options) {
     }
   };
 
-  resources[prefixed('FailedTaskPlacementMetric')] = {
+  resources[prefixed('FailedWorkerPlacementMetric')] = {
     Type: 'AWS::Logs::MetricFilter',
     Properties: {
       FilterPattern: '{ $.failedPlacement = true }',
       LogGroupName: cf.ref(prefixed('LogGroup')),
       MetricTransformations: [{
-        MetricName: cf.join([prefixed('FailedTaskPlacement-'), cf.stackName]),
+        MetricName: cf.join([prefixed('FailedWorkerPlacement-'), cf.stackName]),
         MetricNamespace: 'Mapbox/ecs-watchbot',
         MetricValue: 1
       }]
     }
   };
 
-  resources[prefixed('InvocationErrorMetric')] = {
+  resources[prefixed('WorkerErrorsMetric')] = {
     Type: 'AWS::Logs::MetricFilter',
     Properties: {
       FilterPattern: '{ $.outcome = "failed*" }',
@@ -258,6 +269,25 @@ module.exports = function(options) {
         MetricNamespace: 'Mapbox/ecs-watchbot',
         MetricValue: 1
       }]
+    }
+  };
+
+  resources[prefixed('WorkerErrorsAlarm')] = {
+    Type: 'AWS::CloudWatch::Alarm',
+    Properties: {
+      AlarmDescription: cf.join([
+        'Alarm if more than',
+        typeof options.errorThreshold === 'object' ? options.errorThreshold : options.errorThreshold.toString(),
+        'worker errors in 60 seconds'
+      ]),
+      MetricName: prefixed('WorkerErrorsMetric'),
+      Namespace: 'Mapbox/ecs-watchbot',
+      Statistic: 'Average',
+      Period: '60',
+      EvaluationPeriods: 1,
+      Threshold: options.errorThreshold,
+      AlarmActions: [notify],
+      ComparisonOperator: 'GreaterThanThreshold'
     }
   };
 
@@ -276,14 +306,14 @@ module.exports = function(options) {
     }
   };
 
-  resources[prefixed('MessageRecievesMetric')] = {
+  resources[prefixed('MessageReceivesMetric')] = {
     Type: 'AWS::Logs::MetricFilter',
     Properties: {
       LogGroupName: cf.ref(prefixed('LogGroup')),
       FilterPattern: '{ $.receives = * }',
       MetricTransformations: [
         {
-          MetricName: cf.join([prefixed('MessageRecieves-'), cf.stackName]),
+          MetricName: cf.join([prefixed('MessageReceives-'), cf.stackName]),
           MetricNamespace: 'Mapbox/ecs-watchbot',
           MetricValue: '$.receives'
         }
@@ -569,7 +599,8 @@ module.exports = function(options) {
             { Name: 'ExponentialBackoff', Value: typeof options.backoff === 'object' ? options.backoff : options.backoff.toString() },
             { Name: 'NotifyAfterRetries', Value: options.notifyAfterRetries },
             { Name: 'LogGroupArn', Value: cf.getAtt(prefixed('LogGroup'), 'Arn') },
-            { Name: 'LogLevel', Value: options.debugLogs ? 'debug' : 'info' }
+            { Name: 'LogLevel', Value: options.debugLogs ? 'debug' : 'info' },
+            { Name: 'AlarmOnEachFailure', Value: typeof options.alarmOnEachFailure === 'object' ? options.alarmOnEachFailure : options.alarmOnEachFailure.toString() }
           ],
           LogConfiguration: {
             LogDriver: 'awslogs',

--- a/lib/template.js
+++ b/lib/template.js
@@ -238,10 +238,10 @@ module.exports = function(options) {
   resources[prefixed('FailedTaskPlacementMetric')] = {
     Type: 'AWS::Logs::MetricFilter',
     Properties: {
-      FilterPattern: 'task did not run',
+      FilterPattern: '{ $.failedPlacement = true }',
       LogGroupName: cf.ref(prefixed('LogGroup')),
       MetricTransformations: [{
-        MetricName: cf.join(['FailedTaskPlacement-', cf.stackName]),
+        MetricName: cf.join([prefixed('FailedTaskPlacement-'), cf.stackName]),
         MetricNamespace: 'Mapbox/ecs-watchbot',
         MetricValue: 1
       }]
@@ -251,13 +251,58 @@ module.exports = function(options) {
   resources[prefixed('InvocationErrorMetric')] = {
     Type: 'AWS::Logs::MetricFilter',
     Properties: {
-      FilterPattern: 'failed',
+      FilterPattern: '{ $.outcome = "failed*" }',
       LogGroupName: cf.ref(prefixed('LogGroup')),
       MetricTransformations: [{
-        MetricName: cf.join(['WorkerErrors-', cf.stackName]),
+        MetricName: cf.join([prefixed('WorkerErrors-'), cf.stackName]),
         MetricNamespace: 'Mapbox/ecs-watchbot',
         MetricValue: 1
       }]
+    }
+  };
+
+  resources[prefixed('WorkerDurationMetric')] = {
+    Type: 'AWS::Logs::MetricFilter',
+    Properties: {
+      LogGroupName: cf.ref(prefixed('LogGroup')),
+      FilterPattern: '{ $.duration = * }',
+      MetricTransformations: [
+        {
+          MetricName: cf.join([prefixed('WorkerDuration-'), cf.stackName]),
+          MetricNamespace: 'Mapbox/ecs-watchbot',
+          MetricValue: '$.duration'
+        }
+      ]
+    }
+  };
+
+  resources[prefixed('MessageRecievesMetric')] = {
+    Type: 'AWS::Logs::MetricFilter',
+    Properties: {
+      LogGroupName: cf.ref(prefixed('LogGroup')),
+      FilterPattern: '{ $.receives = * }',
+      MetricTransformations: [
+        {
+          MetricName: cf.join([prefixed('MessageRecieves-'), cf.stackName]),
+          MetricNamespace: 'Mapbox/ecs-watchbot',
+          MetricValue: '$.receives'
+        }
+      ]
+    }
+  };
+
+  resources[prefixed('WatcherConcurrencyMetric')] = {
+    Type: 'AWS::Logs::MetricFilter',
+    Properties: {
+      LogGroupName: cf.ref(prefixed('LogGroup')),
+      FilterPattern: '{ $.concurrency = * }',
+      MetricTransformations: [
+        {
+          MetricName: cf.join([prefixed('WatcherConcurrency-'), cf.stackName]),
+          MetricNamespace: 'Mapbox/ecs-watchbot',
+          MetricValue: '$.concurrency'
+        }
+      ]
     }
   };
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -259,6 +259,21 @@ module.exports = function(options) {
     }
   };
 
+  resources[prefixed('FailedWorkerPlacementAlarm')] = {
+    Type: 'AWS::CloudWatch::Alarm',
+    Properties: {
+      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/alarms.md#failedworkerplacement`,
+      MetricName: cf.join([prefixed('FailedWorkerPlacement-'), cf.stackName]),
+      Namespace: 'Mapbox/ecs-watchbot',
+      Statistic: 'Sum',
+      Period: '60',
+      EvaluationPeriods: 1,
+      Threshold: 5,
+      AlarmActions: [notify],
+      ComparisonOperator: 'GreaterThanThreshold'
+    }
+  };
+
   resources[prefixed('WorkerErrorsMetric')] = {
     Type: 'AWS::Logs::MetricFilter',
     Properties: {
@@ -275,11 +290,7 @@ module.exports = function(options) {
   resources[prefixed('WorkerErrorsAlarm')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      AlarmDescription: cf.join([
-        'Alarm if more than',
-        typeof options.errorThreshold === 'object' ? options.errorThreshold : options.errorThreshold.toString(),
-        'worker errors in 60 seconds'
-      ]),
+      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/alarms.md#workererrors`,
       MetricName: cf.join([prefixed('WorkerErrors-'), cf.stackName]),
       Namespace: 'Mapbox/ecs-watchbot',
       Statistic: 'Sum',
@@ -340,13 +351,7 @@ module.exports = function(options) {
     Type: 'AWS::CloudWatch::Alarm',
     Description: 'An alarm that is tripped when too many messages are in Watchbot\'s queue',
     Properties: {
-      AlarmDescription: cf.join([
-        'Alarm if more than',
-        typeof options.alarmThreshold === 'object' ? options.alarmThreshold : options.alarmThreshold.toString(),
-        'messages in the queue for ',
-        typeof options.alarmPeriods === 'object' ? options.alarmPeriods : options.alarmPeriods.toString(),
-        'consecutive 5 minute periods'
-      ]),
+      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/alarms.md#queuesize`,
       MetricName: 'ApproximateNumberOfMessagesVisible',
       Namespace: 'AWS/SQS',
       Statistic: 'Average',

--- a/lib/template.js
+++ b/lib/template.js
@@ -280,9 +280,9 @@ module.exports = function(options) {
         typeof options.errorThreshold === 'object' ? options.errorThreshold : options.errorThreshold.toString(),
         'worker errors in 60 seconds'
       ]),
-      MetricName: prefixed('WorkerErrorsMetric'),
+      MetricName: cf.join([prefixed('WorkerErrors-'), cf.stackName]),
       Namespace: 'Mapbox/ecs-watchbot',
-      Statistic: 'Average',
+      Statistic: 'Sum',
       Period: '60',
       EvaluationPeriods: 1,
       Threshold: options.errorThreshold,

--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,7 @@ reservation.memory | 64 | specify a hard memory limit
 reservation.softMemory | | specify a soft memory limit
 messageTimeout | 600 | max seconds it takes to process a job
 messageRetention | 1209600 | max seconds a message can remain in SQS
+errorThreshold | 10 | number of failed workers to trigger alarm
 alarmThreshold | 40 | number of jobs in SQS to trigger alarm
 alarmPeriods | 24 | number of 5-min intervals SQS must be above threshold to alarm
 debugLogs | false | enable verbose watcher logging
@@ -245,6 +246,18 @@ $ watchbot-log "This is something that I want logged: eggs and beans"
 # Pipe another command's output into watchbot-log
 $ echo "This is something that I want logged: eggs and beans" | watchbot-log
 ```
+
+## Custom metrics
+
+Custom metrics are collected under the namespace `Mapbox/ecs-watchbot`. They are mined via filters on CloudWatch logs, and can help you learn about the state of your watchbot stack.
+
+|Metric|Description|Statistics
+|---|---|---|
+|`FailedWorkerPlacement-{StackName}`|The total number of times a watcher had difficulty placing a worker on the cluster - This probably means your concurrency is too high, your reservations are too high, or your cluster is too small.|Sum|
+|`WorkerErrors-{StackName}`|The total number of failed workers per minute. High levels of this error trigger the `WorkerErrors` alarm|Sum|
+|`MessageReceives-{StackName}`|A metric collected for every received message that indicates how many times the message has been pulled from the queue.|Maximum|
+|`WatcherConcurrency-{StackName}`|The number of workers running per watcher.|`Sum`and `Average`|
+|`WorkerDuration-{StackName}`|The amount of time taken by a worker to run a task.|`Average`, `Minimum` and `Maximum`|
 
 ## Reduce mode
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -9,7 +9,8 @@ var config = {
   QueueUrl: 'https://fake.us-east-1/sqs/url',
   TaskEventQueueUrl: 'https://fake.us-east-1/sqs/url-for-events',
   StackName: 'watchbot-testing',
-  ExponentialBackoff: false
+  ExponentialBackoff: 'false',
+  AlarmOnEachFailure: 'true'
   // , LogLevel: 'debug'
 };
 
@@ -26,12 +27,7 @@ util.mock('[main] message polling error', function(assert) {
     var errorMsg = context.logs.find(function(log) {
       return /Mock SQS error/.test(log);
     });
-    assert.deepEqual(context.sns.publish, [
-      {
-        Subject: '[watchbot] message polling error',
-        Message: 'Mock SQS error'
-      }
-    ], 'sent expected error notification');
+    assert.deepEqual(context.sns.publish, [], 'sent no error notification');
     assert.ok(errorMsg, 'logged error message');
     assert.end();
   });
@@ -162,12 +158,7 @@ util.mock('[main] message completion error after task run failure', function(ass
     assert.ok(context.logs.find(function(log) {
       return /Mock ECS error/.test(log);
     }), 'printed error message');
-    util.collectionsEqual(assert, context.sns.publish, [
-      {
-        Subject: '[watchbot] message completion error',
-        Message: 'Mock SQS error'
-      }
-    ], 'sent expected error notifications');
+    util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
       { ReceiptHandle: 'error', VisibilityTimeout: 0 }
     ], 'expected sqs.changeMessageVisibility requests');
@@ -359,9 +350,7 @@ util.mock('[main] message completion error', function(assert) {
       { ReceiptHandle: 'error' }, { ReceiptHandle: 'error-event' }
     ], 'expected sqs.deleteMessage request');
 
-    util.collectionsEqual(assert, context.sns.publish, [
-      { Message: 'Mock SQS error', Subject: '[watchbot] message completion error' }
-    ], 'expected sns.publish requests');
+    util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
     assert.end();
   });
 });

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -38,8 +38,15 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotTaskEventQueue, 'task event queue');
   assert.ok(watch.Resources.WatchbotTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.WatchbotTaskEventQueuePolicy, 'task event queue policy');
+  assert.ok(watch.Resources.WatchbotFailedWorkerPlacementMetric, 'failed worker metric');
+  assert.ok(watch.Resources.WatchbotWorkerDurationMetric, 'worker duration metric');
+  assert.ok(watch.Resources.WatchbotMessageReceivesMetric, 'message receives metric');
+  assert.ok(watch.Resources.WatchbotWatcherConcurrencyMetric, 'watcher concurrency metric');
+  assert.ok(watch.Resources.WatchbotWorkerErrorsMetric, 'worker errors metric');
+  assert.ok(watch.Resources.WatchbotWorkerErrorsAlarm, 'worker errors alarm');
+  assert.equal(watch.Resources.WatchbotWorkerErrorsAlarm.Properties.Threshold, 10, 'worker errors alarm threshold');
   assert.ok(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
-  assert.deepEqual(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), [{ Name: 'NotifyAfterRetries', Value: 0 }], 'notify after retry default value');
+  assert.deepEqual(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-4, -3), [{ Name: 'NotifyAfterRetries', Value: 0 }], 'notify after retry default value');
   assert.notOk(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is false');
   assert.equal(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Memory, 64, 'sets default hard memory limit');
   assert.ok(watch.Resources.WatchbotWorkerRole, 'worker role');
@@ -56,7 +63,8 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotService, 'service');
   assert.notOk(watch.Resources.WatchbotProgressTable, 'progress table');
   assert.notOk(watch.Resources.WatchbotProgressTablePermission, 'progress table permission');
-  assert.deepEqual(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'LogLevel', Value: 'info' }], 'log level env var');
+  assert.deepEqual(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-2, -1), [{ Name: 'LogLevel', Value: 'info' }], 'log level env var');
+  assert.deepEqual(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'AlarmOnEachFailure', Value: 'false' }], 'alarm on failure env var');
 
   assert.deepEqual(/^\d+\.\d+\.\d+$/.test(watch.Metadata.EcsWatchbotVersion), true, 'ecs-watchbot version metadata');
 
@@ -124,8 +132,15 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.ok(watch.Resources.testTaskEventQueue, 'task event queue');
   assert.ok(watch.Resources.testTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
+  assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
+  assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
+  assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
+  assert.ok(watch.Resources.testWatcherConcurrencyMetric, 'watcher concurrency metric');
+  assert.ok(watch.Resources.testWorkerErrorsMetric, 'worker errors metric');
+  assert.ok(watch.Resources.testWorkerErrorsAlarm, 'worker errors alarm');
+  assert.equal(watch.Resources.testWorkerErrorsAlarm.Properties.Threshold, 10, 'worker errors alarm threshold');
   assert.ok(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
-  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), [{ Name: 'NotifyAfterRetries', Value: 2 }], 'notify after retry default value');
+  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-4, -3), [{ Name: 'NotifyAfterRetries', Value: 2 }], 'notify after retry default value');
   assert.ok(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is true');
   assert.ok(watch.Resources.testWorkerRole, 'worker role');
   assert.equal(watch.Resources.testWorkerRole.Properties.Policies.length, 1, 'default worker permissions');
@@ -188,9 +203,11 @@ test('[template] include all resources, no references', function(assert) {
     },
     messageTimeout: 300,
     messageRetention: 3000,
+    errorThreshold: 11,
     alarmThreshold: 10,
     alarmPeriods: 6,
-    debugLogs: true
+    debugLogs: true,
+    alarmOnEachFailure: true
   });
 
   assert.ok(watch.Resources.testUser, 'user');
@@ -213,6 +230,13 @@ test('[template] include all resources, no references', function(assert) {
   assert.ok(watch.Resources.testTaskEventQueue, 'task event queue');
   assert.ok(watch.Resources.testTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
+  assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
+  assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
+  assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
+  assert.ok(watch.Resources.testWatcherConcurrencyMetric, 'watcher concurrency metric');
+  assert.ok(watch.Resources.testWorkerErrorsMetric, 'worker errors metric');
+  assert.ok(watch.Resources.testWorkerErrorsAlarm, 'worker errors alarm');
+  assert.equal(watch.Resources.testWorkerErrorsAlarm.Properties.Threshold, 11, 'worker errors alarm threshold');
   assert.ok(watch.Resources.testWorkerRole, 'worker role');
   assert.equal(watch.Resources.testWorkerRole.Properties.Policies.length, 2, 'default and user-defined worker permissions');
   assert.deepEqual(watch.Resources.testWorkerRole.Properties.Policies[1].PolicyDocument.Statement, [{ Effect: 'Allow', Actions: '*', Resources: '*' }], 'user-defined permissions');
@@ -229,7 +253,8 @@ test('[template] include all resources, no references', function(assert) {
   assert.equal(watch.Resources.testProgressTable.Properties.ProvisionedThroughput.WriteCapacityUnits, 30);
   assert.ok(watch.Resources.testProgressTablePermission, 'progress table permission');
   assert.deepEqual(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'ProgressTable', Value: cf.join(['arn:aws:dynamodb:', cf.region, ':', cf.accountId, ':table/', cf.ref('testProgressTable')]) }], 'progress table env var');
-  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'LogLevel', Value: 'debug' }], 'log level env var');
+  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-2, -1), [{ Name: 'LogLevel', Value: 'debug' }], 'log level env var');
+  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'AlarmOnEachFailure', Value: 'true' }], 'alarm on failure env var');
   assert.ok(watch.Resources.testWorker.Properties.ContainerDefinitions[0].MountPoints.every((pt) => { return pt.ContainerPath && pt.SourceVolume; }), 'mount point properties');
   assert.deepEqual(watch.Resources.testWorker.Properties.Volumes[0], { Name: 'mnt-0', Host: { SourcePath: '/var/tmp' } });
   assert.deepEqual(watch.Resources.testWorker.Properties.Volumes[1], { Name: 'mnt-1', Host: { SourcePath: '/mnt/data' } });
@@ -283,7 +308,9 @@ test('[template] include all resources, all references', function(assert) {
     messageTimeout: cf.ref('MessageTimeout'),
     messageRetention: cf.ref('MessageRetention'),
     alarmThreshold: cf.ref('AlarmThreshold'),
-    alarmPeriods: cf.ref('AlarmPeriods')
+    errorThreshold: cf.ref('Errors'),
+    alarmPeriods: cf.ref('AlarmPeriods'),
+    alarmOnEachFailure: cf.ref('AlarmOnFailures')
   });
 
   assert.ok(watch.Resources.testUser, 'user');
@@ -308,6 +335,13 @@ test('[template] include all resources, all references', function(assert) {
   assert.ok(watch.Resources.testTaskEventQueue, 'task event queue');
   assert.ok(watch.Resources.testTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
+  assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
+  assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
+  assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
+  assert.ok(watch.Resources.testWatcherConcurrencyMetric, 'watcher concurrency metric');
+  assert.ok(watch.Resources.testWorkerErrorsMetric, 'worker errors metric');
+  assert.ok(watch.Resources.testWorkerErrorsAlarm, 'worker errors alarm');
+  assert.deepEqual(watch.Resources.testWorkerErrorsAlarm.Properties.Threshold, cf.ref('Errors'), 'worker errors alarm threshold');
   assert.ok(watch.Resources.testWorkerRole, 'worker role');
   assert.equal(watch.Resources.testWorkerRole.Properties.Policies.length, 2, 'default and user-defined worker permissions');
   assert.deepEqual(watch.Resources.testWorkerRole.Properties.Policies[1].PolicyDocument.Statement, [{ Effect: 'Allow', Actions: '*', Resources: '*' }], 'user-defined permissions');
@@ -322,10 +356,10 @@ test('[template] include all resources, all references', function(assert) {
   assert.deepEqual(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'ProgressTable', Value: cf.join(['arn:aws:dynamodb:', cf.region, ':', cf.accountId, ':table/', cf.ref('testProgressTable')]) }], 'progress table env var');
   assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment[3], { Name: 'Concurrency', Value: cf.ref('NumWorkers') }, 'sets Concurrency');
   assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment[8], { Name: 'ExponentialBackoff', Value: cf.ref('UseBackoff') }, 'sets ExponentialBackoff');
+  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'AlarmOnEachFailure', Value: cf.ref('AlarmOnFailures') }], 'alarm on failure env var');
   assert.deepEqual(watch.Resources.testWorker.Properties.Volumes[0], { Name: 'mnt-0', Host: { SourcePath: { 'Fn::Sub': ['/var/tmp/${stack}', { stack: { Ref: 'some-stack-name' } }] } } });
   assert.deepEqual(watch.Resources.testWorker.Properties.Volumes[1], { Name: 'mnt-1', Host: { SourcePath: '/mnt/data' } });
   assert.deepEqual(watch.Resources.testWorker.Properties.Volumes[2], { Name: 'mnt-2', Host: {} });
-
   assert.deepEqual(watch.ref.logGroup, cf.ref('testLogGroup'), 'logGroup ref');
   assert.deepEqual(watch.ref.topic, cf.ref('testTopic'), 'topic ref');
   assert.deepEqual(watch.ref.queueUrl, cf.ref('testQueue'), 'queueUrl ref');


### PR DESCRIPTION
- Fixes a bug that wouldn't have allowed you to disable exponential backoff
- Fixes a bug where worker duration was always reported to be `0`
- Adds metrics for worker error count, worker duration, worker placement failure, watcher concurrency, and message receive counts
- Adds an alarm for number of worker errors in 60s, configurable via `.errorThreshold` (default 10)
- **BREAKING** defaults to not sending notifications each time a worker errors. Can opt-in with `.alarmOnEachFailure: true`
- **BREAKING** no longer sends notifications on SQS errors
- **BREAKING** changes watcher logs to print JSON objects

Fixes #112 #76
cc @jakepruitt @emilymdubois 
