### PR TITLE
Exponential backoff, even on no-op

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -128,11 +128,10 @@ module.exports = function(queue, topic, stackName, sendNotifications, logGroup) 
       if (toDo === 'return' || toDo === 'immediate') {
         queue.defer(function(next) {
           if (receives > 14) return next();
-          var timeout = toDo === 'return' ? Math.pow(2, receives) : 0;
 
           sqs.changeMessageVisibility({
             ReceiptHandle: handle,
-            VisibilityTimeout: timeout
+            VisibilityTimeout: Math.pow(2, receives)
           }, function(err) {
             if (err && messageMissing(err)) return next();
             next(err);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -118,7 +118,7 @@ util.mock('[main] task running failure (out of memory)', function(assert) {
     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
     assert.deepEqual(context.sns.publish, [], 'does not send failure notification');
     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-      { ReceiptHandle: '1', VisibilityTimeout: 0 }
+      { ReceiptHandle: '1', VisibilityTimeout: 2 }
     ], 'expected sqs.changeMessageVisibility requests');
     assert.end();
   });
@@ -137,7 +137,7 @@ util.mock('[main] task running failure (unrecognized reason)', function(assert) 
     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
     assert.deepEqual(context.sns.publish, [], 'does not send failure notification');
     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-      { ReceiptHandle: '1', VisibilityTimeout: 0 }
+      { ReceiptHandle: '1', VisibilityTimeout: 2 }
     ], 'expected sqs.changeMessageVisibility requests');
     assert.end();
   });
@@ -272,7 +272,7 @@ util.mock('[main] manage messages for completed tasks', function(assert) {
     ], ' sqs.deleteMessage for all event messages, and for expected job messages');
     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
       { ReceiptHandle: '2', VisibilityTimeout: 8 },
-      { ReceiptHandle: '4', VisibilityTimeout: 0 }
+      { ReceiptHandle: '4', VisibilityTimeout: 2 }
     ], 'expected sqs.changeMessageVisibility requests');
     util.collectionsEqual(assert, context.sns.publish, [
       {


### PR DESCRIPTION
Return work messages to SQS with exponential backoff even on no-ops.

Fixes #126 