### PR TITLE
Collect metrics on pending task times

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -96,7 +96,8 @@ module.exports = function(config) {
           JSON.stringify({
             outcome: tasks.report(finishedTask.outcome),
             reason: finishedTask.reason,
-            duration: Math.ceil(finishedTask.duration / 1000)
+            duration: Math.ceil(finishedTask.duration / 1000),
+            pending: Math.ceil(finishedTask.pending / 1000)
           })
         );
         queue.defer(messages.complete, finishedTask);

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -162,6 +162,7 @@ function getMessages(sqs, callback) {
     var finishedTasks = data.Messages.map(function(message) {
       var task = JSON.parse(message.Body).detail;
       var duration = +new Date(task.stoppedAt) - +new Date(task.startedAt);
+      var pending = +new Date(task.startedAt) - +new Date(task.createdAt);
       if (isNaN(duration)) duration = 0;
 
       /**
@@ -204,6 +205,8 @@ function getMessages(sqs, callback) {
         reason: taskReason,
 
         duration: duration,
+
+        pending: pending,
 
         outcome: taskOutcome,
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -345,6 +345,21 @@ module.exports = function(options) {
     }
   };
 
+  resources[prefixed('WorkerPendingMetric')] = {
+    Type: 'AWS::Logs::MetricFilter',
+    Properties: {
+      LogGroupName: cf.ref(prefixed('LogGroup')),
+      FilterPattern: '{ $.pending = * }',
+      MetricTransformations: [
+        {
+          MetricName: cf.join([prefixed('WorkerPending-'), cf.stackName]),
+          MetricNamespace: 'Mapbox/ecs-watchbot',
+          MetricValue: '$.pending'
+        }
+      ]
+    }
+  };
+
   resources[prefixed('MessageReceivesMetric')] = {
     Type: 'AWS::Logs::MetricFilter',
     Properties: {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -246,6 +246,7 @@ util.mock('[main] manage messages for completed tasks', function(assert) {
             ]
           },
           containers: [{ exitCode: Number(message.MessageId.split('-')[1]) }],
+          createdAt: 1484155844718,
           startedAt: 1484155849718,
           stoppedAt: 1484155857691
         }
@@ -326,6 +327,7 @@ util.mock('[main] message completion error', function(assert) {
             ]
           },
           containers: [{ exitCode: Number(message.MessageId.split('-')[1]) }],
+          createdAt: 1484155844718,
           startedAt: 1484155849718,
           stoppedAt: 1484155857691
         }

--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -258,6 +258,7 @@ util.mock('[tasks] poll - one of each outcome', function(assert) {
               'CannotPullContainerError: API error (500): Get https://123456789012.dkr.ecr.us-east-1.amazonaws.com/v1/_ping: dial tcp: i/o timeout' : undefined
           }
         ],
+        createdAt: 1484155844718,
         startedAt: 1484155849718,
         stoppedAt: 1484155857691
       }
@@ -283,6 +284,7 @@ util.mock('[tasks] poll - one of each outcome', function(assert) {
         stoppedReason: 'cuz a feel like it',
         overrides: { containerOverrides: [{ environment: [] }] },
         containers: [{ exitCode: 0 }],
+        createdAt: 1484155844718,
         startedAt: 1484155849718,
         stoppedAt: 1484155857691
       }
@@ -316,12 +318,12 @@ util.mock('[tasks] poll - one of each outcome', function(assert) {
       }, 'ecs client initialized properly');
 
       var expectedTaskStatus = [
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'bb8e8e7405617c973ceac2a9076ae19d' }, env: { ApproximateReceiveCount: 1, exit: '0', MessageId: 'exit-0' }, outcome: 'delete', reason: 'success', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '762676041b682bcea049706185d13ac6' }, env: { ApproximateReceiveCount: 1, exit: '1', MessageId: 'exit-1' }, outcome: 'return & notify', reason: 'some container reason', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'fc36323938489380babaf87c56568d7f' }, env: { ApproximateReceiveCount: 1, exit: '2', MessageId: 'exit-2' }, outcome: 'return & notify', reason: '2', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '107e1fc31e0ad9b0e0d2304411596e05' }, env: { ApproximateReceiveCount: 1, exit: '3', MessageId: 'exit-3' }, outcome: 'delete & notify', reason: '3', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'e7336cab2c12be8aacef9718acb7cdb5' }, env: { ApproximateReceiveCount: 1, exit: '4', MessageId: 'exit-4' }, outcome: 'immediate', reason: '4', duration: 7973 },
-        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '6d8e580ee61b2fcb24bb9317d212a404' }, env: { ApproximateReceiveCount: 1, exit: '137', MessageId: 'exit-137' }, outcome: 'immediate', reason: 'CannotPullContainerError: API error (500): Get https://123456789012.dkr.ecr.us-east-1.amazonaws.com/v1/_ping: dial tcp: i/o timeout', duration: 7973 }
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'bb8e8e7405617c973ceac2a9076ae19d' }, env: { ApproximateReceiveCount: 1, exit: '0', MessageId: 'exit-0' }, outcome: 'delete', reason: 'success', duration: 7973, pending: 5000 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '762676041b682bcea049706185d13ac6' }, env: { ApproximateReceiveCount: 1, exit: '1', MessageId: 'exit-1' }, outcome: 'return & notify', reason: 'some container reason', duration: 7973, pending: 5000 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'fc36323938489380babaf87c56568d7f' }, env: { ApproximateReceiveCount: 1, exit: '2', MessageId: 'exit-2' }, outcome: 'return & notify', reason: '2', duration: 7973, pending: 5000 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '107e1fc31e0ad9b0e0d2304411596e05' }, env: { ApproximateReceiveCount: 1, exit: '3', MessageId: 'exit-3' }, outcome: 'delete & notify', reason: '3', duration: 7973, pending: 5000 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: 'e7336cab2c12be8aacef9718acb7cdb5' }, env: { ApproximateReceiveCount: 1, exit: '4', MessageId: 'exit-4' }, outcome: 'immediate', reason: '4', duration: 7973, pending: 5000 },
+        { arns: { cluster: 'cluster-arn', instance: 'instance-arn', task: '6d8e580ee61b2fcb24bb9317d212a404' }, env: { ApproximateReceiveCount: 1, exit: '137', MessageId: 'exit-137' }, outcome: 'immediate', reason: 'CannotPullContainerError: API error (500): Get https://123456789012.dkr.ecr.us-east-1.amazonaws.com/v1/_ping: dial tcp: i/o timeout', duration: 7973, pending: 5000 }
       ];
       expectedTaskStatus.free = 9;
 

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -42,6 +42,7 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotTaskEventQueuePolicy, 'task event queue policy');
   assert.ok(watch.Resources.WatchbotFailedWorkerPlacementMetric, 'failed worker metric');
   assert.ok(watch.Resources.WatchbotWorkerDurationMetric, 'worker duration metric');
+  assert.ok(watch.Resources.WatchbotWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.WatchbotMessageReceivesMetric, 'message receives metric');
   assert.ok(watch.Resources.WatchbotWatcherConcurrencyMetric, 'watcher concurrency metric');
   assert.ok(watch.Resources.WatchbotWorkerErrorsMetric, 'worker errors metric');
@@ -135,6 +136,7 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
   assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
   assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
+  assert.ok(watch.Resources.testWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
   assert.ok(watch.Resources.testWatcherConcurrencyMetric, 'watcher concurrency metric');
   assert.ok(watch.Resources.testWorkerErrorsMetric, 'worker errors metric');
@@ -233,6 +235,7 @@ test('[template] include all resources, no references', function(assert) {
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
   assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
   assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
+  assert.ok(watch.Resources.testWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
   assert.ok(watch.Resources.testWatcherConcurrencyMetric, 'watcher concurrency metric');
   assert.ok(watch.Resources.testWorkerErrorsMetric, 'worker errors metric');
@@ -339,6 +342,7 @@ test('[template] include all resources, all references', function(assert) {
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
   assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
   assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
+  assert.ok(watch.Resources.testWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
   assert.ok(watch.Resources.testWatcherConcurrencyMetric, 'watcher concurrency metric');
   assert.ok(watch.Resources.testWorkerErrorsMetric, 'worker errors metric');


### PR DESCRIPTION
This adds another watchbot metric to record the time between a task's `createdAt` and `startedAt` times.

cc @jakepruitt 