### PR TITLE
Make ecs-cluster errors noop and not notify

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -76,8 +76,7 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, q
     var params = envToRunTaskParams(env, taskDefinition, containerName, startedBy);
 
     ecs.runTask(params, function(err, data) {
-      if (err && (err.code === 'CannotStartContainerError' || err.code === 'CannotPullContainerError' || err.code === 'DockerTimeoutError')) {
-        err = new Error(err.message);
+      if (err && (err.name === 'CannotStartContainerError' || err.name === 'CannotPullContainerError' || err.name === 'DockerTimeoutError')) {
         err.code = 'NotRun';
         return callback(err);
       }

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -76,6 +76,11 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, q
     var params = envToRunTaskParams(env, taskDefinition, containerName, startedBy);
 
     ecs.runTask(params, function(err, data) {
+      if (err && (err.code === 'CannotStartContainerError' || err.code === 'CannotPullContainerError' || err.code === 'DockerTimeoutError') {
+        err = new Error(err.message);
+        err.code = 'NotRun';
+        return callback(err);
+      }
       if (err) return callback(err);
 
       data.tasks.forEach(function(task) {

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -76,7 +76,7 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, q
     var params = envToRunTaskParams(env, taskDefinition, containerName, startedBy);
 
     ecs.runTask(params, function(err, data) {
-      if (err && (err.code === 'CannotStartContainerError' || err.code === 'CannotPullContainerError' || err.code === 'DockerTimeoutError') {
+      if (err && (err.code === 'CannotStartContainerError' || err.code === 'CannotPullContainerError' || err.code === 'DockerTimeoutError')) {
         err = new Error(err.message);
         err.code = 'NotRun';
         return callback(err);

--- a/test/util.js
+++ b/test/util.js
@@ -105,6 +105,12 @@ module.exports.mock = function(name, callback) {
       if (params.overrides.containerOverrides[0].environment[0].name === 'failure')
         return callback(null, { tasks: [], failures: [{ reason: 'unrecognized' }] });
 
+      if (params.overrides.containerOverrides[0].environment[0].name === 'cannotPullContainer') {
+        var err = new Error('API error (500): Get https://234858372212.dkr.ecr.us-east-1.amazonaws.com/v1/_ping: dial tcp: i/o timeout');
+        err.name = 'CannotPullContainerError';
+        return callback(err);
+      }
+
       if (params.overrides.containerOverrides[0].environment[0].name === 'resourceMemory') {
         if (context.ecs.resourceFail === 0) {
           context.ecs.resourceFail++;


### PR DESCRIPTION
These errors are noisy and cause @mapsam and @GretaCB to lose sleep. We're better off just handling them within watchbot.

cc/ @rclark @GretaCB 

Closes #121 