### PR TITLE
change deadletter comparison op to >= 1

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -228,7 +228,7 @@ module.exports = function(options) {
           Value: cf.getAtt(prefixed('DeadLetterQueue'), 'QueueName')
         }
       ],
-      ComparisonOperator: 'GreaterThanThreshold'
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold'
     }
   };
 


### PR DESCRIPTION
> And you can send me dead letters every morning
> Send me dead letters by email
> Send me dead letters to my slack chan
> And I won't forget to put fixes on your branch

The comparison operator for the dead letter alarm is set to `GreaterThanThreshold`, with the threshold being 1.  So users aren't getting notifications until there were at least two dead letter.

This PR changes the operator to `GreaterThanOrEqualToThreshold`.