### PR TITLE
Add clear definition for message timeout parameter

### DIFF
--- a/docs/building-a-template.md
+++ b/docs/building-a-template.md
@@ -78,7 +78,7 @@ family | service name | the name of the the task definition family that watchbot
 errorThreshold | 10 | number of failed workers to trigger alarm
 logAggregationFunction | | the ARN of the log collection Lambda function
 messageRetention | 1209600 | max seconds a message can remain in SQS
-messageTimeout | 600 | max seconds it takes to process a job
+messageTimeout | 600 | max seconds it takes to process a job. Note that the worker is not going to exit after this timeout but the message will be available again to be processed by worker as the messageTimeout actually refers to [visibility timeout](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
 mounts | | defines persistent container mount points from host EC2s or ephemeral mount points on the container
 permissions | [] | permissions to any AWS resources that the worker will need to perform a task. Be sure to unwrap any `PolicyDocument` objects. The use of `PolicyDocument` here will pass `aws cloudformation validate-template`, but will prevent your stack from being created successfully.
 placementConstraints | false | Add any [ECS task placement constraints](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html)


### PR DESCRIPTION
This PR intends to add clearer definition for `messageTimeout` parameter in building template doc as the messageTimeout is not actually the time after which workers times out and exits, but rather it is the time when this message is set to be invisible for any other consumers. But after this timeout, message becomes available again and is processed by worker.

https://github.com/mapbox/ecs-watchbot/blob/24eee9f6c6e44b97132e1c28b2f3aa8329b2dc1e/lib/template.js#L231

This came to me because I was always in the belief that worker exits after hitting messageTimeout limit, which is not true.

Also, feel free to edit it as it might still sound fuzzy.

cc @arunasank @emilymcafee 