### PR TITLE
Make event rule for cloudwatch events shorter

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -441,7 +441,7 @@ module.exports = function(options) {
       Description: cf.join(['Filter CloudWatch events for task-state changes related to ', cf.stackName]),
       Targets: [
         {
-          Id: cf.join([cf.stackName, '-event-target']),
+          Id: cf.stackName,
           Arn: cf.getAtt(prefixed('TaskEventQueue'), 'Arn')
         }
       ],


### PR DESCRIPTION
Solves a problem we had with a very long stack name.

cc/ @rclark 