### PR TITLE
Log messages with missing containers

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -161,6 +161,12 @@ function getMessages(sqs, callback) {
 
     var finishedTasks = data.Messages.map(function(message) {
       var task = JSON.parse(message.Body).detail;
+      // Debugging "TypeError: Cannot read property 'exitCode' of undefined"
+      // Will sit here until we catch a few o_o
+      if (!task.containers.length) {
+        console.log('****** INCOMING WEIRD ******');
+        console.log(message.Body);
+      }
       var duration = +new Date(task.stoppedAt) - +new Date(task.startedAt);
       var pending = +new Date(task.startedAt) - +new Date(task.createdAt);
       if (isNaN(duration)) duration = 0;


### PR DESCRIPTION
Investigating why a task would stop and lead to a cloudwatch event where `containers` is an empty array.

cc @rclark @mapsam 