### PR TITLE
Make sure log group names are unique

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -185,7 +185,7 @@ module.exports = function(options) {
   resources[prefixed('LogGroup')] = {
     Type: 'AWS::Logs::LogGroup',
     Properties: {
-      LogGroupName: cf.join('-', [cf.stackName, cf.region]),
+      LogGroupName: cf.join('-', [cf.stackName, cf.region, options.prefix.toLowerCase()]),
       RetentionInDays: 14
     }
   };


### PR DESCRIPTION
Adding the "prefix" to the log group name insures that a stack that includes multiple sets of watchbot resources will be able to be deployed.

cc @mapsam 