### PR TITLE
Support cloudfriend operators in mount points

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -72,9 +72,15 @@ var table = require('@mapbox/watchbot-progress').table;
  * function to send logs to.
  * @param {string} [options.mounts=''] - if your worker containers need to mount
  * files or folders from the host EC2 file system, specify those mounts with this
- * parameter. A single mount point can be specified as
- * `{host location}:{container location}`, e.g. /root:/mnt/root. Separate multiple
- * mount strings with commas if you need to mount more than one location.
+ * parameter. A single persistent mount point can be specified as
+ * `{host location}:{container location}`, e.g. /root:/mnt/root. A single ephemeral
+ * mount point can be specified as
+ * `{container location}`, e.g. /mnt/tmp. Separate multiple mount strings with commas
+ * if you need to mount more than one location. You can also specify a mount object
+ * with `container` and `host` property arrays, in which the indeces correspond:
+ * `{ container: [{container location}], host: [{host location}] }`, e.g.
+ * { container: [/mnt/root, /mnt/tmp], host: [/root, ''] }. A blank host entry will
+ * create an ephemeral mount point at the corresponding container filepath.
  * @param {object} [options.reservation={}] - worker container resource reservations
  * @param {number|ref} [options.reservation.memory=64] - the number of
  * MB of RAM to reserve. If your worker container tries to utilize more than
@@ -793,19 +799,27 @@ function webhook(prefixed, useKey, resources, references) {
   }
 }
 
-function mount(mountStrs) {
+function mount(mountInputs) {
+  var formatted = { container: [], host: [] };
   var mounts = {
     mountPoints: [],
     volumes: []
   };
 
-  mountStrs.split(',').forEach(function(mountStr, i) {
-    if (!mountStr.length) return;
+  if (typeof mountInputs === 'object') formatted = mountInputs;
+  if (typeof mountInputs === 'string') {
+    mountInputs.split(',').forEach(function(mountStr) {
+      if (!mountStr.length) return;
 
+      var persistent = /:/.test(mountStr);
+      formatted.container.push(persistent ? mountStr.split(':')[1] : mountStr);
+      formatted.host.push(persistent ? mountStr.split(':')[0] : '');
+    });
+  }
+
+  formatted.container.forEach((container, i) => {
     var name = 'mnt-' + i;
-    var persistent = /:/.test(mountStr);
-    var host = persistent ? { SourcePath: mountStr.split(':')[0] } : {};
-    var container = persistent ? mountStr.split(':')[1] : mountStr;
+    var host = formatted.host[i] ? { SourcePath: formatted.host[i] } : {};
 
     mounts.mountPoints.push({ ContainerPath: container, SourceVolume: name });
     mounts.volumes.push({ Name: name, Host: host });


### PR DESCRIPTION
Refs https://github.com/mapbox/ecs-watchbot/issues/90

This PR adds the option to also provide a mount point object:

```js
// two persistent mounts and one ephemeral
mounts: {
  container: ['/var/tmp', '/mnt/data', '/mnt/tmp'],
  host: ['/var/tmp', '/mnt/data', '']
}
```

The array structure allows you to pass in cloudfriend operators without encountering parsing issues.

cc @rclark @rodowi 