### PR TITLE
Dead letter queue

### DIFF
--- a/alarms.md
+++ b/alarms.md
@@ -36,8 +36,20 @@ This likely represents an error in your worker's code, or an edge-case that your
 
 ### Why?
 
-There were more than a threshold number of messages in the SQS queue for some period of time. Both the threshold and the alarm period are configured when you create your template via `watchbot.tempalte()` through the `options.alarmThreshold` and `options.alarmPeriod` values. The default threshold is 40, and the default period is 2 hours.
+There were more than a threshold number of messages in the SQS queue for some period of time. Both the threshold and the alarm period are configured when you create your template via `watchbot.template()` through the `options.alarmThreshold` and `options.alarmPeriod` values. The default threshold is 40, and the default period is 2 hours.
 
-### What to do?
+### What to do
 
 This represents a situation where messages are piling up in SQS faster than they are being processed. You may need to decrease the rate at which messages are being sent to SQS, or investigate whether there is something else preventing workers from processing effectively.
+
+## DeadLetter
+
+### Why?
+
+There are visible messages in the dead letter queue. SQS messages are received by watchbot's watcher container. If processing the message fails for any reason, the message is sent back to watchbot's primary queue and will be retried. If 10 attempts to process a message result in a failure, then the message will be sent to the dead letter queue.
+
+### What to do
+
+These messages consistently failed processing attempts. It is possible that these messages represent an edge case in your worker's processing code. In this case, you should investigate your system's logs to try and determine how the workers failed.
+
+It is also possible that this represents failure to successfully place tasks in your cluster. If this is the case, then you will also have seen alarms on FailedWorkerPlacement (see above).

--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -15,7 +15,6 @@ var required = [
   'StackName',
   'ExponentialBackoff',
   'LogGroupArn',
-  'NotifyAfterRetries',
   'AlarmOnEachFailure'
 ];
 

--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -13,7 +13,6 @@ var required = [
   'TaskEventQueueUrl',
   'NotificationTopic',
   'StackName',
-  'ExponentialBackoff',
   'LogGroupArn',
   'AlarmOnEachFailure'
 ];

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 - **BREAKING** watcher log format has changed. Now watcher logs print JSON objects
 - **BREAKING** removes `.notifyAfterRetries` option
 - **BREAKING** removes `.backoff` option. Workers are always retried with exponential backoff
+- **BREAKING** adds a dead letter queue. Messages received more than 14 times by a watcher container will be sent to this queue. Any visible messages in this queue will trip an alarm.
 
 ### 1.4.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - **BREAKING** no longer sends notifications on error interacting with SQS. Instead watchbot silently proceeds.
 - **BREAKING** watcher log format has changed. Now watcher logs print JSON objects
 - **BREAKING** removes `.notifyAfterRetries` option
+- **BREAKING** removes `.backoff` option. Workers are always retried with exponential backoff
 
 ### 1.4.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 - **BREAKING** by default, watchbot no longer sends notification emails each time a worker errors. You can opt-in to this behavior by setting `watchbot.template(options)` `.alarmOnEachFailure: true`.
 - **BREAKING** no longer sends notifications on error interacting with SQS. Instead watchbot silently proceeds.
 - **BREAKING** watcher log format has changed. Now watcher logs print JSON objects
+- **BREAKING** removes `.notifyAfterRetries` option
 
 ### 1.4.0
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -92,12 +92,6 @@ module.exports = function(config) {
 
       // Handle each finished task
       status.forEach(function(finishedTask) {
-
-        // retry before notifying, if it's been set in options.notifyAfterRetries
-        var lessThanConfiguredRetries = +finishedTask.env.ApproximateReceiveCount <= +config.NotifyAfterRetries;
-        if (lessThanConfiguredRetries && finishedTask.outcome === tasks.outcome.retry)
-          finishedTask.outcome = tasks.outcome.noop;
-
         log.info(
           '[%s] %s',
           finishedTask.env.MessageId,

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,6 @@ var stop = false;
  * @param {string} config.QueueUrl - the URL for the SQS queue
  * @param {string} config.TaskEventQueueUrl - the URL for the SQS queue containing task-state events
  * @param {string} config.StackName - the name of the CFN stack
- * @param {boolean} config.ExponentialBackoff - whether to retry with backoff
  * @param {boolean} config.AlarmOnEachFailure - whether to send errors when workers fail
  * @param {string} [config.LogLevel=info] - fastlog log level
  * @returns {object} an event emitter that will emit an `finish` event if the
@@ -44,7 +43,6 @@ module.exports = function(config) {
     config.QueueUrl,
     config.NotificationTopic,
     config.StackName,
-    config.ExponentialBackoff === 'true' || config.ExponentialBackoff === true ? true : false,
     config.AlarmOnEachFailure === 'true' || config.AlarmOnEachFailure === true ? true : false,
     config.LogGroupArn
   );

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -40,15 +40,13 @@ function messageToEnv(message) {
  * @param {string} queue - the URL of an SQS queue
  * @param {string} topic - the ARN of an SNS topic for failure notifications
  * @param {string} stackName - the name of the CloudFormation stack
- * @param {boolean} backoff - whether jobs retrying should be returned to SQS
- * with exponential backoff.
  * @param {boolean} sendNotifications - whether to send a notification email
  * each time an invocation fails.
  * @param {string} [logGroup] - the ARN of a CloudWatch LogGroup where container
  * logs are written
  * @returns {object} a {@link messages} object
  */
-module.exports = function(queue, topic, stackName, backoff, sendNotifications, logGroup) {
+module.exports = function(queue, topic, stackName, sendNotifications, logGroup) {
   var sqs = new AWS.SQS({
     region: url.parse(queue).host.split('.')[1],
     params: { QueueUrl: queue }
@@ -129,8 +127,8 @@ module.exports = function(queue, topic, stackName, backoff, sendNotifications, l
 
       if (toDo === 'return' || toDo === 'immediate') {
         queue.defer(function(next) {
-          if (backoff && receives > 14) return next();
-          var timeout = backoff && toDo === 'return' ? Math.pow(2, receives) : 0;
+          if (receives > 14) return next();
+          var timeout = toDo === 'return' ? Math.pow(2, receives) : 0;
 
           sqs.changeMessageVisibility({
             ReceiptHandle: handle,

--- a/lib/template.js
+++ b/lib/template.js
@@ -68,11 +68,6 @@ var table = require('@mapbox/watchbot-progress').table;
  * containers that any single watcher is responsible for spawning and monitoring.
  * This parameter can be provided as either a number or a reference, i.e.
  * `{"Ref": "..."}`.
- * @param {boolean|ref} [options.backoff=true] - by default, if a processing job
- * fails for any reason, Watchbot will retry the job. The duration between
- * between retries will increase exponentially according to the number of times
- * that the job has been retried. Set this parameter to false in order to avoid
- * this exponential backoff and retry jobs immediately.
  * @param {string} [options.logAggregationFunction=''] - the ARN of a Lambda function
  * function to send logs to.
  * @param {string} [options.mounts=''] - if your worker containers need to mount
@@ -150,7 +145,6 @@ module.exports = function(options) {
   options.messageRetention = options.messageRetention || 1209600;
   options.watchers = options.watchers || 1;
   options.workers = options.workers || 1;
-  options.backoff = options.backoff === undefined ? true : options.backoff;
   options.mounts = options.mounts || '';
   options.readCapacityUnits = options.readCapacityUnits || 30;
   options.writeCapacityUnits = options.writeCapacityUnits || 30;
@@ -600,7 +594,6 @@ module.exports = function(options) {
             { Name: 'TaskEventQueueUrl', Value: cf.ref(prefixed('TaskEventQueue')) },
             { Name: 'NotificationTopic', Value: notify },
             { Name: 'StackName', Value: cf.stackName },
-            { Name: 'ExponentialBackoff', Value: typeof options.backoff === 'object' ? options.backoff : options.backoff.toString() },
             { Name: 'LogGroupArn', Value: cf.getAtt(prefixed('LogGroup'), 'Arn') },
             { Name: 'LogLevel', Value: options.debugLogs ? 'debug' : 'info' },
             { Name: 'AlarmOnEachFailure', Value: typeof options.alarmOnEachFailure === 'object' ? options.alarmOnEachFailure : options.alarmOnEachFailure.toString() }

--- a/lib/template.js
+++ b/lib/template.js
@@ -190,13 +190,48 @@ module.exports = function(options) {
     }
   };
 
+  resources[prefixed('DeadLetterQueue')] = {
+    Type: 'AWS::SQS::Queue',
+    Description: 'List of messages that failed to process 14 times',
+    Properties: {
+      QueueName: cf.join([cf.stackName, '-', prefixed('DeadLetterQueue')]),
+      MessageRetentionPeriod: 1209600
+    }
+  };
+
+  resources[prefixed('DeadLetterAlarm')] = {
+    Type: 'AWS::CloudWatch::Alarm',
+    Description: 'Provides notification when messages are visible in the dead letter queue',
+    Properties: {
+      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/alarms.md#DeadLetter`,
+      MetricName: 'ApproximateNumberOfMessagesVisible',
+      Namespace: 'AWS/SQS',
+      Statistic: 'Minimum',
+      Period: '60',
+      EvaluationPeriods: 1,
+      Threshold: 1,
+      AlarmActions: [notify],
+      Dimensions: [
+        {
+          Name: 'QueueName',
+          Value: cf.getAtt(prefixed('DeadLetterQueue'), 'QueueName')
+        }
+      ],
+      ComparisonOperator: 'GreaterThanThreshold'
+    }
+  };
+
   resources[prefixed('Queue')] = {
     Type: 'AWS::SQS::Queue',
     Description: 'Watchbot\'s backlog of messages to process',
     Properties: {
       VisibilityTimeout: options.messageTimeout,
       QueueName: cf.join([cf.stackName, '-', prefixed('Queue')]),
-      MessageRetentionPeriod: options.messageRetention
+      MessageRetentionPeriod: options.messageRetention,
+      RedrivePolicy: {
+        deadLetterTargetArn: cf.getAtt(prefixed('DeadLetterQueue'), 'Arn'),
+        maxReceiveCount: 10
+      }
     }
   };
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -152,7 +152,6 @@ module.exports = function(options) {
   options.workers = options.workers || 1;
   options.backoff = options.backoff === undefined ? true : options.backoff;
   options.mounts = options.mounts || '';
-  options.notifyAfterRetries = options.notifyAfterRetries || 0;
   options.readCapacityUnits = options.readCapacityUnits || 30;
   options.writeCapacityUnits = options.writeCapacityUnits || 30;
   options.privileged = options.privileged || false;
@@ -602,7 +601,6 @@ module.exports = function(options) {
             { Name: 'NotificationTopic', Value: notify },
             { Name: 'StackName', Value: cf.stackName },
             { Name: 'ExponentialBackoff', Value: typeof options.backoff === 'object' ? options.backoff : options.backoff.toString() },
-            { Name: 'NotifyAfterRetries', Value: options.notifyAfterRetries },
             { Name: 'LogGroupArn', Value: cf.getAtt(prefixed('LogGroup'), 'Arn') },
             { Name: 'LogLevel', Value: options.debugLogs ? 'debug' : 'info' },
             { Name: 'AlarmOnEachFailure', Value: typeof options.alarmOnEachFailure === 'object' ? options.alarmOnEachFailure : options.alarmOnEachFailure.toString() }

--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,6 @@ errorThreshold | 10 | number of failed workers to trigger alarm
 alarmThreshold | 40 | number of jobs in SQS to trigger alarm
 alarmPeriods | 24 | number of 5-min intervals SQS must be above threshold to alarm
 debugLogs | false | enable verbose watcher logging
-notifyAfterRetries | 0 | retry on any exit codes other than 0, 3, and 4 before alarm
 privileged | false | give the container elevated privileges on the host container instance
 
 ### watchbot.template references

--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,6 @@ readCapacityUnits | 30 | approximate reads per second to progress table in reduc
 writeCapacityUnits | 30 | approximate writes per second to progress table in reduce-mode
 watchers | 1 | number of watcher containers
 workers | 1 | number of concurrent worker containers per watcher
-backoff | true | retry jobs with exponential backoff
 logAggregationFunction | | the ARN of the log collection Lambda function
 mounts | '' | defines persistent container mount points from host EC2s or ephemeral mount points on the container
 reservation | {} | specify desired memory/cpu reservations for worker containers

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -9,7 +9,6 @@ var config = {
   QueueUrl: 'https://fake.us-east-1/sqs/url',
   TaskEventQueueUrl: 'https://fake.us-east-1/sqs/url-for-events',
   StackName: 'watchbot-testing',
-  ExponentialBackoff: 'false',
   AlarmOnEachFailure: 'true'
   // , LogLevel: 'debug'
 };
@@ -100,7 +99,7 @@ util.mock('[main] task running error', function(assert) {
       }
     ], 'sent expected error notification');
     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-      { ReceiptHandle: '1', VisibilityTimeout: 0 }
+      { ReceiptHandle: '1', VisibilityTimeout: 2 }
     ], 'expected sqs.changeMessageVisibility requests');
     assert.end();
   });
@@ -160,7 +159,7 @@ util.mock('[main] message completion error after task run failure', function(ass
     }), 'printed error message');
     util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-      { ReceiptHandle: 'error', VisibilityTimeout: 0 }
+      { ReceiptHandle: 'error', VisibilityTimeout: 2 }
     ], 'expected sqs.changeMessageVisibility requests');
     assert.end();
   });
@@ -272,7 +271,7 @@ util.mock('[main] manage messages for completed tasks', function(assert) {
       { ReceiptHandle: '3' }
     ], ' sqs.deleteMessage for all event messages, and for expected job messages');
     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-      { ReceiptHandle: '2', VisibilityTimeout: 0 },
+      { ReceiptHandle: '2', VisibilityTimeout: 8 },
       { ReceiptHandle: '4', VisibilityTimeout: 0 }
     ], 'expected sqs.changeMessageVisibility requests');
     util.collectionsEqual(assert, context.sns.publish, [

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -46,7 +46,6 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotWorkerErrorsAlarm, 'worker errors alarm');
   assert.equal(watch.Resources.WatchbotWorkerErrorsAlarm.Properties.Threshold, 10, 'worker errors alarm threshold');
   assert.ok(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
-  assert.deepEqual(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-4, -3), [{ Name: 'NotifyAfterRetries', Value: 0 }], 'notify after retry default value');
   assert.notOk(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is false');
   assert.equal(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Memory, 64, 'sets default hard memory limit');
   assert.ok(watch.Resources.WatchbotWorkerRole, 'worker role');
@@ -108,7 +107,6 @@ test('[template] webhooks but no key, no references', function(assert) {
     messageRetention: 3000,
     alarmThreshold: 10,
     alarmPeriods: 6,
-    notifyAfterRetries: 2,
     privileged: true
   });
 
@@ -140,7 +138,6 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.ok(watch.Resources.testWorkerErrorsAlarm, 'worker errors alarm');
   assert.equal(watch.Resources.testWorkerErrorsAlarm.Properties.Threshold, 10, 'worker errors alarm threshold');
   assert.ok(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
-  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-4, -3), [{ Name: 'NotifyAfterRetries', Value: 2 }], 'notify after retry default value');
   assert.ok(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is true');
   assert.ok(watch.Resources.testWorkerRole, 'worker role');
   assert.equal(watch.Resources.testWorkerRole.Properties.Policies.length, 1, 'default worker permissions');

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -97,7 +97,6 @@ test('[template] webhooks but no key, no references', function(assert) {
     env: { SomeKey: 'SomeValue', AnotherKey: 'AnotherValue' },
     watchers: 2,
     workers: 2,
-    backoff: false,
     mounts: '/var/tmp:/var/tmp,/mnt/data:/mnt/data,/mnt/tmp',
     reservation: {
       memory: 512,
@@ -187,7 +186,6 @@ test('[template] include all resources, no references', function(assert) {
     permissions: [{ Effect: 'Allow', Actions: '*', Resources: '*' }],
     watchers: 2,
     workers: 2,
-    backoff: false,
     mounts: {
       container: ['/var/tmp', '/mnt/data', '/mnt/tmp'],
       host: ['/var/tmp', '/mnt/data', '']
@@ -292,7 +290,6 @@ test('[template] include all resources, all references', function(assert) {
     permissions: [{ Effect: 'Allow', Actions: '*', Resources: '*' }],
     watchers: cf.ref('NumWatchers'),
     workers: cf.ref('NumWorkers'),
-    backoff: cf.ref('UseBackoff'),
     mounts: {
       container: [cf.sub('/var/tmp/${stack}', { stack: cf.ref(stackName) }), '/mnt/data', '/mnt/tmp'],
       host: [cf.sub('/var/tmp/${stack}', { stack: cf.ref(stackName) }), '/mnt/data', '']
@@ -352,7 +349,6 @@ test('[template] include all resources, all references', function(assert) {
   assert.ok(watch.Resources.testProgressTablePermission, 'progress table permission');
   assert.deepEqual(watch.Resources.testWorker.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'ProgressTable', Value: cf.join(['arn:aws:dynamodb:', cf.region, ':', cf.accountId, ':table/', cf.ref('testProgressTable')]) }], 'progress table env var');
   assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment[3], { Name: 'Concurrency', Value: cf.ref('NumWorkers') }, 'sets Concurrency');
-  assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment[8], { Name: 'ExponentialBackoff', Value: cf.ref('UseBackoff') }, 'sets ExponentialBackoff');
   assert.deepEqual(watch.Resources.testWatcher.Properties.ContainerDefinitions[0].Environment.slice(-1), [{ Name: 'AlarmOnEachFailure', Value: cf.ref('AlarmOnFailures') }], 'alarm on failure env var');
   assert.deepEqual(watch.Resources.testWorker.Properties.Volumes[0], { Name: 'mnt-0', Host: { SourcePath: { 'Fn::Sub': ['/var/tmp/${stack}', { stack: { Ref: 'some-stack-name' } }] } } });
   assert.deepEqual(watch.Resources.testWorker.Properties.Volumes[1], { Name: 'mnt-1', Host: { SourcePath: '/mnt/data' } });
@@ -390,7 +386,6 @@ test('[template] resources are valid', function(assert) {
     permissions: [{ Effect: 'Allow', Actions: '*', Resources: '*' }],
     watchers: 2,
     workers: 2,
-    backoff: false,
     mounts: '/var/tmp:/var/tmp,/mnt/data:/mnt/data,/mnt/tmp',
     logAggregationFunction: 'arn:aws:lambda:us-east-1:123456789000:function:log-fake-test',
     reservation: {
@@ -434,7 +429,6 @@ test('[template] notificationTopic vs notificationEmail', function(assert) {
       permissions: [{ Effect: 'Allow', Actions: '*', Resources: '*' }],
       watchers: 2,
       workers: 2,
-      backoff: false,
       mounts: '/var/tmp:/var/tmp,/mnt/data:/mnt/data,/mnt/tmp',
       logAggregationFunction: 'arn:aws:lambda:us-east-1:123456789000:function:log-fake-test',
       reservation: {
@@ -464,7 +458,6 @@ test('[template] notificationTopic vs notificationEmail', function(assert) {
     permissions: [{ Effect: 'Allow', Actions: '*', Resources: '*' }],
     watchers: 2,
     workers: 2,
-    backoff: false,
     mounts: '/var/tmp:/var/tmp,/mnt/data:/mnt/data,/mnt/tmp',
     logAggregationFunction: 'arn:aws:lambda:us-east-1:123456789000:function:log-fake-test',
     reservation: {

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -32,6 +32,8 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotLogGroup, 'log group');
   assert.notOk(watch.Resources.WatchbotLogForwarding, 'log forwarding function');
   assert.ok(watch.Resources.WatchbotQueue, 'queue');
+  assert.ok(watch.Resources.WatchbotDeadLetterQueue, 'dead letter queue');
+  assert.ok(watch.Resources.WatchbotDeadLetterAlarm, 'dead letter alarm');
   assert.ok(watch.Resources.WatchbotTopic, 'topic');
   assert.ok(watch.Resources.WatchbotQueuePolicy, 'queue policy');
   assert.ok(watch.Resources.WatchbotQueueSizeAlarm, 'queue alarm');
@@ -123,6 +125,8 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.ok(watch.Resources.testLogGroup, 'log group');
   assert.notOk(watch.Resources.testLogForwarding, 'log forwarding function');
   assert.ok(watch.Resources.testQueue, 'queue');
+  assert.ok(watch.Resources.testDeadLetterQueue, 'dead letter queue');
+  assert.ok(watch.Resources.testDeadLetterAlarm, 'dead letter alarm');
   assert.ok(watch.Resources.testTopic, 'topic');
   assert.ok(watch.Resources.testQueuePolicy, 'queue policy');
   assert.ok(watch.Resources.testQueueSizeAlarm, 'queue alarm');
@@ -219,6 +223,8 @@ test('[template] include all resources, no references', function(assert) {
   assert.ok(watch.Resources.testLogGroup, 'log group');
   assert.ok(watch.Resources.testLogForwarding, 'log forwarding function');
   assert.ok(watch.Resources.testQueue, 'queue');
+  assert.ok(watch.Resources.testDeadLetterQueue, 'dead letter queue');
+  assert.ok(watch.Resources.testDeadLetterAlarm, 'dead letter alarm');
   assert.ok(watch.Resources.testTopic, 'topic');
   assert.ok(watch.Resources.testQueuePolicy, 'queue policy');
   assert.ok(watch.Resources.testQueueSizeAlarm, 'queue alarm');
@@ -323,6 +329,8 @@ test('[template] include all resources, all references', function(assert) {
   assert.equal(watch.Resources.testLogForwarding.Condition, 'testUseLogForwarding', 'log forwarding function is conditional');
   assert.deepEqual(watch.Conditions.testUseLogForwarding, cf.notEquals(cf.ref('LogAggregationFunction'), ''), 'log forwarding condition provided');
   assert.ok(watch.Resources.testQueue, 'queue');
+  assert.ok(watch.Resources.testDeadLetterQueue, 'dead letter queue');
+  assert.ok(watch.Resources.testDeadLetterAlarm, 'dead letter alarm');
   assert.ok(watch.Resources.testTopic, 'topic');
   assert.ok(watch.Resources.testQueuePolicy, 'queue policy');
   assert.ok(watch.Resources.testQueueSizeAlarm, 'queue alarm');


### PR DESCRIPTION
After the switch to alarms on error **rate** rather than per-failure (#76), we are in a situation where we will know if there are a lot of errors, but if there are only a few jobs that are failing, and perhaps hitting workers very slowly, the failures can slip under the radar.

Adding a dead letter queue means messages that retried several times will be dropped out from cycling in the stack. They'll land in a separate, stagnant queue, and we can trigger an alarm when there are any messages in that queue. This gives us visibility into edge-case jobs that need some more attention. 

Once they've landed in the queue, it will take manual inspection of each message and re-queuing into the primary SQS queue if the message needs to be reprocessed. I think that we'll build some tooling to assist with this, but not in this PR.

Messages will be attempted up to 10 times. On the 11th receive, the message will not be seen by the watcher, but will instead land in the dead letter queue. Each time the message fails it is put back into the queue with an increasing backoff interval before it can be attempted again. These intervals look like:

attempt number | backoff interval (s)
--- | ---
1 | 2
2 | 4
3 | 8
4 | 16
5 | 32
6 | 64
7 | 128
8 | 256
9 | 512
10 | 1024

This means that on the 9th receive, the message will be invisible for at least 8.5 minutes before it is retried. If the 10th attempt also fails, then the message will have been retrying for a minimum of 17 minutes, and at this point it will fall into the dead letter queue.

**Note: number of attempts != number of times a worker has tried to process the task**. If a cluster is full, watchbot will attempt to place tasks, and fail, and replace them in the queue, and try again. This counts as a retry. If cluster capacity is a problem, the cluster basically has 17 minutes to accommodate the increased demand before message will start falling into the dead letter queue. During this time, watchbot will also trip a FailedWorkerPlacement alarm, in case manual intervention is required.

Besides adding a dead letter queue, this PR also:
- removes the `.notifyAfterRetries` option
- removes the `.backoff` option, enforcing exponential backoff always

cc @jacquestardie @tcql @rodowi @mapsam @jakepruitt 
Fixes #106 