### PR TITLE
ecs:runTask needs permissions that match the name of the TaskDefinition

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -549,10 +549,16 @@ module.exports = function(options) {
               {
                 Effect: 'Allow',
                 Action: ['ecs:RunTask'],
-                Resource: cf.join([
-                  'arn:aws:ecs:', cf.region, ':', cf.accountId,
-                  ':task-definition/', options.service, '*'
-                ]),
+                Resource: [
+                  cf.join([
+                    'arn:aws:ecs:', cf.region, ':', cf.accountId,
+                    ':task-definition/', options.service, '*'
+                  ]),
+                  cf.join([
+                    'arn:aws:ecs:', cf.region, ':', cf.accountId,
+                    ':task-definition/', cf.stackName, '*'
+                  ])
+                ],
                 Condition: { StringEquals: { 'ecs:cluster': options.cluster } }
               },
               {

--- a/lib/template.js
+++ b/lib/template.js
@@ -551,7 +551,7 @@ module.exports = function(options) {
                 Action: ['ecs:RunTask'],
                 Resource: cf.join([
                   'arn:aws:ecs:', cf.region, ':', cf.accountId,
-                  ':task-definition/', cf.stackName, '*'
+                  ':task-definition/', options.service, '*'
                 ]),
                 Condition: { StringEquals: { 'ecs:cluster': options.cluster } }
               },


### PR DESCRIPTION
Removes mismatch between https://github.com/mapbox/ecs-watchbot/blob/master/lib/template.js#L553-L554 and https://github.com/mapbox/ecs-watchbot/blob/master/lib/template.js#L595
cc/ @rclark 