### PR TITLE
Adjust log groups

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -589,7 +589,7 @@ module.exports = function(options) {
             Options: {
               'awslogs-group': cf.ref(prefixed('LogGroup')),
               'awslogs-region': cf.region,
-              'awslogs-stream-prefix': cf.join('-', [cf.stackName, options.serviceVersion])
+              'awslogs-stream-prefix': options.serviceVersion
             }
           }
         }
@@ -638,7 +638,7 @@ module.exports = function(options) {
             Options: {
               'awslogs-group': cf.ref(prefixed('LogGroup')),
               'awslogs-region': cf.region,
-              'awslogs-stream-prefix': cf.join('-', [cf.stackName, options.serviceVersion])
+              'awslogs-stream-prefix': options.serviceVersion
             }
           }
         }
@@ -730,7 +730,7 @@ function logAggregator(prefixed, resources, conditions, options) {
     DependsOn: prefixed('LogGroup'),
     Properties: {
       DestinationArn: options.logAggregationFunction,
-      LogGroupName: cf.join('-', [cf.stackName, cf.region]),
+      LogGroupName: cf.ref(prefixed('LogGroup')),
       FilterPattern: ''
     }
   };

--- a/lib/template.js
+++ b/lib/template.js
@@ -589,7 +589,7 @@ module.exports = function(options) {
             Options: {
               'awslogs-group': cf.ref(prefixed('LogGroup')),
               'awslogs-region': cf.region,
-              'awslogs-stream-prefix': cf.stackName
+              'awslogs-stream-prefix': cf.join('-', [cf.stackName, options.serviceVersion])
             }
           }
         }
@@ -730,7 +730,7 @@ function logAggregator(prefixed, resources, conditions, options) {
     DependsOn: prefixed('LogGroup'),
     Properties: {
       DestinationArn: options.logAggregationFunction,
-      LogGroupName: cf.join('-', [cf.stackName, cf.region, options.serviceVersion]),
+      LogGroupName: cf.join('-', [cf.stackName, cf.region]),
       FilterPattern: ''
     }
   };

--- a/lib/template.js
+++ b/lib/template.js
@@ -185,7 +185,7 @@ module.exports = function(options) {
   resources[prefixed('LogGroup')] = {
     Type: 'AWS::Logs::LogGroup',
     Properties: {
-      LogGroupName: cf.join('-', [cf.stackName, cf.region, options.serviceVersion]),
+      LogGroupName: cf.join('-', [cf.stackName, cf.region]),
       RetentionInDays: 14
     }
   };
@@ -638,7 +638,7 @@ module.exports = function(options) {
             Options: {
               'awslogs-group': cf.ref(prefixed('LogGroup')),
               'awslogs-region': cf.region,
-              'awslogs-stream-prefix': cf.stackName
+              'awslogs-stream-prefix': cf.join('-', [cf.stackName, options.serviceVersion])
             }
           }
         }


### PR DESCRIPTION
Adjusts the log group names to not include the version, which led to the log groups being deleted and recreated on deploys, thus removing manually created logs. To preserve the ability to see which gitsha logs are from, adding gitsha to the `awslogs-stream-prefix` instead.

Refs: #128 

cc @rclark @GretaCB @yhahn 