### PR TITLE
Drop task event messages that are > 20 min old

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### next
+
+- stale messages in the TaskEventQueue will be dropped after 20 minutes
+
 ### 2.1.1
 
 - Removes `-event-target` from the ID of the cloudwatch events filter to make it shorter. refs #119

--- a/lib/template.js
+++ b/lib/template.js
@@ -403,7 +403,7 @@ module.exports = function(options) {
     Properties: {
       VisibilityTimeout: 10,
       QueueName: cf.join([cf.stackName, '-', prefixed('TaskEventQueue')]),
-      MessageRetentionPeriod: 1209600
+      MessageRetentionPeriod: 1200
     }
   };
 


### PR DESCRIPTION
fixes #122 
cc @jakepruitt you on board with this?