### PR TITLE
Fix broken links to alarm documentation

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -203,7 +203,7 @@ module.exports = function(options) {
     Type: 'AWS::CloudWatch::Alarm',
     Description: 'Provides notification when messages are visible in the dead letter queue',
     Properties: {
-      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/alarms.md#DeadLetter`,
+      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/docs/alarms.md#DeadLetter`,
       MetricName: 'ApproximateNumberOfMessagesVisible',
       Namespace: 'AWS/SQS',
       Statistic: 'Minimum',
@@ -290,7 +290,7 @@ module.exports = function(options) {
   resources[prefixed('FailedWorkerPlacementAlarm')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/alarms.md#failedworkerplacement`,
+      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/docs/alarms.md#failedworkerplacement`,
       MetricName: cf.join([prefixed('FailedWorkerPlacement-'), cf.stackName]),
       Namespace: 'Mapbox/ecs-watchbot',
       Statistic: 'Sum',
@@ -318,7 +318,7 @@ module.exports = function(options) {
   resources[prefixed('WorkerErrorsAlarm')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/alarms.md#workererrors`,
+      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/docs/alarms.md#workererrors`,
       MetricName: cf.join([prefixed('WorkerErrors-'), cf.stackName]),
       Namespace: 'Mapbox/ecs-watchbot',
       Statistic: 'Sum',
@@ -379,7 +379,7 @@ module.exports = function(options) {
     Type: 'AWS::CloudWatch::Alarm',
     Description: 'An alarm that is tripped when too many messages are in Watchbot\'s queue',
     Properties: {
-      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/alarms.md#queuesize`,
+      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/docs/alarms.md#queuesize`,
       MetricName: 'ApproximateNumberOfMessagesVisible',
       Namespace: 'AWS/SQS',
       Statistic: 'Average',


### PR DESCRIPTION
This just points those broken links at the right places.