### PR TITLE
Add notification topic as a .ref property

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 3.3.0
+
+- Adds `.ref.notificationTopic` to the output from `watchbot.template()`
+
 ### 3.2.1
 
 - Adjusts watcher permissions on RunTask so that it can only launch its own Worker tasks.

--- a/docs/building-a-template.md
+++ b/docs/building-a-template.md
@@ -109,6 +109,7 @@ Name | Description
 .ref.queueUrl | the URL of the SQS Queue Watchbot built
 .ref.queueArn | the ARN of the SQS Queue Watchbot built
 .ref.queueName | the name of the SQS Queue Watchbot built
+.ref.notificationTopic | the SNS topic that receives notifications when processing fails
 .ref.webhookEnpoint | [conditional] if requested, the URL for the webhook endpoint
 .ref.webhookKey | [conditional] if requested, the access token for making webhook requests
 .ref.accessKeyId | [conditional] if requested, an AccessKeyId with permission to publish to Watchbot's SNS topic

--- a/lib/template.js
+++ b/lib/template.js
@@ -160,7 +160,8 @@ module.exports = function(options) {
     topic: cf.ref(prefixed('Topic')),
     queueUrl: cf.ref(prefixed('Queue')),
     queueArn: cf.getAtt(prefixed('Queue'), 'Arn'),
-    queueName: cf.getAtt(prefixed('Queue'), 'QueueName')
+    queueName: cf.getAtt(prefixed('Queue'), 'QueueName'),
+    notificationTopic: cf.ref(prefixed('NotificationTopic'))
   };
 
   if (options.user) user(prefixed, resources, references);

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -77,6 +77,7 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.deepEqual(watch.ref.queueUrl, cf.ref('WatchbotQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('WatchbotQueue', 'Arn'), 'queueArn ref');
   assert.deepEqual(watch.ref.queueName, cf.getAtt('WatchbotQueue', 'QueueName'), 'queueName ref');
+  assert.deepEqual(watch.ref.notificationTopic, cf.ref('WatchbotNotificationTopic'), 'notificationTopic ref');
   assert.notOk(watch.ref.accessKeyId, 'accessKeyId ref');
   assert.notOk(watch.ref.secretAccessKey, 'secretAccessKey ref');
   assert.notOk(watch.ref.webhookKey, 'webhookKey ref');
@@ -165,6 +166,7 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.deepEqual(watch.ref.queueUrl, cf.ref('testQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('testQueue', 'Arn'), 'queueArn ref');
   assert.deepEqual(watch.ref.queueName, cf.getAtt('testQueue', 'QueueName'), 'queueName ref');
+  assert.deepEqual(watch.ref.notificationTopic, cf.ref('testNotificationTopic'), 'notificationTopic ref');
   assert.deepEqual(watch.ref.accessKeyId, cf.ref('testUserKey'), 'accessKeyId ref');
   assert.deepEqual(watch.ref.secretAccessKey, cf.getAtt('testUserKey', 'SecretAccessKey'), 'secretAccessKey ref');
   assert.notOk(watch.ref.webhookKey, 'webhookKey ref');
@@ -274,6 +276,7 @@ test('[template] include all resources, no references', function(assert) {
   assert.deepEqual(watch.ref.queueUrl, cf.ref('testQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('testQueue', 'Arn'), 'queueArn ref');
   assert.deepEqual(watch.ref.queueName, cf.getAtt('testQueue', 'QueueName'), 'queueName ref');
+  assert.deepEqual(watch.ref.notificationTopic, cf.ref('testNotificationTopic'), 'notificationTopic ref');
   assert.deepEqual(watch.ref.accessKeyId, cf.ref('testUserKey'), 'accessKeyId ref');
   assert.deepEqual(watch.ref.secretAccessKey, cf.getAtt('testUserKey', 'SecretAccessKey'), 'secretAccessKey ref');
   assert.deepEqual(watch.ref.webhookKey, cf.ref('testWebhookKey'), 'webhookKey ref');
@@ -375,6 +378,7 @@ test('[template] include all resources, all references', function(assert) {
   assert.deepEqual(watch.ref.queueUrl, cf.ref('testQueue'), 'queueUrl ref');
   assert.deepEqual(watch.ref.queueArn, cf.getAtt('testQueue', 'Arn'), 'queueArn ref');
   assert.deepEqual(watch.ref.queueName, cf.getAtt('testQueue', 'QueueName'), 'queueName ref');
+  assert.deepEqual(watch.ref.notificationTopic, cf.ref('testNotificationTopic'), 'notificationTopic ref');
   assert.deepEqual(watch.ref.accessKeyId, cf.ref('testUserKey'), 'accessKeyId ref');
   assert.deepEqual(watch.ref.secretAccessKey, cf.getAtt('testUserKey', 'SecretAccessKey'), 'secretAccessKey ref');
   assert.deepEqual(watch.ref.webhookKey, cf.ref('testWebhookKey'), 'webhookKey ref');


### PR DESCRIPTION
This adds the notification topic as a `.ref` property returned by `watchbot.template()`. This is particularly useful when you want to add custom alarms to your stack but only manage one topic for such notifications.

cc @rclark 