### PR TITLE
Broadcast FailedWorkerPlacement metric under the name of the cluster

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 2.4.0
+
+- Broadcast FailedWorkerPlacement metric under the name of the cluster, in addition to stack name.
+
 ### 2.3.1
 
 - Add quotes around `$@` operator in the watchbot-progress.sh script to preserve spaces in metadata arguments [#142](https://github.com/mapbox/ecs-watchbot/pull/142)

--- a/cloudformation/ci.template.js
+++ b/cloudformation/ci.template.js
@@ -1,4 +1,4 @@
-var cloudfriend = require('cloudfriend');
+var cloudfriend = require('@mapbox/cloudfriend');
 
 module.exports = {
   AWSTemplateFormatVersion: '2010-09-09',

--- a/docs/worker-retry-cycle.md
+++ b/docs/worker-retry-cycle.md
@@ -19,7 +19,7 @@ This means that after a failure on the 9th attempt, the message will be invisibl
 
 Each time a message fails during processing, it is recorded in [the WorkerErrors or FailedWorkerPlacement metrics](./logging-and-metrics.md#custom-metrics). The [WorkerErrors alarm](./alarms.md#workererrors) will trigger whenever there are more than a configured number of failed attempts per minute. The [FailedWorkerPlacement alarm](./alarms.md#failedworkerplacement) will trigger if there are more than 5 failed placements per minute.
 
-If the 10th attempt to process a message fails, then the message will have been retrying for a minimum of 17 minutes, and at this point it will fall into a dead letter queue.
+If the 10th attempt to process a message fails, then the message will have been retrying for a minimum of 17 minutes, and at this point it will fall into a dead letter queue. The FailedWorkerPlacement metric is also collected under the name of the cluster, so you can set scaling policies on your cluster to react to it.
 
 **Important: number of attempts != number of times a worker has tried to process a message**. If a cluster is full, Watchbot will attempt to place workers, fail, replace the messages in the queue, and try again. This counts as an attempt. If cluster capacity is a problem, the cluster basically has 17 minutes to accommodate the increased demand before message will start falling into the dead letter queue. During this time, Watchbot will also trip the [FailedWorkerPlacement alarm](./alarms.md#failedworkerplacement), in case manual intervention is required.
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var cf = require('cloudfriend');
+var cf = require('@mapbox/cloudfriend');
 
 /**
  * Watchbot's JavaScript API

--- a/lib/template.js
+++ b/lib/template.js
@@ -287,6 +287,19 @@ module.exports = function(options) {
     }
   };
 
+  resources[prefixed('FailedWorkerPlacementClusterMetric')] = {
+    Type: 'AWS::Logs::MetricFilter',
+    Properties: {
+      FilterPattern: '{ $.failedPlacement = true }',
+      LogGroupName: cf.ref(prefixed('LogGroup')),
+      MetricTransformations: [{
+        MetricName: cf.join([prefixed('FailedWorkerPlacement-'), cf.select(1, cf.split('/', options.cluster))]),
+        MetricNamespace: 'Mapbox/ecs-watchbot',
+        MetricValue: 1
+      }]
+    }
+  };
+
   resources[prefixed('FailedWorkerPlacementAlarm')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,4 +1,4 @@
-var cf = require('cloudfriend');
+var cf = require('@mapbox/cloudfriend');
 var path = require('path');
 var pkg = require(path.resolve(__dirname, '..', 'package.json'));
 var table = require('@mapbox/watchbot-progress').table;

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "watchbot": "./bin/cli.js"
   },
   "dependencies": {
+    "@mapbox/cloudfriend": "^1.8.1",
     "@mapbox/watchbot-progress": "^1.1.1",
     "aws-sdk": "^2.4.11",
     "binary-split": "^1.0.2",
-    "cloudfriend": "^1.6.0",
     "cwlogs": "^1.0.2",
     "d3-queue": "^2.0.3",
     "dyno": "^1.2.0",

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 var watchbot = require('..');
-var cf = require('cloudfriend');
+var cf = require('@mapbox/cloudfriend');
 var fs = require('fs');
 var path = require('path');
 var os = require('os');


### PR DESCRIPTION
Sends the FailedWorkerPlacement metric to CloudWatch under the name of the selected cluster in addition to the name of the stack. This allows you to tune cluster scaling policies to react to a failure of the watcher to place worker containers on the cluster.

cc @rclark - have we thought about this? Is this a good idea?