### PR TITLE
Pin to LTS ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:14.04
 
 # Setup
 RUN apt-get update -qq && apt-get install -y curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 # Setup
 RUN apt-get update -qq && apt-get install -y curl


### PR DESCRIPTION
I noticed we are using `ubuntu:latest` in this repo while we consistently pin to a LTS for other ecs projects. This changes to pinning. /cc @rclark any reason not to pin?