### PR TITLE
Set family on worker and watcher to service name

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -589,6 +589,7 @@ module.exports = function(options) {
     Description: 'The task definition responsible for processing messages',
     Properties: {
       TaskRoleArn: cf.ref(prefixed('WorkerRole')),
+      Family: options.service,
       ContainerDefinitions: [
         {
           Name: prefixed('-worker-' + options.service),
@@ -637,6 +638,7 @@ module.exports = function(options) {
     Description: 'The task definition responsible for watching the queue and running tasks',
     Properties: {
       TaskRoleArn: cf.ref(prefixed('WatcherRole')),
+      Family: options.service,
       ContainerDefinitions: [
         {
           Name: prefixed('-watcher-' + options.service),

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -49,8 +49,10 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotWorkerErrorsAlarm, 'worker errors alarm');
   assert.equal(watch.Resources.WatchbotWorkerErrorsAlarm.Properties.Threshold, 10, 'worker errors alarm threshold');
   assert.ok(watch.Resources.WatchbotWatcher.Properties.ContainerDefinitions[0].Environment.slice(-3, -2), 'notify after retry');
+  assert.equal(watch.Resources.WatchbotWatcher.Properties.Family, 'my-service', 'watcher family = service name');
   assert.notOk(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Privileged, 'privileged is false');
   assert.equal(watch.Resources.WatchbotWorker.Properties.ContainerDefinitions[0].Memory, 64, 'sets default hard memory limit');
+  assert.equal(watch.Resources.WatchbotWorker.Properties.Family, 'my-service', 'worker family = service name');
   assert.ok(watch.Resources.WatchbotWorkerRole, 'worker role');
   assert.equal(watch.Resources.WatchbotWorkerRole.Properties.Policies.length, 1, 'default worker permissions');
   assert.ok(watch.Resources.WatchbotWatcherRole, 'watcher role');


### PR DESCRIPTION
This sets a `Family` property on the watcher and worker task definitions that will group the definitions under the service's name. Successive updates to an ecs-watchbot stack will result in new revisions in this family of task definitions.