### PR TITLE
Fixes DeadLetter alarm description URL anchor

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -206,7 +206,7 @@ module.exports = function(options) {
     Type: 'AWS::CloudWatch::Alarm',
     Description: 'Provides notification when messages are visible in the dead letter queue',
     Properties: {
-      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/docs/alarms.md#DeadLetter`,
+      AlarmDescription: `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/docs/alarms.md#deadletter`,
       MetricName: 'ApproximateNumberOfMessagesVisible',
       Namespace: 'AWS/SQS',
       Statistic: 'Minimum',


### PR DESCRIPTION
`#DeadLetter` → `#deadletter`