### PR TITLE
Consolidated CLI, dead letter management

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,18 +4,21 @@
 
 var meow = require('meow');
 
-var cli = meow(`
-  USAGE: watchbot <command> [OPTIONS]
+var cli = meow({
+  help: `
+    USAGE: watchbot <command> [OPTIONS]
 
-  Commands:
-    worker-capacity     assess available resources on the cluster
-    dead-letter         triage messages in dead letter queue
+    Commands:
+      worker-capacity     assess available resources on the cluster
+      dead-letter         triage messages in dead letter queue
 
-  Options:
-    -h, --help          show this help message
-    -s, --stack-name    the full name of a watchbot stack
-    -r, --region        the region of the stack (default us-east-1)
-`, {
+    Options:
+      -h, --help          show this help message
+      -s, --stack-name    the full name of a watchbot stack
+      -r, --region        the region of the stack (default us-east-1)
+  `,
+  description: 'Helper utilities for interacting with watchbot stacks'
+}, {
   alias: { s: 'stack-name', r: 'region' },
   defaults: { region: 'us-east-1' }
 });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+var meow = require('meow');
+
+var cli = meow(`
+  USAGE: watchbot <command> [OPTIONS]
+
+  Commands:
+    worker-capacity     assess available resources on the cluster
+    dead-letter         triage messages in dead letter queue
+
+  Options:
+    -h, --help          show this help message
+    -s, --stack-name    the full name of a watchbot stack
+    -r, --region        the region of the stack (default us-east-1)
+`, {
+  alias: { s: 'stack-name', r: 'region' },
+  defaults: { region: 'us-east-1' }
+});
+
+var command = cli.input[0];
+var fn;
+try { fn = require(`../lib/${command}`); }
+catch(err) {
+  console.error(err.message);
+  cli.showHelp(1);
+}
+
+fn(cli.flags, function(err) {
+  if (err) {
+    console.error(err.stack);
+    cli.showHelp(1);
+  }
+});

--- a/bin/worker-capacity.js
+++ b/bin/worker-capacity.js
@@ -1,9 +1,0 @@
-#!/usr/bin/env node
-
-var argv = process.argv.slice(2);
-var run = require('../lib/capacity').run;
-
-run(argv, (err, result) => {
-  if (err) console.log('\n%s\n', err);
-  if (result.capacity) console.log('\n%s currently has enough space for an additional %s %s workers.\n', result.cluster, result.capacity, result.stack);
-});

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 ### unreleased
 
+- fixes a bug in the changelog
+- consolidates CLI commands into a single `watchbot` command
+- adds a CLI command for interacting with the dead letter queue
+
+### 2.0.0
+
 - fixes a bug that wouldn't have allowed you to disable exponential backoff
 - returns `task.container[n].reason` as `reason` when task finishes, if available
 - adds a second SQS queue used for the watcher's internal tracking of CloudWatch task state-change events

--- a/docs/command-line-utilities.md
+++ b/docs/command-line-utilities.md
@@ -1,15 +1,57 @@
 ## Command-line utilities
 
-### Assessing worker capacity in your service's cluster
-
-`worker-capacity` is a CLI command to estimate how many additional workers
-can be placed in your service's cluster at its current capacity using the CPU and
-memory reservations provided in your `watchbot.template`.
-
 ```
-$ worker-capacity <region> <stack_name>
+> watchbot --help
+
+  Build an AWS stack to do your work for you
+
+  USAGE: watchbot <command> [OPTIONS]
+
+  Commands:
+    worker-capacity     assess available resources on the cluster
+    dead-letter         triage messages in dead letter queue
+
+  Options:
+    -h, --help          show this help message
+    -s, --stack-name    the full name of a watchbot stack
+    -r, --region        the region of the stack (default us-east-1)
 ```
+
+### worker-capacity
+
+`worker-capacity` helps estimate how many additional workers can be placed in
+your service's cluster at its current capacity using the CPU and memory
+reservations provided in your `watchbot.template`.
 
 You must provide both a service region and stack name to execute this command. Note
-that your stack will need to expose the cluster ARN in your watchbot stack `Outputs`
-property, which may require upgrading your `@mapbox/watchbot` version.
+that your stack will need to expose the cluster ARN in your Watchbot stack `Outputs`
+property. Pre-2.0 versions of Watchbot do not expose these outputs.
+
+### dead-letter
+
+`dead-letter` is an interactive tool for dealing with messages in Watchbot's [dead letter queue](./worker-retry-cycle.md#the-dead-letter-queue).
+
+You must provide both a service region and stack name to execute this command. Note
+that your stack will need to expose the cluster ARN in your Watchbot stack `Outputs`
+property. Pre-2.0 versions of Watchbot do not expose these outputs.
+
+### Dead letter workflow
+
+First, if your stack contains more than one watchbot system, you will first be prompted to select which one you wish to work with. If your stack contains only one watchbot system, you will proceed straight to the next step.
+
+You'll be asked with action you wish to take. Your choices are:
+
+  - **Triage dead messages individually?**: interact with messages one-by-one
+  - **Print out all dead messages?**: This will print the subject and message of every job in the dead letter queue as line-delimited JSON strings
+  - **Return all dead messages to the work queue?**: Every message in the dead letter queue is sent back to Watchbot's primary work queue for another attempt. You will be asked to confirm before this will proceed.  
+  - **Purge the dead letter queue?**: Deletes every message from the dead letter queue. If messages in the dead letter queue still need to be processed, you will have to send them to Watchbot's primary work queue again manually. You will be asked to confirm before this will proceed.
+
+If you selected individual triage, you'll be presented with a set of options for each message in the dead letter queue.
+
+  - **View this message's recent logs?**: Queries CloudWatch Logs to try and find the most recent 50kb worth of logs related to the message. *Warning:* this can be quite slow.
+  - **Return this message to the work queue?**: Sends this message back to Watchbot's primary work queue for reprocessing.
+  - **Return this message to the dead letter queue?**: Puts the message back into the dead letter queue to be investigated later.
+  - **Delete this message entirely?**: Removes the message from the dead letter queue. If the message still needs to be processed, you will have to send it to Watchbot's primary work queue again manually.
+  - **Stop individual triage?**: Stop triaging and exit the CLI.
+
+Once all the messages in the dead letter queue have been either sent back to primary work queue or deleted, the CLI will exit.

--- a/docs/worker-retry-cycle.md
+++ b/docs/worker-retry-cycle.md
@@ -27,4 +27,4 @@ If the 10th attempt to process a message fails, then the message will have been 
 
 If a message fails processing 10 times, Watchbot will stop attempting it. The message will be dropped into a second SQS queue, called a dead letter queue. When there are **any** messages visible in this queue, Watchbot will trip the [DeadLetter alarm](./alarms.md#deadletter). This helps to give visibility into edge-case messages that may highlight a bug in worker code.
 
-Once a message is in the dead letter queue, it will stay there until it is manually removed, or after 14 days. Coming soon: command-line utility to help process messages in the dead letter queue.
+Once a message is in the dead letter queue, it will stay there until it is manually removed, or after 14 days. See [the CLI documentation](./command-line-utilities.md#dead-letter) for instructions for interacting with the dead letter queue.

--- a/lib/dead-letter.js
+++ b/lib/dead-letter.js
@@ -4,6 +4,7 @@ var AWS = require('aws-sdk');
 var inquirer = require('inquirer');
 var stream = require('stream');
 var Queue = require('p-queue');
+var logs = require('./logs');
 
 module.exports = function(options, callback) {
   var cfn = new AWS.CloudFormation({ region: options.region });
@@ -38,14 +39,22 @@ function findQueues(cfn, options) {
         url: o.OutputValue
       }));
 
-    return { deadLetterQueues, workQueues };
+    var logGroups = res.Stacks[0].Outputs
+      .filter((o) => /LogGroup/.test(o.OutputKey))
+      .map((o) => ({
+        prefix: o.OutputKey.replace('LogGroup', ''),
+        arn: o.OutputValue
+      }));
+
+    return { deadLetterQueues, workQueues, logGroups };
   });
 }
 
 function selectQueue(queues) {
   if (queues.deadLetterQueues.length === 1) return Promise.resolve({
     deadLetter: queues.deadLetterQueues[0].url,
-    work: queues.workQueues.find((queue) => queue.prefix === queues.deadLetterQueues[0].prefix).url
+    work: queues.workQueues.find((queue) => queue.prefix === queues.deadLetterQueues[0].prefix).url,
+    logs: queues.logGroups.find((group) => group.prefix === queues.deadLetterQueues[0].prefix).arn
   });
 
   return inquirer.prompt([
@@ -59,7 +68,8 @@ function selectQueue(queues) {
     var deadLetterQueue = queues.deadLetterQueues.find((queue) => queue.prefix === answers.queue);
     return {
       deadLetter: deadLetterQueue.url,
-      work: queues.workQueues.find((queue) => queue.prefix === deadLetterQueue.prefix)
+      work: queues.workQueues.find((queue) => queue.prefix === deadLetterQueue.prefix).url,
+      logs: queues.logGroups.find((group) => group.prefix === deadLetterQueue.prefix).arn
     };
   });
 }
@@ -176,6 +186,46 @@ function triage(sqs, queue) {
   });
 }
 
+function triagePrompts(sqs, queue, message) {
+  var actions = { replayOne, returnOne, deleteOne };
+
+  return inquirer.prompt([
+    {
+      type: 'list',
+      name: 'action',
+      message: 'Would you like to:',
+      choices: [
+        'View this message\'s recent logs?',
+        'Return this message to the work queue?',
+        'Return this message to the dead letter queue?',
+        'Delete this message entirely?',
+        'Stop individual triage?'
+      ]
+    }
+  ]).then((answers) => {
+    var mapping = {
+      'View this message\'s recent logs?': 'logs',
+      'Return this message to the work queue?': 'replayOne',
+      'Return this message to the dead letter queue?': 'returnOne',
+      'Delete this message entirely?': 'deleteOne',
+      'Stop individual triage?': 'stop'
+    };
+
+    var choice = mapping[answers.action];
+    var queueUrl = choice === 'replayOne' ? queue.work : queue.deadLetter;
+
+    if (choice === 'logs') return getLogs(sqs, queue, message);
+
+    if (choice === 'stop') return returnOne(sqs, queueUrl, message)
+      .then(() => Promise.reject({ finished: true }));
+
+    if (choice === 'replayOne') return replayOne(sqs, queueUrl, message)
+      .then(() => deleteOne(sqs, queue.deadLetter, message));
+
+    return actions[choice](sqs, queueUrl, message);
+  });
+}
+
 function triageOne(sqs, queue) {
   return receive(sqs, 1, queue.deadLetter)
     .then((messages) => {
@@ -186,39 +236,7 @@ function triageOne(sqs, queue) {
       console.log(`Subject: ${message.subject}`);
       console.log(`Message: ${message.message}`);
 
-      var actions = { replayOne, returnOne, deleteOne };
-
-      return inquirer.prompt([
-        {
-          type: 'list',
-          name: 'action',
-          message: 'Would you like to:',
-          choices: [
-            'Return this message to the work queue?',
-            'Return this message to the dead letter queue?',
-            'Delete this message entirely?',
-            'Stop individual triage?'
-          ]
-        }
-      ]).then((answers) => {
-        var mapping = {
-          'Return this message to the work queue?': 'replayOne',
-          'Return this message to the dead letter queue?': 'returnOne',
-          'Delete this message entirely?': 'deleteOne',
-          'Stop individual triage?': 'stop'
-        };
-
-        var choice = mapping[answers.action];
-        var queueUrl = choice === 'replayOne' ? queue.work : queue.deadLetter;
-
-        if (choice === 'stop') return returnOne(sqs, queueUrl, message)
-          .then(() => Promise.reject({ finished: true }));
-
-        if (choice === 'replayOne') return replayOne(sqs, queueUrl, message)
-          .then(() => deleteOne(sqs, queue.deadLetter, message));
-
-        return actions[choice](sqs, queueUrl, message);
-      });
+      return triagePrompts(sqs, queue, message);
     });
 }
 
@@ -290,5 +308,27 @@ function receiveAll(sqs, queueUrl) {
         .then(() => this._read())
         .catch((err) => this.emit('error', err));
     }
+  });
+}
+
+function getLogs(sqs, queue, message) {
+  return new Promise((resolve, reject) => {
+    logs.fetch(queue.logs, message.message, (err, data) => {
+      if (err) return reject(err);
+
+      var re = new RegExp(`\\[watchbot\\] \\[(.*?)\\] {"subject":".*?","message":"${message.message}"`);
+      var line = data.split('\n').find((line) => re.test(line));
+      if (!line) return Promise.resolve('Could not find any matching logs\n');
+
+      var id = line.match(re)[1];
+      logs.fetch(queue.logs, id, (err, data) => {
+        if (err) return reject(err);
+        resolve(data);
+      });
+    });
+  }).then((data) => {
+    console.log();
+    console.log(data);
+    return triagePrompts(sqs, queue, message);
   });
 }

--- a/lib/dead-letter.js
+++ b/lib/dead-letter.js
@@ -1,0 +1,292 @@
+/* eslint-disable no-console */
+
+var AWS = require('aws-sdk');
+var inquirer = require('inquirer');
+var stream = require('stream');
+var Queue = require('p-queue');
+
+module.exports = function(options, callback) {
+  var cfn = new AWS.CloudFormation({ region: options.region });
+  var sqs = new AWS.SQS({ region: options.region });
+
+  var actions = { purge, writeOut, replay, triage };
+
+  findQueues(cfn, options)
+    .then((queues) => selectQueue(queues))
+    .then((queue) => triageSelection(queue))
+    .then((data) => actions[data.action](sqs, data.queue))
+    .then(() => callback())
+    .catch((err) => callback(err));
+};
+
+function findQueues(cfn, options) {
+  return cfn.describeStacks({ StackName: options.stackName }).promise().then((res) => {
+    if (!res.Stacks[0])
+      return Promise.reject(new Error(`Could not find ${options.stackName} in ${options.region}`));
+
+    var deadLetterQueues = res.Stacks[0].Outputs
+      .filter((o) => /DeadLetterQueueUrl/.test(o.OutputKey))
+      .map((o) => ({
+        prefix: o.OutputKey.replace('DeadLetterQueueUrl', ''),
+        url: o.OutputValue
+      }));
+
+    var workQueues = res.Stacks[0].Outputs
+      .filter((o) => /QueueUrl/.test(o.OutputKey) && !/DeadLetterQueueUrl/.test(o.OutputKey))
+      .map((o) => ({
+        prefix: o.OutputKey.replace('QueueUrl', ''),
+        url: o.OutputValue
+      }));
+
+    return { deadLetterQueues, workQueues };
+  });
+}
+
+function selectQueue(queues) {
+  if (queues.deadLetterQueues.length === 1) return Promise.resolve({
+    deadLetter: queues.deadLetterQueues[0].url,
+    work: queues.workQueues.find((queue) => queue.prefix === queues.deadLetterQueues[0].prefix).url
+  });
+
+  return inquirer.prompt([
+    {
+      type: 'list',
+      name: 'queue',
+      message: 'Which queue would you like to triage?',
+      choices: queues.deadLetterQueues.map((queue) => queue.prefix)
+    }
+  ]).then((answers) => {
+    var deadLetterQueue = queues.deadLetterQueues.find((queue) => queue.prefix === answers.queue);
+    return {
+      deadLetter: deadLetterQueue.url,
+      work: queues.workQueues.find((queue) => queue.prefix === deadLetterQueue.prefix)
+    };
+  });
+}
+
+function triageSelection(queue) {
+  return inquirer.prompt([
+    {
+      type: 'list',
+      name: 'action',
+      message: 'Would you like to:',
+      choices: [
+        'Purge the dead letter queue?',
+        'Return all dead messages to the work queue?',
+        'Triage dead mesages individually?',
+        'Print out all dead messages?'
+      ]
+    }
+  ]).then((answers) => {
+    var mapping = {
+      'Purge the dead letter queue?': 'purge',
+      'Return all dead messages to the work queue?': 'replay',
+      'Triage dead mesages individually?': 'triage',
+      'Print out all dead messages?': 'writeOut'
+    };
+
+    return { queue, action: mapping[answers.action] };
+  });
+}
+
+function purge(sqs, queue) {
+  return inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'purge',
+      message: 'You are about to remove all jobs from the dead letter queue permanently. Are you sure?'
+    }
+  ]).then((answers) => {
+    if (answers.purge)
+      return sqs.purgeQueue({ QueueUrl: queue.deadLetter }).promise();
+    return Promise.resolve();
+  });
+}
+
+function writeOut(sqs, queue) {
+  var reciever = receiveAll(sqs, queue.deadLetter);
+
+  var stringifier = new stream.Transform({
+    objectMode: true,
+    transform: function(msg, _, callback) {
+      var data = { subject: msg.subject, message: msg.message };
+      this.push(`${JSON.stringify(data)}\n`);
+      stringifier.handles.push(msg.handle);
+      callback();
+    }
+  });
+  stringifier.handles = [];
+
+  return new Promise((resolve, reject) => {
+    var done = () => returnMany(sqs, queue.deadLetter, stringifier.handles)
+      .then(() => resolve())
+      .catch((err) => reject(err));
+
+    reciever
+        .on('error', reject)
+      .pipe(stringifier)
+        .on('error', reject)
+        .on('end', done)
+      .pipe(process.stdout);
+  });
+}
+
+function replay(sqs, queue) {
+  var reciever = receiveAll(sqs, queue.deadLetter);
+
+  var replayer = new stream.Writable({
+    objectMode: true,
+    write: function(msg, _, callback) {
+      replayOne(sqs, queue.work, msg)
+        .then(() => deleteOne(sqs, queue.deadLetter, msg))
+        .then(() => callback())
+        .catch((err) => callback(err));
+    }
+  });
+
+  return inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'replayAll',
+      message: 'You are about to return all messages in the dead letter queue to the work queue. Are you sure?'
+    }
+  ]).then((answers) => {
+    if (!answers.replayAll) return Promise.resolve();
+
+    return new Promise((resolve, reject) => {
+      reciever
+          .on('error', reject)
+        .pipe(replayer)
+          .on('error', reject)
+          .on('finish', resolve);
+    });
+  });
+}
+
+function triage(sqs, queue) {
+  return new Promise((resolve, reject) => {
+    (function recurse() {
+      triageOne(sqs, queue)
+        .then(() => recurse())
+        .catch((err) => {
+          if (err.finished) return resolve();
+          reject(err);
+        });
+    })();
+  });
+}
+
+function triageOne(sqs, queue) {
+  return receive(sqs, 1, queue.deadLetter)
+    .then((messages) => {
+      var message = messages[0];
+      if (!message) return Promise.reject({ finished: true });
+
+      console.log('');
+      console.log(`ID: ${message.id}`);
+      console.log(`Subject: ${message.subject}`);
+      console.log(`Message: ${message.message}`);
+
+      var actions = { replayOne, returnOne, deleteOne };
+
+      return inquirer.prompt([
+        {
+          type: 'list',
+          name: 'action',
+          message: 'Would you like to:',
+          choices: [
+            'Return this message to the work queue?',
+            'Return this message to the dead letter queue?',
+            'Delete this message entirely?',
+            'Stop individual triage?'
+          ]
+        }
+      ]).then((answers) => {
+        var mapping = {
+          'Return this message to the work queue?': 'replayOne',
+          'Return this message to the dead letter queue?': 'returnOne',
+          'Delete this message entirely?': 'deleteOne',
+          'Stop individual triage?': 'stop'
+        };
+
+        var choice = mapping[answers.action];
+        var queueUrl = choice === 'replayOne' ? queue.work : queue.deadLetter;
+
+        if (choice === 'stop') return returnOne(sqs, queueUrl, message)
+          .then(() => Promise.reject({ finished: true }));
+
+        return actions[choice](sqs, queueUrl, message);
+      });
+    });
+}
+
+function receive(sqs, count, queueUrl) {
+  return sqs.receiveMessage({
+    QueueUrl: queueUrl,
+    WaitTimeSeconds: 1,
+    MaxNumberOfMessages: count,
+    VisibilityTimeout: 10 * 60
+  }).promise().then((data) => (data.Messages || []).map((message) => ({
+    id: message.MessageId,
+    body: message.Body,
+    subject: JSON.parse(message.Body).Subject,
+    message: JSON.parse(message.Body).Message,
+    handle: message.ReceiptHandle
+  })));
+}
+
+function returnOne(sqs, queueUrl, message) {
+  var handle = typeof message === 'string' ? message : message.handle;
+  return sqs.changeMessageVisibility({
+    QueueUrl: queueUrl,
+    ReceiptHandle: handle,
+    VisibilityTimeout: 0
+  }).promise();
+}
+
+function returnMany(sqs, queueUrl, handles) {
+  var queue = new Queue({ concurrency: 10 });
+  var returns = handles.map((handle) => queue.add(() => returnOne(sqs, queueUrl, handle)));
+  return Promise.all(returns);
+}
+
+function replayOne(sqs, queueUrl, message) {
+  return sqs.sendMessage({
+    QueueUrl: queueUrl,
+    MessageBody: message.body
+  }).promise();
+}
+
+function deleteOne(sqs, queueUrl, message) {
+  return sqs.deleteMessage({
+    QueueUrl: queueUrl,
+    ReceiptHandle: message.handle
+  }).promise();
+}
+
+function receiveAll(sqs, queueUrl) {
+  var messages = [];
+  var pending = false;
+
+  var next = function() {
+    pending = true;
+    return receive(sqs, 10, queueUrl).then((msgs) => {
+      pending = false;
+      msgs.forEach((msg) => messages.push(msg));
+      if (!msgs.length) next = null;
+    });
+  };
+
+  return new stream.Readable({
+    objectMode: true,
+    read: function() {
+      var status = true;
+      while (status && messages.length) status = this.push(messages.shift());
+      if (messages.length)  return;
+      if (!next) return this.push(null);
+      if (status && !pending) return next()
+          .then(() => this._read())
+          .catch((err) => this.emit('error', err));
+    }
+  });
+}

--- a/lib/dead-letter.js
+++ b/lib/dead-letter.js
@@ -5,6 +5,7 @@ var inquirer = require('inquirer');
 var stream = require('stream');
 var Queue = require('p-queue');
 var logs = require('./logs');
+var Spinner = require('cli-spinner').Spinner;
 
 module.exports = function(options, callback) {
   var cfn = new AWS.CloudFormation({ region: options.region });
@@ -151,6 +152,10 @@ function replay(sqs, queue) {
   ]).then((answers) => {
     if (!answers.replayAll) return Promise.resolve();
 
+    var spinner = new Spinner('Returning all dead messages to the work queue...');
+    spinner.setSpinnerString('⠄⠆⠇⠋⠙⠸⠰⠠⠰⠸⠙⠋⠇⠆');
+    spinner.start();
+
     var reciever = receiveAll(sqs, queue.deadLetter);
 
     var replayer = new stream.Writable({
@@ -169,7 +174,8 @@ function replay(sqs, queue) {
         .pipe(replayer)
           .on('error', reject)
           .on('finish', resolve);
-    });
+    })
+    .then(() => spinner.stop(true));
   });
 }
 
@@ -265,9 +271,14 @@ function returnOne(sqs, queueUrl, message) {
 }
 
 function returnMany(sqs, queueUrl, handles) {
+  var spinner = new Spinner(`Returning ${handles.length} jobs to the queue...`);
+  spinner.setSpinnerString('⠄⠆⠇⠋⠙⠸⠰⠠⠰⠸⠙⠋⠇⠆');
+  spinner.start();
+
   var queue = new Queue({ concurrency: 10 });
   var returns = handles.map((handle) => queue.add(() => returnOne(sqs, queueUrl, handle)));
-  return Promise.all(returns);
+  return Promise.all(returns)
+    .then(() => spinner.stop(true));
 }
 
 function replayOne(sqs, queueUrl, message) {
@@ -312,6 +323,10 @@ function receiveAll(sqs, queueUrl) {
 }
 
 function getLogs(sqs, queue, message) {
+  var spinner = new Spinner('Searching CloudWatch logs...');
+  spinner.setSpinnerString('⠄⠆⠇⠋⠙⠸⠰⠠⠰⠸⠙⠋⠇⠆');
+  spinner.start();
+
   return new Promise((resolve, reject) => {
     logs.fetch(queue.logs, message.message, (err, data) => {
       if (err) return reject(err);
@@ -327,6 +342,7 @@ function getLogs(sqs, queue, message) {
       });
     });
   }).then((data) => {
+    spinner.stop(true);
     console.log();
     console.log(data);
     return triagePrompts(sqs, queue, message);

--- a/lib/dead-letter.js
+++ b/lib/dead-letter.js
@@ -73,7 +73,7 @@ function triageSelection(queue) {
       choices: [
         'Purge the dead letter queue?',
         'Return all dead messages to the work queue?',
-        'Triage dead mesages individually?',
+        'Triage dead messages individually?',
         'Print out all dead messages?'
       ]
     }
@@ -81,7 +81,7 @@ function triageSelection(queue) {
     var mapping = {
       'Purge the dead letter queue?': 'purge',
       'Return all dead messages to the work queue?': 'replay',
-      'Triage dead mesages individually?': 'triage',
+      'Triage dead messages individually?': 'triage',
       'Print out all dead messages?': 'writeOut'
     };
 
@@ -132,18 +132,6 @@ function writeOut(sqs, queue) {
 }
 
 function replay(sqs, queue) {
-  var reciever = receiveAll(sqs, queue.deadLetter);
-
-  var replayer = new stream.Writable({
-    objectMode: true,
-    write: function(msg, _, callback) {
-      replayOne(sqs, queue.work, msg)
-        .then(() => deleteOne(sqs, queue.deadLetter, msg))
-        .then(() => callback())
-        .catch((err) => callback(err));
-    }
-  });
-
   return inquirer.prompt([
     {
       type: 'confirm',
@@ -152,6 +140,18 @@ function replay(sqs, queue) {
     }
   ]).then((answers) => {
     if (!answers.replayAll) return Promise.resolve();
+
+    var reciever = receiveAll(sqs, queue.deadLetter);
+
+    var replayer = new stream.Writable({
+      objectMode: true,
+      write: function(msg, _, callback) {
+        replayOne(sqs, queue.work, msg)
+          .then(() => deleteOne(sqs, queue.deadLetter, msg))
+          .then(() => callback())
+          .catch((err) => callback(err));
+      }
+    });
 
     return new Promise((resolve, reject) => {
       reciever
@@ -183,7 +183,6 @@ function triageOne(sqs, queue) {
       if (!message) return Promise.reject({ finished: true });
 
       console.log('');
-      console.log(`ID: ${message.id}`);
       console.log(`Subject: ${message.subject}`);
       console.log(`Message: ${message.message}`);
 
@@ -214,6 +213,9 @@ function triageOne(sqs, queue) {
 
         if (choice === 'stop') return returnOne(sqs, queueUrl, message)
           .then(() => Promise.reject({ finished: true }));
+
+        if (choice === 'replayOne') return replayOne(sqs, queueUrl, message)
+          .then(() => deleteOne(sqs, queue.deadLetter, message));
 
         return actions[choice](sqs, queueUrl, message);
       });
@@ -285,8 +287,8 @@ function receiveAll(sqs, queueUrl) {
       if (messages.length)  return;
       if (!next) return this.push(null);
       if (status && !pending) return next()
-          .then(() => this._read())
-          .catch((err) => this.emit('error', err));
+        .then(() => this._read())
+        .catch((err) => this.emit('error', err));
     }
   });
 }

--- a/lib/dead-letter.js
+++ b/lib/dead-letter.js
@@ -81,10 +81,10 @@ function triageSelection(queue) {
       name: 'action',
       message: 'Would you like to:',
       choices: [
-        'Purge the dead letter queue?',
-        'Return all dead messages to the work queue?',
         'Triage dead messages individually?',
-        'Print out all dead messages?'
+        'Print out all dead messages?',
+        'Return all dead messages to the work queue?',
+        'Purge the dead letter queue?'
       ]
     }
   ]).then((answers) => {

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -52,7 +52,8 @@ function fetch(logGroup, messageId, callback) {
     region: logGroup.split(':')[3],
     group: logGroup.split(':')[6],
     pattern: messageId,
-    messages: true
+    messages: true,
+    start: Date.now() - 6 * 60 * 60 * 1000
   }).on('error', callback);
 
   var writable = new stream.Writable();

--- a/lib/template.js
+++ b/lib/template.js
@@ -657,6 +657,23 @@ module.exports = function(options) {
     }
   };
 
+  var outputs = {
+    ClusterArn: {
+      Description: 'Service cluster ARN',
+      Value: options.cluster
+    }
+  };
+
+  outputs[prefixed('DeadLetterQueueUrl')] = {
+    Description: 'The URL for the dead letter queue',
+    Value: cf.ref(prefixed('DeadLetterQueue'))
+  };
+
+  outputs[prefixed('QueueUrl')] = {
+    Description: 'The URL for the primary work queue',
+    Value: cf.ref(prefixed('Queue'))
+  };
+
   /**
    * The Watchbot template builder output object
    *
@@ -697,12 +714,7 @@ module.exports = function(options) {
       EcrRegion: require('../mappings/ecr-region.json')
     },
     ref: references,
-    Outputs: {
-      ClusterArn: {
-        Description: 'Service cluster ARN',
-        Value: options.cluster
-      }
-    }
+    Outputs: outputs
   };
 };
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -674,6 +674,11 @@ module.exports = function(options) {
     Value: cf.ref(prefixed('Queue'))
   };
 
+  outputs[prefixed('LogGroup')] = {
+    Description: 'The ARN of Watchbot\'s log group',
+    Value: cf.getAtt(prefixed('LogGroup'), 'Arn')
+  };
+
   /**
    * The Watchbot template builder output object
    *

--- a/lib/worker-capacity.js
+++ b/lib/worker-capacity.js
@@ -1,32 +1,31 @@
+/* eslint-disable no-console */
+
 var AWS = require('aws-sdk');
 
-module.exports = {};
-module.exports.run = run;
+module.exports = run;
 module.exports.getClusterArn = getClusterArn;
 module.exports.getReservations = getReservations;
 module.exports.listInstances = listInstances;
 module.exports.calculateRoom = calculateRoom;
 
-function run(argv, callback) {
-  /* Confirm that region and stack are provided */
-  var usage = 'Usage:   worker-capacity <region> <stack_name>\n';
-  usage += 'Example: worker-capacity us-east-1 cats-api-staging';
-
-  if (argv.length !== 2) return callback(usage);
-  argv = { region: argv[0], stack: argv[1] };
+function run(options, callback) {
+  if (!options.stackName) return callback(new Error('No stack name provided'));
+  if (!options.region) return callback(new Error('No region specified'));
 
   /* Run functions */
-  getClusterArn(argv, (err, clusterArn) => {
+  getClusterArn(options, (err, clusterArn) => {
     if (err) return callback(err);
-    getReservations(argv, (err, reservations) => {
+    getReservations(options, (err, reservations) => {
       if (err) return callback(err);
-      listInstances(argv, clusterArn, (err, resources) => {
+      listInstances(options, clusterArn, (err, resources) => {
         if (err) return callback(err);
         var result = {
           capacity: calculateRoom(resources, reservations),
           cluster: clusterArn.match(/arn:aws:ecs:.*:\d*:cluster\/(.*)/)[1],
-          stack: argv.stack
+          stack: options.stackName
         };
+
+        console.log('\n%s currently has enough space for an additional %s %s workers.\n', result.cluster, result.capacity, result.stack);
         return callback(null, result);
       });
     });
@@ -36,7 +35,7 @@ function run(argv, callback) {
 function getClusterArn(argv, callback) {
   var cfn = new AWS.CloudFormation({ region: argv.region });
 
-  cfn.describeStacks({ StackName: argv.stack }, (err, res) => {
+  cfn.describeStacks({ StackName: argv.stackName }, (err, res) => {
     if (err) return callback(new Error(err));
     if (!res.Stacks[0] || !res.Stacks[0].Outputs.length) return callback(new Error('Check that the provided region and stack name are correct. You may need to re-create your stack to expose the Outputs property.'));
 
@@ -50,7 +49,7 @@ function getReservations(argv, callback) {
   var cfn = new AWS.CloudFormation({ region: argv.region });
   var ecs = new AWS.ECS({ region: argv.region });
 
-  cfn.describeStackResources({ StackName: argv.stack }, (err, res) => {
+  cfn.describeStackResources({ StackName: argv.stackName }, (err, res) => {
     if (err) return callback(new Error(err));
     var worker = res.StackResources.find((r) => { return r.LogicalResourceId === 'WatchbotWorker'; }).PhysicalResourceId;
     ecs.describeTaskDefinition({ taskDefinition: worker }, (err, res) => {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@mapbox/mock-aws-sdk-js": "0.0.4",
+    "cli-spinner": "^0.2.6",
     "dynamodb-test": "^0.2.2",
     "eslint": "^2.6.0",
     "inquirer": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "bin": {
     "watchbot-log": "./bin/watchbot-log.js",
     "watchbot-progress": "./node_modules/@mapbox/watchbot-progress/bin/watchbot-progress.js",
-    "worker-capacity": "./bin/worker-capacity.js"
+    "watchbot": "./bin/cli.js"
   },
   "dependencies": {
     "@mapbox/watchbot-progress": "^1.1.1",
@@ -37,7 +37,6 @@
     "d3-queue": "^2.0.3",
     "dyno": "^1.2.0",
     "fastlog": "^1.0.0",
-    "meow": "^3.7.0",
     "stream-combiner": "^0.2.2",
     "underscore": "^1.8.3"
   },
@@ -45,8 +44,11 @@
     "@mapbox/mock-aws-sdk-js": "0.0.4",
     "dynamodb-test": "^0.2.2",
     "eslint": "^2.6.0",
+    "inquirer": "^3.0.1",
+    "meow": "^3.7.0",
     "nyc": "^6.4.0",
     "opener": "^1.4.1",
+    "p-queue": "^1.0.0",
     "sinon": "^1.17.5",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.1"

--- a/test/dead-letter.test.js
+++ b/test/dead-letter.test.js
@@ -81,10 +81,10 @@ test('[dead-letter] check initial prompts (multiple watchbots)', (assert) => {
     assert.equal(prompt.args[1][0].length, 1, 'second prompt one question');
     assert.equal(prompt.args[1][0][0].type, 'list', 'second prompt type = list');
     assert.deepEqual(prompt.args[1][0][0].choices, [
-      'Purge the dead letter queue?',
-      'Return all dead messages to the work queue?',
       'Triage dead messages individually?',
-      'Print out all dead messages?'
+      'Print out all dead messages?',
+      'Return all dead messages to the work queue?',
+      'Purge the dead letter queue?'
     ], 'second prompt expected actions');
 
     assert.equal(prompt.args[2][0].length, 1, 'third prompt one question');
@@ -132,10 +132,10 @@ test('[dead-letter] check initial prompts (single watchbot)', (assert) => {
     assert.equal(prompt.args[0][0].length, 1, 'first prompt one question');
     assert.equal(prompt.args[0][0][0].type, 'list', 'first prompt type = list');
     assert.deepEqual(prompt.args[0][0][0].choices, [
-      'Purge the dead letter queue?',
-      'Return all dead messages to the work queue?',
       'Triage dead messages individually?',
-      'Print out all dead messages?'
+      'Print out all dead messages?',
+      'Return all dead messages to the work queue?',
+      'Purge the dead letter queue?'
     ], 'first prompt expected actions');
 
     assert.equal(prompt.args[1][0].length, 1, 'second prompt one question');

--- a/test/dead-letter.test.js
+++ b/test/dead-letter.test.js
@@ -1,0 +1,464 @@
+var test = require('tape');
+var sinon = require('sinon');
+var AWS = require('@mapbox/mock-aws-sdk-js');
+var dead = require('../lib/dead-letter');
+var inquirer = require('inquirer');
+
+test('[dead-letter] proper client setup & stack description', (assert) => {
+  var desc = AWS.stub('CloudFormation', 'describeStacks', function() {
+    this.request.promise.returns(Promise.reject(new Error('bail')));
+  });
+
+  AWS.stub('SQS', 'purgeQueue');
+
+  dead({ stackName: 'stack', region: 'region' }, (err) => {
+    assert.equal(err.message, 'bail', 'test bail out');
+
+    assert.ok(AWS.CloudFormation.calledWith({ region: 'region' }), 'CloudFormation client in correct region');
+    assert.equal(desc.callCount, 1, 'called describeStacks');
+    assert.ok(desc.calledWith({ StackName: 'stack' }), 'describeStacks on provieded stack name');
+
+    assert.ok(AWS.SQS.calledWith({ region: 'region' }), 'SQS client in correct region');
+
+    AWS.CloudFormation.restore();
+    AWS.SQS.restore();
+    assert.end();
+  });
+});
+
+test('[dead-letter] stack not found', (assert) => {
+  AWS.stub('CloudFormation', 'describeStacks', function() {
+    this.request.promise.returns(Promise.resolve({
+      Stacks: []
+    }));
+  });
+
+  dead({ stackName: 'stack', region: 'region' }, (err) => {
+    assert.equal(err.message, 'Could not find stack in region', 'expected error message');
+    AWS.CloudFormation.restore();
+    assert.end();
+  });
+});
+
+test('[dead-letter] check initial prompts (multiple watchbots)', (assert) => {
+  var prompt = sinon.stub(inquirer, 'prompt');
+  prompt.onCall(0).returns(Promise.resolve({ queue: 'one' }));
+  prompt.onCall(1).returns(Promise.resolve({ action: 'Purge the dead letter queue?' }));
+  prompt.onCall(2).returns(Promise.resolve({ purge: true }));
+
+  AWS.stub('CloudFormation', 'describeStacks', function() {
+    this.request.promise.returns(Promise.resolve({
+      Stacks: [
+        {
+          Outputs: [
+            { OutputKey: 'oneDeadLetterQueueUrl', OutputValue: 'oneDead' },
+            { OutputKey: 'twoDeadLetterQueueUrl', OutputValue: 'twoDead' },
+            { OutputKey: 'oneQueueUrl', OutputValue: 'oneWork' },
+            { OutputKey: 'twoQueueUrl', OutputValue: 'twoWork' }
+          ]
+        }
+      ]
+    }));
+  });
+
+  var purge = AWS.stub('SQS', 'purgeQueue', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  dead({ stackName: 'stack', region: 'region' }, (err) => {
+    assert.ifError(err, 'success');
+    if (err) return assert.end();
+
+    assert.equal(prompt.callCount, 3, 'three prompts');
+
+    assert.equal(prompt.args[0][0].length, 1, 'first prompt one question');
+    assert.equal(prompt.args[0][0][0].type, 'list', 'first prompt type = list');
+    assert.deepEqual(prompt.args[0][0][0].choices, ['one', 'two'], 'first prompt correctly identifies queue prefixes');
+
+    assert.equal(prompt.args[1][0].length, 1, 'second prompt one question');
+    assert.equal(prompt.args[1][0][0].type, 'list', 'second prompt type = list');
+    assert.deepEqual(prompt.args[1][0][0].choices, [
+      'Purge the dead letter queue?',
+      'Return all dead messages to the work queue?',
+      'Triage dead messages individually?',
+      'Print out all dead messages?'
+    ], 'second prompt expected actions');
+
+    assert.equal(prompt.args[2][0].length, 1, 'third prompt one question');
+    assert.equal(prompt.args[2][0][0].type, 'confirm', 'third prompt type = confirm');
+
+    assert.equal(purge.callCount, 1, 'calls purgeQueue');
+    assert.ok(purge.calledWith({ QueueUrl: 'oneDead' }), 'purges the dead letter queue');
+
+    prompt.restore();
+    AWS.CloudFormation.restore();
+    AWS.SQS.restore();
+    assert.end();
+  });
+});
+
+test('[dead-letter] check initial prompts (single watchbot)', (assert) => {
+  var prompt = sinon.stub(inquirer, 'prompt');
+  prompt.onCall(0).returns(Promise.resolve({ action: 'Purge the dead letter queue?' }));
+  prompt.onCall(1).returns(Promise.resolve({ purge: true }));
+
+  AWS.stub('CloudFormation', 'describeStacks', function() {
+    this.request.promise.returns(Promise.resolve({
+      Stacks: [
+        {
+          Outputs: [
+            { OutputKey: 'oneDeadLetterQueueUrl', OutputValue: 'oneDead' },
+            { OutputKey: 'oneQueueUrl', OutputValue: 'oneWork' }
+          ]
+        }
+      ]
+    }));
+  });
+
+  var purge = AWS.stub('SQS', 'purgeQueue', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  dead({ stackName: 'stack', region: 'region' }, (err) => {
+    assert.ifError(err, 'success');
+    if (err) return assert.end();
+
+    assert.equal(prompt.callCount, 2, 'two prompts');
+
+    assert.equal(prompt.args[0][0].length, 1, 'first prompt one question');
+    assert.equal(prompt.args[0][0][0].type, 'list', 'first prompt type = list');
+    assert.deepEqual(prompt.args[0][0][0].choices, [
+      'Purge the dead letter queue?',
+      'Return all dead messages to the work queue?',
+      'Triage dead messages individually?',
+      'Print out all dead messages?'
+    ], 'first prompt expected actions');
+
+    assert.equal(prompt.args[1][0].length, 1, 'second prompt one question');
+    assert.equal(prompt.args[1][0][0].type, 'confirm', 'second prompt type = confirm');
+
+    assert.equal(purge.callCount, 1, 'calls purgeQueue');
+    assert.ok(purge.calledWith({ QueueUrl: 'oneDead' }), 'purges the dead letter queue');
+
+    prompt.restore();
+    AWS.CloudFormation.restore();
+    AWS.SQS.restore();
+    assert.end();
+  });
+});
+
+test('[dead-letter] reject purge confirmation', (assert) => {
+  var prompt = sinon.stub(inquirer, 'prompt');
+  prompt.onCall(0).returns(Promise.resolve({ action: 'Purge the dead letter queue?' }));
+  prompt.onCall(1).returns(Promise.resolve({ purge: false }));
+
+  AWS.stub('CloudFormation', 'describeStacks', function() {
+    this.request.promise.returns(Promise.resolve({
+      Stacks: [
+        {
+          Outputs: [
+            { OutputKey: 'oneDeadLetterQueueUrl', OutputValue: 'oneDead' },
+            { OutputKey: 'oneQueueUrl', OutputValue: 'oneWork' }
+          ]
+        }
+      ]
+    }));
+  });
+
+  var purge = AWS.stub('SQS', 'purgeQueue', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  dead({ stackName: 'stack', region: 'region' }, (err) => {
+    assert.ifError(err, 'success');
+    if (err) return assert.end();
+
+    assert.equal(purge.callCount, 0, 'does not call purgeQueue');
+
+    prompt.restore();
+    AWS.CloudFormation.restore();
+    AWS.SQS.restore();
+    assert.end();
+  });
+});
+
+test('[dead-letter] return messages to work queue', (assert) => {
+  var prompt = sinon.stub(inquirer, 'prompt');
+  prompt.onCall(0).returns(Promise.resolve({ action: 'Return all dead messages to the work queue?' }));
+  prompt.onCall(1).returns(Promise.resolve({ replayAll: true }));
+
+  AWS.stub('CloudFormation', 'describeStacks', function() {
+    this.request.promise.returns(Promise.resolve({
+      Stacks: [
+        {
+          Outputs: [
+            { OutputKey: 'oneDeadLetterQueueUrl', OutputValue: 'oneDead' },
+            { OutputKey: 'oneQueueUrl', OutputValue: 'oneWork' }
+          ]
+        }
+      ]
+    }));
+  });
+
+  var receives = 0;
+  var receive = AWS.stub('SQS', 'receiveMessage', function() {
+    receives++;
+    var payload = {};
+
+    if (receives === 1) payload = {
+      Messages: [
+        {
+          MessageId: 'id-1',
+          Body: JSON.stringify({ Subject: 'subject-1', Message: 'message-1' }),
+          ReceiptHandle: 'handle-1'
+        },
+        {
+          MessageId: 'id-2',
+          Body: JSON.stringify({ Subject: 'subject-2', Message: 'message-2' }),
+          ReceiptHandle: 'handle-2'
+        }
+      ]
+    };
+
+    if (receives > 1) payload = { Messages: [] };
+
+    this.request.promise.returns(Promise.resolve(payload));
+  });
+
+  var send = AWS.stub('SQS', 'sendMessage', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  var del = AWS.stub('SQS', 'deleteMessage', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  dead({ stackName: 'stack', region: 'region' }, (err) => {
+    assert.ifError(err, 'success');
+    if (err) return assert.end();
+
+    assert.equal(prompt.args[1][0].length, 1, 'second prompt one question');
+    assert.equal(prompt.args[1][0][0].type, 'confirm', 'second prompt type = confirm');
+
+    assert.equal(receive.callCount, 2, 'calls receiveMessage twice');
+    assert.ok(receive.alwaysCalledWith({
+      QueueUrl: 'oneDead',
+      WaitTimeSeconds: 1,
+      MaxNumberOfMessages: 10,
+      VisibilityTimeout: 600
+    }), 'reads correct queue, uses long-polling, receives up to 10, 10min timeout');
+
+    assert.equal(send.callCount, 2, 'calls sendMessage twice');
+    assert.ok(send.calledWith({
+      QueueUrl: 'oneWork',
+      MessageBody: JSON.stringify({ Subject: 'subject-1', Message: 'message-1' })
+    }), 'sends one dead SQS message back to work queue');
+    assert.ok(send.calledWith({
+      QueueUrl: 'oneWork',
+      MessageBody: JSON.stringify({ Subject: 'subject-2', Message: 'message-2' })
+    }), 'sends the other dead SQS message back to work queue');
+
+    assert.equal(del.callCount, 2, 'calls deleteMessage twice');
+    assert.ok(del.calledWith({
+      QueueUrl: 'oneDead',
+      ReceiptHandle: 'handle-1'
+    }), 'deletes one message from dead letter queue');
+    assert.ok(del.calledWith({
+      QueueUrl: 'oneDead',
+      ReceiptHandle: 'handle-2'
+    }), 'deletes the other message from dead letter queue');
+
+    prompt.restore();
+    AWS.CloudFormation.restore();
+    AWS.SQS.restore();
+    assert.end();
+  });
+});
+
+test('[dead-letter] reject return messages confirmation', (assert) => {
+  var prompt = sinon.stub(inquirer, 'prompt');
+  prompt.onCall(0).returns(Promise.resolve({ action: 'Return all dead messages to the work queue?' }));
+  prompt.onCall(1).returns(Promise.resolve({ replayAll: false }));
+
+  AWS.stub('CloudFormation', 'describeStacks', function() {
+    this.request.promise.returns(Promise.resolve({
+      Stacks: [
+        {
+          Outputs: [
+            { OutputKey: 'oneDeadLetterQueueUrl', OutputValue: 'oneDead' },
+            { OutputKey: 'oneQueueUrl', OutputValue: 'oneWork' }
+          ]
+        }
+      ]
+    }));
+  });
+
+  var receive = AWS.stub('SQS', 'receiveMessage', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  var send = AWS.stub('SQS', 'sendMessage', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  var del = AWS.stub('SQS', 'deleteMessage', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  dead({ stackName: 'stack', region: 'region' }, (err) => {
+    assert.ifError(err, 'success');
+    if (err) return assert.end();
+
+    assert.equal(receive.callCount, 0, 'receives no messages');
+    assert.equal(send.callCount, 0, 'sends no messages');
+    assert.equal(del.callCount, 0, 'deletes no messages');
+
+    prompt.restore();
+    AWS.CloudFormation.restore();
+    AWS.SQS.restore();
+    assert.end();
+  });
+});
+
+test('[dead-letter] individual message triage', (assert) => {
+  var prompt = sinon.stub(inquirer, 'prompt');
+  prompt.onCall(0).returns(Promise.resolve({ action: 'Triage dead messages individually?' }));
+  prompt.onCall(1).returns(Promise.resolve({ action: 'Return this message to the work queue?' }));
+  prompt.onCall(2).returns(Promise.resolve({ action: 'Return this message to the dead letter queue?' }));
+  prompt.onCall(3).returns(Promise.resolve({ action: 'Delete this message entirely?' }));
+  prompt.onCall(4).returns(Promise.resolve({ action: 'Stop individual triage?' }));
+
+  AWS.stub('CloudFormation', 'describeStacks', function() {
+    this.request.promise.returns(Promise.resolve({
+      Stacks: [
+        {
+          Outputs: [
+            { OutputKey: 'oneDeadLetterQueueUrl', OutputValue: 'oneDead' },
+            { OutputKey: 'oneQueueUrl', OutputValue: 'oneWork' }
+          ]
+        }
+      ]
+    }));
+  });
+
+  var receive = AWS.stub('SQS', 'receiveMessage');
+  receive.onCall(0).returns({
+    promise: () => Promise.resolve({ Messages: [{ MessageId: 'id-1', Body: JSON.stringify({ Subject: 'subject-1', Message: 'message-1' }), ReceiptHandle: 'handle-1' }] })
+  });
+  receive.onCall(1).returns({
+    promise: () => Promise.resolve({ Messages: [{ MessageId: 'id-2', Body: JSON.stringify({ Subject: 'subject-2', Message: 'message-2' }), ReceiptHandle: 'handle-2' }] })
+  });
+  receive.onCall(2).returns({
+    promise: () => Promise.resolve({ Messages: [{ MessageId: 'id-3', Body: JSON.stringify({ Subject: 'subject-3', Message: 'message-3' }), ReceiptHandle: 'handle-3' }] })
+  });
+  receive.onCall(3).returns({
+    promise: () => Promise.resolve({ Messages: [{ MessageId: 'id-4', Body: JSON.stringify({ Subject: 'subject-4', Message: 'message-4' }), ReceiptHandle: 'handle-4' }] })
+  });
+
+  var send = AWS.stub('SQS', 'sendMessage', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  var del = AWS.stub('SQS', 'deleteMessage', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  var vis = AWS.stub('SQS', 'changeMessageVisibility', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  dead({ stackName: 'stack', region: 'region' }, (err) => {
+    assert.ifError(err, 'success');
+    if (err) return assert.end();
+
+    assert.equal(send.callCount, 1, 'one sendMessage request');
+    assert.ok(send.calledWith({
+      QueueUrl: 'oneWork',
+      MessageBody: JSON.stringify({ Subject: 'subject-1', Message: 'message-1' })
+    }), 'returns the first message to work queue');
+
+    assert.equal(del.callCount, 2, 'two deleteMessage requests');
+    assert.ok(del.calledWith({
+      QueueUrl: 'oneDead',
+      ReceiptHandle: 'handle-1'
+    }), 'deletes the first message from the dead letter queue');
+    assert.ok(del.calledWith({
+      QueueUrl: 'oneDead',
+      ReceiptHandle: 'handle-3'
+    }), 'deletes the third message from the dead letter queue');
+
+    assert.equal(vis.callCount, 2, 'two changeMessageVisibility requests');
+    assert.ok(vis.calledWith({
+      QueueUrl: 'oneDead',
+      ReceiptHandle: 'handle-2',
+      VisibilityTimeout: 0
+    }), 'returns the second message to the dead letter queue');
+    assert.ok(vis.calledWith({
+      QueueUrl: 'oneDead',
+      ReceiptHandle: 'handle-4',
+      VisibilityTimeout: 0
+    }), 'returns the fourth, unseen message to the dead letter queue');
+
+    prompt.restore();
+    AWS.CloudFormation.restore();
+    AWS.SQS.restore();
+    assert.end();
+  });
+});
+
+test('[dead-letter] write out messages', (assert) => {
+  var prompt = sinon.stub(inquirer, 'prompt');
+  prompt.onCall(0).returns(Promise.resolve({ action: 'Print out all dead messages?' }));
+
+  AWS.stub('CloudFormation', 'describeStacks', function() {
+    this.request.promise.returns(Promise.resolve({
+      Stacks: [
+        {
+          Outputs: [
+            { OutputKey: 'oneDeadLetterQueueUrl', OutputValue: 'oneDead' },
+            { OutputKey: 'oneQueueUrl', OutputValue: 'oneWork' }
+          ]
+        }
+      ]
+    }));
+  });
+  
+  var receive = AWS.stub('SQS', 'receiveMessage');
+  receive.onCall(0).returns({
+    promise: () => Promise.resolve({
+      Messages: [
+        { MessageId: 'id-1', Body: JSON.stringify({ Subject: 'subject-1', Message: 'message-1' }), ReceiptHandle: 'handle-1' },
+        { MessageId: 'id-2', Body: JSON.stringify({ Subject: 'subject-2', Message: 'message-2' }), ReceiptHandle: 'handle-2' }
+      ]
+    })
+  });
+  receive.onCall(1).returns({
+    promise: () => Promise.resolve({})
+  });
+
+  var vis = AWS.stub('SQS', 'changeMessageVisibility', function() {
+    this.request.promise.returns(Promise.resolve());
+  });
+
+  dead({ stackName: 'stack', region: 'region' }, (err) => {
+    assert.ifError(err, 'success');
+    if (err) return assert.end();
+
+    assert.equal(vis.callCount, 2, 'two changeMessageVisibility requests');
+    assert.ok(vis.calledWith({
+      QueueUrl: 'oneDead',
+      ReceiptHandle: 'handle-1',
+      VisibilityTimeout: 0
+    }), 'returns the first message to the dead letter queue');
+    assert.ok(vis.calledWith({
+      QueueUrl: 'oneDead',
+      ReceiptHandle: 'handle-2',
+      VisibilityTimeout: 0
+    }), 'returns the second message to the dead letter queue');
+
+    prompt.restore();
+    AWS.CloudFormation.restore();
+    AWS.SQS.restore();
+    assert.end();
+  });
+});

--- a/test/logs.test.js
+++ b/test/logs.test.js
@@ -106,6 +106,10 @@ test('[logs] fetch a ton of logs', function(assert) {
   logs += '\n' + crypto.randomBytes(25 * 1024).toString('hex') + '\n';
 
   sinon.stub(cwlogs, 'readable', function(options) {
+    var tminus6 = Date.now() - 6 * 60 * 60 * 1000;
+    assert.ok(Math.abs(tminus6 - options.start) < 10000, 'queries last 6 hours of logs');
+    delete options.start;
+    
     assert.deepEqual(options, {
       region: 'eu-west-1',
       group: 'some-log-group',

--- a/test/worker-capacity.test.js
+++ b/test/worker-capacity.test.js
@@ -1,22 +1,22 @@
 var AWS = require('@mapbox/mock-aws-sdk-js');
-var file = require('../lib/capacity');
+var capacity = require('../lib/worker-capacity');
 var fixtures = require('./fixtures/capacity');
 var test = require('tape');
 
-var argv = { region: 'us-east-1', stack: 'cats-api-staging' };
+var argv = { region: 'us-east-1', stackName: 'cats-api-staging' };
 var cluster = 'arn:aws:ecs:us-east-1:123456789000:cluster/some-cluster-Cluster-000000000000';
 var error = 'some error';
 
 test('[capacity] run - missing region', (assert) => {
-  file.run(['cats-api-staging'], (err) => {
-    assert.equal(err, 'Usage:   worker-capacity <region> <stack_name>\nExample: worker-capacity us-east-1 cats-api-staging');
+  capacity({ stackName: 'cats-api-staging' }, (err) => {
+    assert.equal(err.message, 'No region specified');
     assert.end();
   });
 });
 
 test('[capacity] run - missing stack', (assert) => {
-  file.run(['us-east-1'], (err) => {
-    assert.equal(err, 'Usage:   worker-capacity <region> <stack_name>\nExample: worker-capacity us-east-1 cats-api-staging');
+  capacity({ region: 'us-east-1' }, (err) => {
+    assert.equal(err.message, 'No stack name provided');
     assert.end();
   });
 });
@@ -38,7 +38,7 @@ test('[capacity] run', (assert) => {
   describeContainerInstances.onCall(0).yields(null, fixtures.describeContainerInstances0);
   describeContainerInstances.onCall(1).yields(null, fixtures.describeContainerInstances1);
 
-  file.run(['us-east-1', 'cats-api-staging'], (err, res) => {
+  capacity({ region: 'us-east-1', stackName: 'cats-api-staging' }, (err, res) => {
     assert.ifError(err, 'should not error');
     assert.deepEqual(res, { capacity: 256, cluster: 'some-cluster-Cluster-000000000000', stack: 'cats-api-staging' });
     AWS.CloudFormation.restore();
@@ -50,8 +50,8 @@ test('[capacity] run', (assert) => {
 test('[capacity] getClusterArn - describeStacks error', (assert) => {
   var describeStacks = AWS.stub('CloudFormation', 'describeStacks').yields(error);
 
-  file.getClusterArn(argv, (err) => {
-    assert.deepEqual(describeStacks.firstCall.args[0], { StackName: argv.stack });
+  capacity.getClusterArn(argv, (err) => {
+    assert.deepEqual(describeStacks.firstCall.args[0], { StackName: argv.stackName });
     assert.equal(err.message, error);
     AWS.CloudFormation.restore();
     assert.end();
@@ -61,8 +61,8 @@ test('[capacity] getClusterArn - describeStacks error', (assert) => {
 test('[capacity] getClusterArn', (assert) => {
   var describeStacks = AWS.stub('CloudFormation', 'describeStacks').yields(null, fixtures.describeStacks);
 
-  file.getClusterArn(argv, (err, res) => {
-    assert.deepEqual(describeStacks.firstCall.args[0], { StackName: argv.stack });
+  capacity.getClusterArn(argv, (err, res) => {
+    assert.deepEqual(describeStacks.firstCall.args[0], { StackName: argv.stackName });
     assert.ifError(err, 'should not error');
     assert.equal(res, fixtures.describeStacks.Stacks[0].Outputs[0].OutputValue);
     AWS.CloudFormation.restore();
@@ -74,8 +74,8 @@ test('[capacity] getReservations - describeStackResources error', (assert) => {
   var describeStackResources = AWS.stub('CloudFormation', 'describeStackResources').yields(error);
   var describeTaskDefinition = AWS.stub('ECS', 'describeTaskDefinition');
 
-  file.getReservations(argv, (err) => {
-    assert.deepEqual(describeStackResources.firstCall.args[0], { StackName: argv.stack });
+  capacity.getReservations(argv, (err) => {
+    assert.deepEqual(describeStackResources.firstCall.args[0], { StackName: argv.stackName });
     assert.equal(describeTaskDefinition.called, false, 'ecs.describeTaskDefinition should not be called');
     assert.equal(err.message, error);
     AWS.CloudFormation.restore();
@@ -88,8 +88,8 @@ test('[capacity] getReservations - describeTaskDefinition error', (assert) => {
   var describeStackResources = AWS.stub('CloudFormation', 'describeStackResources').yields(null, fixtures.describeStackResources);
   var describeTaskDefinition = AWS.stub('ECS', 'describeTaskDefinition').yields(error);
 
-  file.getReservations(argv, (err) => {
-    assert.deepEqual(describeStackResources.firstCall.args[0], { StackName: argv.stack });
+  capacity.getReservations(argv, (err) => {
+    assert.deepEqual(describeStackResources.firstCall.args[0], { StackName: argv.stackName });
     assert.deepEqual(describeTaskDefinition.firstCall.args[0], { taskDefinition: fixtures.describeStackResources.StackResources[0].PhysicalResourceId });
     assert.equal(err.message, error);
     AWS.CloudFormation.restore();
@@ -102,8 +102,8 @@ test('[capacity] getReservations - soft memory', (assert) => {
   var describeStackResources = AWS.stub('CloudFormation', 'describeStackResources').yields(null, fixtures.describeStackResources);
   var describeTaskDefinition = AWS.stub('ECS', 'describeTaskDefinition').yields(null, fixtures.describeTaskDefinitionSoftMem);
 
-  file.getReservations(argv, (err, res) => {
-    assert.deepEqual(describeStackResources.firstCall.args[0], { StackName: argv.stack });
+  capacity.getReservations(argv, (err, res) => {
+    assert.deepEqual(describeStackResources.firstCall.args[0], { StackName: argv.stackName });
     assert.deepEqual(describeTaskDefinition.firstCall.args[0], { taskDefinition: fixtures.describeStackResources.StackResources[0].PhysicalResourceId });
     assert.ifError(err, 'should not error');
     assert.deepEqual(res, { Memory: 128, Cpu: 256 });
@@ -117,8 +117,8 @@ test('[capacity] getReservations - hard memory', (assert) => {
   var describeStackResources = AWS.stub('CloudFormation', 'describeStackResources').yields(null, fixtures.describeStackResources);
   var describeTaskDefinition = AWS.stub('ECS', 'describeTaskDefinition').yields(null, fixtures.describeTaskDefinitionHardMem);
 
-  file.getReservations(argv, (err, res) => {
-    assert.deepEqual(describeStackResources.firstCall.args[0], { StackName: argv.stack });
+  capacity.getReservations(argv, (err, res) => {
+    assert.deepEqual(describeStackResources.firstCall.args[0], { StackName: argv.stackName });
     assert.deepEqual(describeTaskDefinition.firstCall.args[0], { taskDefinition: fixtures.describeStackResources.StackResources[0].PhysicalResourceId });
     assert.ifError(err, 'should not error');
     assert.deepEqual(res, { Memory: 128, Cpu: 256 });
@@ -132,8 +132,8 @@ test('[capacity] getReservations - both memories', (assert) => {
   var describeStackResources = AWS.stub('CloudFormation', 'describeStackResources').yields(null, fixtures.describeStackResources);
   var describeTaskDefinition = AWS.stub('ECS', 'describeTaskDefinition').yields(null, fixtures.describeTaskDefinitionBothMem);
 
-  file.getReservations(argv, (err, res) => {
-    assert.deepEqual(describeStackResources.firstCall.args[0], { StackName: argv.stack });
+  capacity.getReservations(argv, (err, res) => {
+    assert.deepEqual(describeStackResources.firstCall.args[0], { StackName: argv.stackName });
     assert.deepEqual(describeTaskDefinition.firstCall.args[0], { taskDefinition: fixtures.describeStackResources.StackResources[0].PhysicalResourceId });
     assert.ifError(err, 'should not error');
     assert.deepEqual(res, { Memory: 128, Cpu: 256 });
@@ -151,7 +151,7 @@ test('[capacity] listInstances - listContainerInstances error', (assert) => {
   });
   var describeContainerInstances = AWS.stub('ECS', 'describeContainerInstances');
 
-  file.listInstances(argv, cluster, (err) => {
+  capacity.listInstances(argv, cluster, (err) => {
     assert.deepEqual(listContainerInstances.firstCall.args, [{ cluster: cluster }]);
     assert.equal(describeContainerInstances.called, false, 'should not have called ecs.describeContainerInstances');
     assert.equal(err.message, error);
@@ -170,7 +170,7 @@ test('[capacity] listInstances - describeContainerInstances error', (assert) => 
   });
   var describeContainerInstances = AWS.stub('ECS', 'describeContainerInstances').yields(error);
 
-  file.listInstances(argv, cluster, (err) => {
+  capacity.listInstances(argv, cluster, (err) => {
     assert.deepEqual(listContainerInstances.firstCall.args[0], { cluster: cluster });
     assert.deepEqual(describeContainerInstances.firstCall.args[0], { cluster: cluster, containerInstances: fixtures.listContainerInstances.containerInstanceArns });
     assert.equal(err.message, error);
@@ -189,7 +189,7 @@ test('[capacity] listInstances - single page', (assert) => {
   });
   var describeContainerInstances = AWS.stub('ECS', 'describeContainerInstances').yields(null, fixtures.describeContainerInstances);
 
-  file.listInstances(argv, cluster, (err, res) => {
+  capacity.listInstances(argv, cluster, (err, res) => {
     assert.deepEqual(listContainerInstances.firstCall.args[0], { cluster: cluster });
     assert.deepEqual(describeContainerInstances.firstCall.args[0], { cluster: cluster, containerInstances: listContainerInstances.containerInstanceArns });
     assert.ifError(err, 'should not error');
@@ -216,7 +216,7 @@ test('[capacity] listInstances - multiple pages', (assert) => {
   describeContainerInstances.onCall(0).yields(null, fixtures.describeContainerInstances0);
   describeContainerInstances.onCall(1).yields(null, fixtures.describeContainerInstances1);
 
-  file.listInstances(argv, cluster, (err, res) => {
+  capacity.listInstances(argv, cluster, (err, res) => {
     assert.deepEqual(listContainerInstances.firstCall.args[0], { cluster: cluster });
     assert.deepEqual(describeContainerInstances.firstCall.args[0], {
       cluster: 'arn:aws:ecs:us-east-1:123456789000:cluster/some-cluster-Cluster-000000000000',
@@ -241,8 +241,8 @@ test('[capacity] calculateRoom - no room', (assert) => {
   var noCpu = [[{ name: 'CPU', integerValue: '0' }, { name: 'MEMORY', integerValue: '1000' }]];
   var noMem = [[{ name: 'CPU', integerValue: '1000' }, { name: 'MEMORY', integerValue: '0' }]];
 
-  assert.equal(file.calculateRoom(noCpu, reservation), 0, 'should return room for 0 workers if no CPU remaining');
-  assert.equal(file.calculateRoom(noMem, reservation), 0, 'should return room for 0 workers if no memory remaining');
+  assert.equal(capacity.calculateRoom(noCpu, reservation), 0, 'should return room for 0 workers if no CPU remaining');
+  assert.equal(capacity.calculateRoom(noMem, reservation), 0, 'should return room for 0 workers if no memory remaining');
   assert.end();
 });
 
@@ -254,7 +254,7 @@ test('[capacity] calculateRoom - room', (assert) => {
     [{ name: 'CPU', integerValue: '60000' }, { name: 'MEMORY', integerValue: '50000' }]
   ];
 
-  var result = file.calculateRoom(resources, reservation);
+  var result = capacity.calculateRoom(resources, reservation);
   assert.equal(result, 235, 'should equal sum of tasks per instance based on most limited resource');
   assert.end();
 });


### PR DESCRIPTION
Sets up a framework for a consolidated CLI, currently with 2 commands available:

```
> watchbot --help

  Build an AWS stack to do your work for you

  USAGE: watchbot <command> [OPTIONS]

  Commands:
    worker-capacity     assess available resources on the cluster
    dead-letter         triage messages in dead letter queue

  Options:
    -h, --help          show this help message
    -s, --stack-name    the full name of a watchbot stack
    -r, --region        the region of the stack (default us-east-1)
```

This incorporates @emilymdubois' worker-capacity function, and adds a command for interacting with the dead letter queue:

```
> watchbot dead-letter -r ap-northeast-1 -s ecs-telephone-rclark
? Would you like to: (Use arrow keys)
❯ Triage dead messages individually? 
  Print out all dead messages? 
  Return all dead messages to the work queue? 
  Purge the dead letter queue? 
```

These options are pretty self-explanatory. The individual triage pulls one message from the dead letter queue, prints it out for you, and asks you if you want to:

```
? Would you like to: (Use arrow keys)
❯ View this message's recent logs?
  Return this message to the work queue?,
  Return this message to the dead letter queue?,
  Delete this message entirely?,
  Stop individual triage?
```

Upon making a selection, it does that, then presents you with another dead message (if there is one).

TODO:

- [x] fix worker capacity tests
- [x] tests for new command
- [x] fix CLI description text
- [x] view recent logs for individual jobs
- [x] spinner / progress indication on long processes
- [ ] ~~try to improve cloudwatch log search speeds~~ this will require some work in cwlogs.