### PR TITLE
upgrade webhook function runtime to node4.3

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -918,7 +918,7 @@ function webhook(prefixed, useKey, resources, references) {
       Role: cf.getAtt(prefixed('WebhookFunctionRole'), 'Arn'),
       Description: cf.join([prefixed('-watchbot webhooks for '), cf.stackName]),
       Handler: 'index.webhooks',
-      Runtime: 'nodejs',
+      Runtime: 'nodejs4.3',
       Timeout: 30,
       MemorySize: 128
     }


### PR DESCRIPTION
The nodejs runtime is deprecated. This upgrades the webhook function runtime to 4.3.

cc @rclark 