### PR TITLE
quote progress args

### DIFF
--- a/bin/watchbot-progress.sh
+++ b/bin/watchbot-progress.sh
@@ -5,4 +5,4 @@ set -e
 progress=$(node -e "console.log(require.resolve('@mapbox/watchbot-progress'));")
 base=$(dirname ${progress})
 
-${base}/bin/watchbot-progress.js $@
+${base}/bin/watchbot-progress.js "$@"


### PR DESCRIPTION
Arguments using the `watchbot-progress.sh` command that included spaces in a JSON value were misinterpreted as multiple arguments. Here's an example:

```shell
metadata='{"hello":"i have a space"}'
output=$(watchbot-progress set-metadata --parts $parts --metadata "$metadata")
```

This results in an incomplete JSON being sent to the actual watchbot-progress script, and the following error:

```
{"hello":"i
                                                          

SyntaxError: Unexpected end of input
```

Wrapping the `$@` in quotes, `"$@"` resolves the issue by preserving strings with spaces.

cc @rclark @springmeyer 