### PR TITLE
Make failed worker placement alarm periods customizable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 3.3.1
+
+- Makes `EvaluationPeriods` for `FailedWorkerPlacementAlarm` customizable
+
 ### 3.3.0
 
 - Adds `.ref.notificationTopic` to the output from `watchbot.template()`

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-### 3.3.1
+### 3.4.0
 
 - Makes `EvaluationPeriods` for `FailedWorkerPlacementAlarm` customizable
 

--- a/docs/building-a-template.md
+++ b/docs/building-a-template.md
@@ -76,6 +76,7 @@ debugLogs | false | enable verbose watcher logging
 env | {} | environment variables to set on worker containers
 family | service name | the name of the the task definition family that watchbot will create revisions of
 errorThreshold | 10 | number of failed workers to trigger alarm
+failedPlacementAlarmPeriods | 1 | number of 1-min intervals for which failed placements exceeds the threshold of 5 in order to alarm
 logAggregationFunction | | the ARN of the log collection Lambda function
 messageRetention | 1209600 | max seconds a message can remain in SQS
 messageTimeout | 600 | max seconds it takes to process a job

--- a/lib/template.js
+++ b/lib/template.js
@@ -120,6 +120,12 @@ var table = require('@mapbox/watchbot-progress').table;
  * triggering an alarm. You specify the number of 5-minute periods before an
  * alarm is triggered. The default is 24 periods, or 2 hours. This parameter
  * can be provided as either a number or a reference, i.e. `{"Ref": "..."}`.
+ * @param {number|ref} [options.failedWorkerPlacementAlarmPeriods=1] - Use this
+ * parameter to control the duration that the SQS queue must be over the failed
+ * worker placement threshold before triggering an alarm. You specify the number
+ * of 1-minute periods before an alarm is triggered. The default is 1 period, or
+ * 1 minute. This parameter can be provided as either a number or a reference,
+ * i.e. `{"Ref": "..."}`.
  * @param {boolean} [options.debugLogs=false] - enable verbose watcher logging
  * @param {boolean} [options.privileged=false] - give the container elevated
  * privileges on the host container instance
@@ -143,6 +149,7 @@ module.exports = function(options) {
   options.errorThreshold = options.errorThreshold || 10;
   options.alarmThreshold = options.alarmThreshold || 40;
   options.alarmPeriods = options.alarmPeriods || 24;
+  options.failedWorkerPlacementAlarmPeriods = options.failedWorkerPlacementAlarmPeriods || 1;
   options.messageTimeout = options.messageTimeout || 600;
   options.messageRetention = options.messageRetention || 1209600;
   options.watchers = options.watchers || 1;
@@ -299,7 +306,7 @@ module.exports = function(options) {
       Namespace: 'Mapbox/ecs-watchbot',
       Statistic: 'Sum',
       Period: '60',
-      EvaluationPeriods: 1,
+      EvaluationPeriods: options.failedWorkerPlacementAlarmPeriods,
       Threshold: 5,
       AlarmActions: [notify],
       ComparisonOperator: 'GreaterThanThreshold'

--- a/lib/template.js
+++ b/lib/template.js
@@ -120,9 +120,9 @@ var table = require('@mapbox/watchbot-progress').table;
  * triggering an alarm. You specify the number of 5-minute periods before an
  * alarm is triggered. The default is 24 periods, or 2 hours. This parameter
  * can be provided as either a number or a reference, i.e. `{"Ref": "..."}`.
- * @param {number|ref} [options.failedWorkerPlacementAlarmPeriods=1] - Use this
- * parameter to control the duration that the SQS queue must be over the failed
- * worker placement threshold before triggering an alarm. You specify the number
+ * @param {number|ref} [options.failedPlacementAlarmPeriods=1] - Use this
+ * parameter to control the duration for which the failed placements exceed
+ * the threshold of 5 before triggering an alarm. You specify the number
  * of 1-minute periods before an alarm is triggered. The default is 1 period, or
  * 1 minute. This parameter can be provided as either a number or a reference,
  * i.e. `{"Ref": "..."}`.
@@ -149,7 +149,7 @@ module.exports = function(options) {
   options.errorThreshold = options.errorThreshold || 10;
   options.alarmThreshold = options.alarmThreshold || 40;
   options.alarmPeriods = options.alarmPeriods || 24;
-  options.failedWorkerPlacementAlarmPeriods = options.failedWorkerPlacementAlarmPeriods || 1;
+  options.failedPlacementAlarmPeriods = options.failedPlacementAlarmPeriods || 1;
   options.messageTimeout = options.messageTimeout || 600;
   options.messageRetention = options.messageRetention || 1209600;
   options.watchers = options.watchers || 1;
@@ -306,7 +306,7 @@ module.exports = function(options) {
       Namespace: 'Mapbox/ecs-watchbot',
       Statistic: 'Sum',
       Period: '60',
-      EvaluationPeriods: options.failedWorkerPlacementAlarmPeriods,
+      EvaluationPeriods: options.failedPlacementAlarmPeriods,
       Threshold: 5,
       AlarmActions: [notify],
       ComparisonOperator: 'GreaterThanThreshold'

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -40,8 +40,9 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotTaskEventQueue, 'task event queue');
   assert.ok(watch.Resources.WatchbotTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.WatchbotTaskEventQueuePolicy, 'task event queue policy');
-  assert.ok(watch.Resources.WatchbotFailedWorkerPlacementMetric, 'failed worker metric');
-  assert.ok(watch.Resources.WatchbotFailedWorkerPlacementAlarm, 'failed worker alarm');
+  assert.ok(watch.Resources.WatchbotFailedWorkerPlacementMetric, 'failed placement metric');
+  assert.ok(watch.Resources.WatchbotFailedWorkerPlacementAlarm, 'failed placement alarm');
+  assert.equal(watch.Resources.WatchbotFailedWorkerPlacementAlarm.Properties.EvaluationPeriods, 1, 'failed placement alarm period');
   assert.ok(watch.Resources.WatchbotWorkerDurationMetric, 'worker duration metric');
   assert.ok(watch.Resources.WatchbotWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.WatchbotMessageReceivesMetric, 'message receives metric');
@@ -113,7 +114,7 @@ test('[template] webhooks but no key, no references', function(assert) {
     messageRetention: 3000,
     alarmThreshold: 10,
     alarmPeriods: 6,
-    failedWorkerPlacementAlarmPeriods: 5,
+    failedPlacementAlarmPeriods: 5,
     privileged: true
   });
 
@@ -139,8 +140,8 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.ok(watch.Resources.testTaskEventQueue, 'task event queue');
   assert.ok(watch.Resources.testTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
-  assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
-  assert.ok(watch.Resources.testFailedWorkerPlacementAlarm, 'failed worker alarm');
+  assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed placement metric');
+  assert.ok(watch.Resources.testFailedWorkerPlacementAlarm, 'failed placement alarm');
   assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
   assert.ok(watch.Resources.testWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
@@ -214,7 +215,7 @@ test('[template] include all resources, no references', function(assert) {
     errorThreshold: 11,
     alarmThreshold: 10,
     alarmPeriods: 6,
-    failedWorkerPlacementAlarmPeriods: 5,
+    failedPlacementAlarmPeriods: 5,
     debugLogs: true,
     alarmOnEachFailure: true,
     family: 'hibbity'
@@ -242,8 +243,8 @@ test('[template] include all resources, no references', function(assert) {
   assert.ok(watch.Resources.testTaskEventQueue, 'task event queue');
   assert.ok(watch.Resources.testTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
-  assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
-  assert.ok(watch.Resources.testFailedWorkerPlacementAlarm, 'failed worker alarm');
+  assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed placement metric');
+  assert.ok(watch.Resources.testFailedWorkerPlacementAlarm, 'failed placement alarm');
   assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
   assert.ok(watch.Resources.testWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
@@ -326,7 +327,7 @@ test('[template] include all resources, all references', function(assert) {
     alarmThreshold: cf.ref('AlarmThreshold'),
     errorThreshold: cf.ref('Errors'),
     alarmPeriods: cf.ref('AlarmPeriods'),
-    failedWorkerPlacementAlarmPeriods: cf.ref('FailedWorkerPlacementAlarmPeriods'),
+    failedPlacementAlarmPeriods: cf.ref('failedPlacementAlarmPeriods'),
     alarmOnEachFailure: cf.ref('AlarmOnFailures')
   });
 
@@ -354,8 +355,8 @@ test('[template] include all resources, all references', function(assert) {
   assert.ok(watch.Resources.testTaskEventQueue, 'task event queue');
   assert.ok(watch.Resources.testTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
-  assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
-  assert.ok(watch.Resources.testFailedWorkerPlacementAlarm, 'failed worker alarm');
+  assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed placement metric');
+  assert.ok(watch.Resources.testFailedWorkerPlacementAlarm, 'failed placement alarm');
   assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
   assert.ok(watch.Resources.testWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
@@ -424,7 +425,7 @@ test('[template] resources are valid', function(assert) {
     messageRetention: 3000,
     alarmThreshold: 10,
     alarmPeriods: 6,
-    failedWorkerPlacementAlarmPeriods: 5
+    failedPlacementAlarmPeriods: 5
   });
 
   var tmp = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex') + '.json');
@@ -468,7 +469,7 @@ test('[template] notificationTopic vs notificationEmail', function(assert) {
       messageRetention: 3000,
       alarmThreshold: 10,
       alarmPeriods: 6,
-      failedWorkerPlacementAlarmPeriods: 5
+      failedPlacementAlarmPeriods: 5
     });
   }, /Cannot provide both notificationTopic and notificationEmail./);
 
@@ -498,7 +499,7 @@ test('[template] notificationTopic vs notificationEmail', function(assert) {
     messageRetention: 3000,
     alarmThreshold: 10,
     alarmPeriods: 6,
-    failedWorkerPlacementAlarmPeriods: 5
+    failedPlacementAlarmPeriods: 5
   });
 
   var tmp = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex') + '.json');

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -41,6 +41,7 @@ test('[template] bare-bones, all defaults, no references', function(assert) {
   assert.ok(watch.Resources.WatchbotTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.WatchbotTaskEventQueuePolicy, 'task event queue policy');
   assert.ok(watch.Resources.WatchbotFailedWorkerPlacementMetric, 'failed worker metric');
+  assert.ok(watch.Resources.WatchbotFailedWorkerPlacementAlarm, 'failed worker alarm');
   assert.ok(watch.Resources.WatchbotWorkerDurationMetric, 'worker duration metric');
   assert.ok(watch.Resources.WatchbotWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.WatchbotMessageReceivesMetric, 'message receives metric');
@@ -112,6 +113,7 @@ test('[template] webhooks but no key, no references', function(assert) {
     messageRetention: 3000,
     alarmThreshold: 10,
     alarmPeriods: 6,
+    failedWorkerPlacementAlarmPeriods: 5,
     privileged: true
   });
 
@@ -138,6 +140,7 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.ok(watch.Resources.testTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
   assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
+  assert.ok(watch.Resources.testFailedWorkerPlacementAlarm, 'failed worker alarm');
   assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
   assert.ok(watch.Resources.testWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
@@ -211,6 +214,7 @@ test('[template] include all resources, no references', function(assert) {
     errorThreshold: 11,
     alarmThreshold: 10,
     alarmPeriods: 6,
+    failedWorkerPlacementAlarmPeriods: 5,
     debugLogs: true,
     alarmOnEachFailure: true,
     family: 'hibbity'
@@ -239,6 +243,7 @@ test('[template] include all resources, no references', function(assert) {
   assert.ok(watch.Resources.testTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
   assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
+  assert.ok(watch.Resources.testFailedWorkerPlacementAlarm, 'failed worker alarm');
   assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
   assert.ok(watch.Resources.testWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
@@ -321,6 +326,7 @@ test('[template] include all resources, all references', function(assert) {
     alarmThreshold: cf.ref('AlarmThreshold'),
     errorThreshold: cf.ref('Errors'),
     alarmPeriods: cf.ref('AlarmPeriods'),
+    failedWorkerPlacementAlarmPeriods: cf.ref('FailedWorkerPlacementAlarmPeriods'),
     alarmOnEachFailure: cf.ref('AlarmOnFailures')
   });
 
@@ -349,6 +355,7 @@ test('[template] include all resources, all references', function(assert) {
   assert.ok(watch.Resources.testTaskEventRule, 'task event rule');
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
   assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed worker metric');
+  assert.ok(watch.Resources.testFailedWorkerPlacementAlarm, 'failed worker alarm');
   assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
   assert.ok(watch.Resources.testWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');
@@ -416,7 +423,8 @@ test('[template] resources are valid', function(assert) {
     messageTimeout: 300,
     messageRetention: 3000,
     alarmThreshold: 10,
-    alarmPeriods: 6
+    alarmPeriods: 6,
+    failedWorkerPlacementAlarmPeriods: 5
   });
 
   var tmp = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex') + '.json');
@@ -459,7 +467,8 @@ test('[template] notificationTopic vs notificationEmail', function(assert) {
       messageTimeout: 300,
       messageRetention: 3000,
       alarmThreshold: 10,
-      alarmPeriods: 6
+      alarmPeriods: 6,
+      failedWorkerPlacementAlarmPeriods: 5
     });
   }, /Cannot provide both notificationTopic and notificationEmail./);
 
@@ -488,7 +497,8 @@ test('[template] notificationTopic vs notificationEmail', function(assert) {
     messageTimeout: 300,
     messageRetention: 3000,
     alarmThreshold: 10,
-    alarmPeriods: 6
+    alarmPeriods: 6,
+    failedWorkerPlacementAlarmPeriods: 5
   });
 
   var tmp = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex') + '.json');

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -142,6 +142,7 @@ test('[template] webhooks but no key, no references', function(assert) {
   assert.ok(watch.Resources.testTaskEventQueuePolicy, 'task event queue policy');
   assert.ok(watch.Resources.testFailedWorkerPlacementMetric, 'failed placement metric');
   assert.ok(watch.Resources.testFailedWorkerPlacementAlarm, 'failed placement alarm');
+  assert.equal(watch.Resources.testFailedWorkerPlacementAlarm.Properties.EvaluationPeriods, 5, 'failed placement alarm period');
   assert.ok(watch.Resources.testWorkerDurationMetric, 'worker duration metric');
   assert.ok(watch.Resources.testWorkerPendingMetric, 'worker pending metric');
   assert.ok(watch.Resources.testMessageReceivesMetric, 'message receives metric');


### PR DESCRIPTION
Ref #169 

This PR makes the `EvaluationPeriods` for `FailedWorkerPlacementAlarm` customizable

cc @rclark @nickcordella 