### PR TITLE
Log SQS duplicate receives, and attempt to stop long-pending tasks

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -133,7 +133,23 @@ module.exports = function(config) {
               })
             );
 
-            queue.defer(tasks.stopIfPending, skipped);
+            queue.defer(function(next) {
+              tasks.stopIfPending(skipped, function(err, stopped) {
+                if (err) return next(err);
+
+                if (stopped) log.info(
+                  '[%s] [stopped-pending] %s',
+                  skipped.MessageId,
+                  JSON.stringify({
+                    subject: skipped.Subject,
+                    message: skipped.Message.substr(0, 2048),
+                    receives: skipped.ApproximateReceiveCount
+                  })
+                );
+
+                next();
+              });
+            });
           });
         }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -118,23 +118,33 @@ module.exports = function(config) {
         log.debug('[debug] %s messages in flight: %s', Object.keys(messages.inFlight).length, Object.keys(messages.inFlight).join(', '));
         log.debug('[debug] messages received: %s', envs ? envs.length : 0);
 
-        // Log duplicate receives
-        if (skips) skips.forEach(function(skipped) {
-          log.info(
-            '[%s] [duplicate-receive] %s',
-            skipped.MessageId,
-            JSON.stringify({
-              subject: skipped.Subject,
-              message: skipped.Message.substr(0, 2048),
-              receives: skipped.ApproximateReceiveCount
-            })
-          );
+        var queue = d3.queue(10);
+
+        // Log duplicate receives, and stop in-flight tasks if they are pending
+        if (skips) {
+          skips.forEach(function(skipped) {
+            log.info(
+              '[%s] [duplicate-receive] %s',
+              skipped.MessageId,
+              JSON.stringify({
+                subject: skipped.Subject,
+                message: skipped.Message.substr(0, 2048),
+                receives: skipped.ApproximateReceiveCount
+              })
+            );
+
+            queue.defer(tasks.stopIfPending, skipped);
+          });
+        }
+
+        queue.awaitAll(function(err) {
+          if (err) log.error(err);
+
+          if (!envs || !envs.length)
+            return setTimeout(main, 1000, config, emitter);
+
+          messagesPolled(envs);
         });
-
-        if (!envs || !envs.length)
-          return setTimeout(main, 1000, config, emitter);
-
-        messagesPolled(envs);
       });
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -137,7 +137,9 @@ module.exports = function(config) {
               tasks.stopIfPending(skipped, function(err, stopped) {
                 if (err) return next(err);
 
-                if (stopped) log.info(
+                if (!stopped) return next();
+
+                log.info(
                   '[%s] [stopped-pending] %s',
                   skipped.MessageId,
                   JSON.stringify({
@@ -147,7 +149,15 @@ module.exports = function(config) {
                   })
                 );
 
-                next();
+                messages.complete({
+                  arns: {},
+                  reason: 'Task stuck in PENDING state',
+                  env: skipped,
+                  outcome: tasks.outcome.noop
+                }, function(err) {
+                  if (err) log.error(err);
+                  next();
+                });
               });
             });
           });

--- a/lib/main.js
+++ b/lib/main.js
@@ -111,12 +111,26 @@ module.exports = function(config) {
 
     function completedTasks(status) {
       log.debug('[debug] poll for %s messages', status.free);
-      messages.poll(status.free, function(err, envs) {
+      messages.poll(status.free, function(err, envs, skips) {
         if (err) log.error(err);
 
         // If there are no messages, wait a second before repeating
         log.debug('[debug] %s messages in flight: %s', Object.keys(messages.inFlight).length, Object.keys(messages.inFlight).join(', '));
         log.debug('[debug] messages received: %s', envs ? envs.length : 0);
+
+        // Log duplicate receives
+        if (skips) skips.forEach(function(skipped) {
+          log.info(
+            '[%s] [duplicate-receive] %s',
+            skipped.MessageId,
+            JSON.stringify({
+              subject: skipped.Subject,
+              message: skipped.Message.substr(0, 2048),
+              receives: skipped.ApproximateReceiveCount
+            })
+          );
+        });
+
         if (!envs || !envs.length)
           return setTimeout(main, 1000, config, emitter);
 
@@ -138,7 +152,7 @@ module.exports = function(config) {
                 env.MessageId,
                 JSON.stringify({
                   subject: env.Subject,
-                  message: env.Message.length < 2048 ? env.Message : env.Message.substr(0, 2048),
+                  message: env.Message.substr(0, 2048),
                   receives: env.ApproximateReceiveCount
                 })
               );

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -83,15 +83,17 @@ module.exports = function(queue, topic, stackName, sendNotifications, logGroup) 
       if (!data.Messages || !data.Messages.length)
         return callback(null, []);
 
+      var skips = [];
       var envs = data.Messages.filter(function(message) {
-        var notInFlight = !messagesInFlight[message.MessageId];
+        var isInFlight = messagesInFlight[message.MessageId];
+        if (isInFlight) skips.push(messageToEnv(message));
         messagesInFlight[message.MessageId] = message.ReceiptHandle;
-        return notInFlight;
+        return !isInFlight;
       }).map(function(message) {
         return messageToEnv(message);
       });
 
-      callback(null, envs);
+      callback(null, envs, skips);
     });
   };
 
@@ -175,7 +177,7 @@ module.exports = function(queue, topic, stackName, sendNotifications, logGroup) 
     });
 
     function allDone(err) {
-      delete messagesInFlight[messageId];
+      if (!finishedTask.skip) delete messagesInFlight[messageId];
       callback(err);
     }
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -122,17 +122,24 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, q
   };
 
   tasks.stopIfPending = function(env, callback) {
-    var taskArn = taskStateCache[env.MessageId];
+    // console.log(env.MessageId);
+    // console.log(taskStateCache.inFlight);
+    // console.log(taskStateCache.messageIndex);
 
-    if (!taskArn) return callback();
+    var taskArn = taskStateCache.messageIndex[env.MessageId];
+
+    if (!taskArn) return callback(null, false);
 
     ecs.describeTasks({ tasks: [taskArn] }, function(err, data) {
       if (err) return callback(err);
 
       var isPending = data.tasks[0].lastStatus === 'PENDING';
-      if (!isPending) return callback();
+      if (!isPending) return callback(null, false);
 
-      ecs.stopTask({ task: taskArn }, callback);
+      ecs.stopTask({ task: taskArn }, function(err) {
+        if (err) return callback(err);
+        callback(null, true);
+      });
     });
   };
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -79,7 +79,7 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, q
       if (err) return callback(err);
 
       data.tasks.forEach(function(task) {
-        taskStateCache.taskStarted(task.taskArn);
+        taskStateCache.taskStarted(task.taskArn, env);
       });
 
       if (data.failures && data.failures.length) {
@@ -119,6 +119,21 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, q
     var taskStatus = taskStateCache.completedTasks;
     taskStatus.free = concurrency - taskStateCache.inFlightCount;
     setImmediate(callback, null, taskStatus);
+  };
+
+  tasks.stopIfPending = function(env, callback) {
+    var taskArn = taskStateCache[env.MessageId];
+
+    if (!taskArn) return callback();
+
+    ecs.describeTasks({ tasks: [taskArn] }, function(err, data) {
+      if (err) return callback(err);
+
+      var isPending = data.tasks[0].lastStatus === 'PENDING';
+      if (!isPending) return callback();
+
+      ecs.stopTask({ task: taskArn }, callback);
+    });
   };
 
   return tasks;
@@ -243,6 +258,7 @@ class TaskStateCache extends events.EventEmitter {
     super();
     this.sqs = sqs;
     this.inFlight = {};
+    this.messageIndex = {};
     this.pendingCompletion = [];
   }
 
@@ -277,19 +293,21 @@ class TaskStateCache extends events.EventEmitter {
     var completed = [].concat(this.pendingCompletion);
     this.pendingCompletion = [];
     return completed.map((task) => {
-      this.taskCompleted(task.arns.task);
+      this.taskCompleted(task);
       delete task.removeEvent;
       delete task.ignoreEvent;
       return task;
     });
   }
 
-  taskStarted(taskArn) {
+  taskStarted(taskArn, env) {
     this.inFlight[taskArn] = true;
+    this.messageIndex[env.MessageId] = taskArn;
   }
 
-  taskCompleted(taskArn) {
-    delete this.inFlight[taskArn];
+  taskCompleted(task) {
+    delete this.inFlight[task.arns.task];
+    delete this.messageIndex[task.env.MessageId];
   }
 
   stopPolling() {

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -122,10 +122,6 @@ module.exports = function(cluster, taskDefinition, containerName, concurrency, q
   };
 
   tasks.stopIfPending = function(env, callback) {
-    // console.log(env.MessageId);
-    // console.log(taskStateCache.inFlight);
-    // console.log(taskStateCache.messageIndex);
-
     var taskArn = taskStateCache.messageIndex[env.MessageId];
 
     if (!taskArn) return callback(null, false);

--- a/lib/template.js
+++ b/lib/template.js
@@ -565,7 +565,11 @@ module.exports = function(options) {
               },
               {
                 Effect: 'Allow',
-                Action: ['ecs:DescribeTasks', 'ecs:DescribeContainerInstances'],
+                Action: [
+                  'ecs:DescribeTasks',
+                  'ecs:DescribeContainerInstances',
+                  'ecs:StopTask'
+                ],
                 Resource: '*',
                 Condition: { StringEquals: { 'ecs:cluster': options.cluster } }
               },

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -13,355 +13,384 @@ var config = {
   // , LogLevel: 'debug'
 };
 
-util.mock('[main] message polling error', function(assert) {
-  var context = this;
+// util.mock('[main] message polling error', function(assert) {
+//   var context = this;
+//
+//   context.sqs.messages = [
+//     { MessageId: 'error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0 } }
+//   ];
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+//     var errorMsg = context.logs.find(function(log) {
+//       return /Mock SQS error/.test(log);
+//     });
+//     assert.deepEqual(context.sns.publish, [], 'sent no error notification');
+//     assert.ok(errorMsg, 'logged error message');
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] nothing to do', function(assert) {
+//   var context = this;
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] run a task', function(assert) {
+//   var context = this;
+//
+//   context.sqs.messages = [
+//     { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+//   ];
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+//     assert.deepEqual(context.ecs.runTask, [
+//       {
+//         startedBy: config.StackName,
+//         taskDefinition: config.TaskDefinition,
+//         overrides: {
+//           containerOverrides: [
+//             {
+//               name: config.ContainerName,
+//               environment: [
+//                 { name: 'MessageId', value: '1' },
+//                 { name: 'Subject', value: 'subject1' },
+//                 { name: 'Message', value: 'message1' },
+//                 { name: 'SentTimestamp', value: '10' },
+//                 { name: 'ApproximateFirstReceiveTimestamp', value: '20' },
+//                 { name: 'ApproximateReceiveCount', value: '1' }
+//               ]
+//             }
+//           ]
+//         }
+//       }
+//     ], 'expected ecs.runTask request');
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] task running error', function(assert) {
+//   var context = this;
+//
+//   context.sqs.messages = [
+//     { MessageId: 'ecs-error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+//   ];
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+//     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
+//     assert.ok(context.logs.find(function(log) {
+//       return /Mock ECS error/.test(log);
+//     }), 'printed error message');
+//
+//     util.collectionsEqual(assert, context.sns.publish, [
+//       {
+//         Subject: config.StackName + ' failed processing message ecs-error',
+//         Message: 'At ${date}, processing message ecs-error failed on ' + config.StackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: Mock ECS error\n\nMessage information:\nMessageId: ecs-error\nSubject: subject1\nMessage: message1\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: undefined\nInstance ARN: undefined\nTask ARN: undefined\n'
+//       }
+//     ], 'sent expected error notification');
+//     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
+//       { ReceiptHandle: '1', VisibilityTimeout: 2 }
+//     ], 'expected sqs.changeMessageVisibility requests');
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] task running failure (out of memory)', function(assert) {
+//   var context = this;
+//
+//   context.sqs.messages = [
+//     { MessageId: 'ecs-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+//   ];
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+//     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
+//     assert.deepEqual(context.sns.publish, [], 'does not send failure notification');
+//     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
+//       { ReceiptHandle: '1', VisibilityTimeout: 2 }
+//     ], 'expected sqs.changeMessageVisibility requests');
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] task running failure (unrecognized reason)', function(assert) {
+//   var context = this;
+//
+//   context.sqs.messages = [
+//     { MessageId: 'ecs-unrecognized', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+//   ];
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+//     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
+//     assert.deepEqual(context.sns.publish, [], 'does not send failure notification');
+//     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
+//       { ReceiptHandle: '1', VisibilityTimeout: 2 }
+//     ], 'expected sqs.changeMessageVisibility requests');
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] message completion error after task run failure', function(assert) {
+//   var context = this;
+//
+//   context.sqs.messages = [
+//     { MessageId: 'ecs-error', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+//   ];
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+//     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
+//     assert.ok(context.logs.find(function(log) {
+//       return /Mock ECS error/.test(log);
+//     }), 'printed error message');
+//     util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
+//     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
+//       { ReceiptHandle: 'error', VisibilityTimeout: 2 }
+//     ], 'expected sqs.changeMessageVisibility requests');
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] task polling error', function(assert) {
+//   var context = this;
+//
+//   context.sqs.messages = [
+//     { MessageId: 'task-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+//   ];
+//
+//   context.sqs.eventMessages = [
+//     { MessageId: 'error', Attributes: { ApproximateReceiveCount: 0 } }
+//   ];
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+//     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
+//     assert.ok(context.logs.find(function(log) {
+//       return /Mock SQS error/.test(log);
+//     }), 'printed error message');
+//     assert.deepEqual(context.sns.publish, [], 'sent no error notification');
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] no free tasks', function(assert) {
+//   var context = this;
+//
+//   context.sqs.messages = [
+//     { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+//     { MessageId: '2', ReceiptHandle: '2', Body: JSON.stringify({ Subject: 'subject2', Message: 'message2' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+//     { MessageId: '3', ReceiptHandle: '3', Body: JSON.stringify({ Subject: 'subject3', Message: 'message3' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+//     { MessageId: '4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+//   ];
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 1, 'one sqs.receiveMessage requests');
+//     assert.equal(context.ecs.runTask.length, 3, 'three ecs.runTask requests');
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] manage messages for completed tasks', function(assert) {
+//   var context = this;
+//
+//   context.sqs.messages = [
+//     { MessageId: 'finish-0', ReceiptHandle: '0', Body: JSON.stringify({ Subject: 'subject0', Message: 'message0' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+//     { MessageId: 'finish-2', ReceiptHandle: '2', Body: JSON.stringify({ Subject: 'subject2', Message: 'message2' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 2, ApproximateFirstReceiveTimestamp: 20 } },
+//     { MessageId: 'finish-3', ReceiptHandle: '3', Body: JSON.stringify({ Subject: 'subject3', Message: 'message3' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+//     { MessageId: 'finish-4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+//   ];
+//
+//   context.sqs.eventMessages = context.sqs.messages.map((message) => {
+//     return {
+//       MessageId: `${message.MessageId}-event`,
+//       ReceiptHandle: `${message.ReceiptHandle}-event`,
+//       Attributes: {
+//         SentTimestamp: message.Attributes.SentTimestamp,
+//         ApproximateReceiveCount: 0
+//       },
+//       Body: JSON.stringify({
+//         detail: {
+//           clusterArn: 'cluster-arn',
+//           containerInstanceArn: 'instance-arn',
+//           taskArn: util.expectedArn(message, config.TaskDefinition, config.ContainerName, config.StackName),
+//           lastStatus: 'STOPPED',
+//           stoppedReason: message.MessageId.split('-')[1],
+//           overrides: {
+//             containerOverrides: [
+//               {
+//                 environment: [
+//                   { name: 'MessageId', value: message.MessageId },
+//                   { name: 'Subject', value: JSON.parse(message.Body).Subject },
+//                   { name: 'Message', value: JSON.parse(message.Body).Message },
+//                   { name: 'SentTimestamp', value: message.Attributes.SentTimestamp },
+//                   { name: 'ApproximateFirstReceiveTimestamp', value: message.Attributes.ApproximateFirstReceiveTimestamp },
+//                   { name: 'ApproximateReceiveCount', value: message.Attributes.ApproximateReceiveCount + 1 }
+//                 ]
+//               }
+//             ]
+//           },
+//           containers: [{ exitCode: Number(message.MessageId.split('-')[1]) }],
+//           createdAt: 1484155844718,
+//           startedAt: 1484155849718,
+//           stoppedAt: 1484155857691
+//         }
+//       })
+//     };
+//   });
+//
+//   var testConfig = Object.assign({}, config, {
+//     Concurrency: '5',
+//     NotifyAfterRetries: '1'
+//   });
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(testConfig).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+//     assert.equal(context.ecs.runTask.length, 4, 'four ecs.runTask requests');
+//     util.collectionsEqual(assert, context.sqs.deleteMessage, [
+//       { ReceiptHandle: '0-event' },
+//       { ReceiptHandle: '2-event' },
+//       { ReceiptHandle: '3-event' },
+//       { ReceiptHandle: '4-event' },
+//       { ReceiptHandle: '0' },
+//       { ReceiptHandle: '3' }
+//     ], ' sqs.deleteMessage for all event messages, and for expected job messages');
+//     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
+//       { ReceiptHandle: '2', VisibilityTimeout: 8 },
+//       { ReceiptHandle: '4', VisibilityTimeout: 2 }
+//     ], 'expected sqs.changeMessageVisibility requests');
+//     util.collectionsEqual(assert, context.sns.publish, [
+//       {
+//         Subject: config.StackName + ' failed processing message finish-2',
+//         Message: 'At ${date}, processing message finish-2 failed on ' + config.StackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: 2\n\nMessage information:\nMessageId: finish-2\nSubject: subject2\nMessage: message2\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 3\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 3120b788edc53b003f3ebb8afc557f07\n'
+//       },
+//       {
+//         Subject: config.StackName + ' failed processing message finish-3',
+//         Message: 'At ${date}, processing message finish-3 failed on ' + config.StackName + '\n\nTask outcome: delete & notify\n\nTask stopped reason: 3\n\nMessage information:\nMessageId: finish-3\nSubject: subject3\nMessage: message3\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 496a1bbc7db7ef69c5b024bed0fa66e7\n'
+//       }
+//     ], 'expected sns.publish requests');
+//
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] message completion error', function(assert) {
+//   var context = this;
+//
+//   context.sqs.messages = [
+//     { MessageId: 'finish-0', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject0', Message: 'message0' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+//   ];
+//
+//   context.sqs.eventMessages = context.sqs.messages.map((message) => {
+//     return {
+//       MessageId: `${message.MessageId}-event`,
+//       ReceiptHandle: `${message.ReceiptHandle}-event`,
+//       Attributes: {
+//         SentTimestamp: message.Attributes.SentTimestamp,
+//         ApproximateReceiveCount: 0
+//       },
+//       Body: JSON.stringify({
+//         detail: {
+//           clusterArn: 'cluster-arn',
+//           containerInstanceArn: 'instance-arn',
+//           taskArn: util.expectedArn(message, config.TaskDefinition, config.ContainerName, config.StackName),
+//           lastStatus: 'STOPPED',
+//           stoppedReason: message.MessageId.split('-')[1],
+//           overrides: {
+//             containerOverrides: [
+//               {
+//                 environment: [
+//                   { name: 'MessageId', value: message.MessageId },
+//                   { name: 'Subject', value: JSON.parse(message.Body).Subject },
+//                   { name: 'Message', value: JSON.parse(message.Body).Message },
+//                   { name: 'SentTimestamp', value: message.Attributes.SentTimestamp },
+//                   { name: 'ApproximateFirstReceiveTimestamp', value: message.Attributes.ApproximateFirstReceiveTimestamp },
+//                   { name: 'ApproximateReceiveCount', value: message.Attributes.ApproximateReceiveCount + 1 }
+//                 ]
+//               }
+//             ]
+//           },
+//           containers: [{ exitCode: Number(message.MessageId.split('-')[1]) }],
+//           createdAt: 1484155844718,
+//           startedAt: 1484155849718,
+//           stoppedAt: 1484155857691
+//         }
+//       })
+//     };
+//   });
+//
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+//     assert.equal(context.ecs.runTask.length, 1, 'one ecs.runTask requests');
+//     assert.equal(context.sqs.changeMessageVisibility.length, 0, 'no sqs.changeMessageVisibility requests');
+//     var errorMsg = context.logs.find(function(log) {
+//       return /Mock SQS error/.test(log);
+//     });
+//     assert.ok(errorMsg, 'logged error');
+//     util.collectionsEqual(assert, context.sqs.deleteMessage, [
+//       { ReceiptHandle: 'error' }, { ReceiptHandle: 'error-event' }
+//     ], 'expected sqs.deleteMessage request');
+//
+//     util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
+//     assert.end();
+//   });
+// });
+//
+// util.mock('[main] LogLevel', function(assert){
+//   config.LogLevel = 'debug';
+//   var context = this;
+//   setTimeout(watchbot.main.end, 1800);
+//   watchbot.main(config).on('finish', function() {
+//     assert.ok(context.logs.find(function(log) {
+//       return /\[debug\]/.test(log);
+//     }), 'logs debug messages');
+//     delete config.LogLevel;
+//     assert.end();
+//   });
+// });
 
-  context.sqs.messages = [
-    { MessageId: 'error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0 } }
-  ];
-
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-    var errorMsg = context.logs.find(function(log) {
-      return /Mock SQS error/.test(log);
-    });
-    assert.deepEqual(context.sns.publish, [], 'sent no error notification');
-    assert.ok(errorMsg, 'logged error message');
-    assert.end();
-  });
-});
-
-util.mock('[main] nothing to do', function(assert) {
-  var context = this;
-
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-    assert.end();
-  });
-});
-
-util.mock('[main] run a task', function(assert) {
-  var context = this;
-
-  context.sqs.messages = [
-    { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-  ];
-
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-    assert.deepEqual(context.ecs.runTask, [
-      {
-        startedBy: config.StackName,
-        taskDefinition: config.TaskDefinition,
-        overrides: {
-          containerOverrides: [
-            {
-              name: config.ContainerName,
-              environment: [
-                { name: 'MessageId', value: '1' },
-                { name: 'Subject', value: 'subject1' },
-                { name: 'Message', value: 'message1' },
-                { name: 'SentTimestamp', value: '10' },
-                { name: 'ApproximateFirstReceiveTimestamp', value: '20' },
-                { name: 'ApproximateReceiveCount', value: '1' }
-              ]
-            }
-          ]
-        }
-      }
-    ], 'expected ecs.runTask request');
-    assert.end();
-  });
-});
-
-util.mock('[main] task running error', function(assert) {
-  var context = this;
-
-  context.sqs.messages = [
-    { MessageId: 'ecs-error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-  ];
-
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-    assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
-    assert.ok(context.logs.find(function(log) {
-      return /Mock ECS error/.test(log);
-    }), 'printed error message');
-
-    util.collectionsEqual(assert, context.sns.publish, [
-      {
-        Subject: config.StackName + ' failed processing message ecs-error',
-        Message: 'At ${date}, processing message ecs-error failed on ' + config.StackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: Mock ECS error\n\nMessage information:\nMessageId: ecs-error\nSubject: subject1\nMessage: message1\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: undefined\nInstance ARN: undefined\nTask ARN: undefined\n'
-      }
-    ], 'sent expected error notification');
-    util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-      { ReceiptHandle: '1', VisibilityTimeout: 2 }
-    ], 'expected sqs.changeMessageVisibility requests');
-    assert.end();
-  });
-});
-
-util.mock('[main] task running failure (out of memory)', function(assert) {
-  var context = this;
-
-  context.sqs.messages = [
-    { MessageId: 'ecs-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-  ];
-
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-    assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
-    assert.deepEqual(context.sns.publish, [], 'does not send failure notification');
-    util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-      { ReceiptHandle: '1', VisibilityTimeout: 2 }
-    ], 'expected sqs.changeMessageVisibility requests');
-    assert.end();
-  });
-});
-
-util.mock('[main] task running failure (unrecognized reason)', function(assert) {
-  var context = this;
-
-  context.sqs.messages = [
-    { MessageId: 'ecs-unrecognized', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-  ];
-
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-    assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
-    assert.deepEqual(context.sns.publish, [], 'does not send failure notification');
-    util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-      { ReceiptHandle: '1', VisibilityTimeout: 2 }
-    ], 'expected sqs.changeMessageVisibility requests');
-    assert.end();
-  });
-});
-
-util.mock('[main] message completion error after task run failure', function(assert) {
-  var context = this;
-
-  context.sqs.messages = [
-    { MessageId: 'ecs-error', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-  ];
-
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-    assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
-    assert.ok(context.logs.find(function(log) {
-      return /Mock ECS error/.test(log);
-    }), 'printed error message');
-    util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
-    util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-      { ReceiptHandle: 'error', VisibilityTimeout: 2 }
-    ], 'expected sqs.changeMessageVisibility requests');
-    assert.end();
-  });
-});
-
-util.mock('[main] task polling error', function(assert) {
-  var context = this;
-
-  context.sqs.messages = [
-    { MessageId: 'task-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-  ];
-
-  context.sqs.eventMessages = [
-    { MessageId: 'error', Attributes: { ApproximateReceiveCount: 0 } }
-  ];
-
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-    assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
-    assert.ok(context.logs.find(function(log) {
-      return /Mock SQS error/.test(log);
-    }), 'printed error message');
-    assert.deepEqual(context.sns.publish, [], 'sent no error notification');
-    assert.end();
-  });
-});
-
-util.mock('[main] no free tasks', function(assert) {
+util.mock('[main] duplicated receives', function(assert) {
   var context = this;
 
   context.sqs.messages = [
     { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
     { MessageId: '2', ReceiptHandle: '2', Body: JSON.stringify({ Subject: 'subject2', Message: 'message2' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
     { MessageId: '3', ReceiptHandle: '3', Body: JSON.stringify({ Subject: 'subject3', Message: 'message3' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
-    { MessageId: '4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+    { MessageId: '4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: '5', ReceiptHandle: '5', Body: JSON.stringify({ Subject: 'subject5', Message: 'message5' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: '6', ReceiptHandle: '6', Body: JSON.stringify({ Subject: 'subject6', Message: 'message6' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: '7', ReceiptHandle: '7', Body: JSON.stringify({ Subject: 'subject7', Message: 'message7' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: '8', ReceiptHandle: '8', Body: JSON.stringify({ Subject: 'subject8', Message: 'message8' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: '9', ReceiptHandle: '9', Body: JSON.stringify({ Subject: 'subject9', Message: 'message9' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: '10', ReceiptHandle: '10', Body: JSON.stringify({ Subject: 'subject10', Message: 'message10' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
   setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 1, 'one sqs.receiveMessage requests');
-    assert.equal(context.ecs.runTask.length, 3, 'three ecs.runTask requests');
-    assert.end();
-  });
-});
-
-util.mock('[main] manage messages for completed tasks', function(assert) {
-  var context = this;
-
-  context.sqs.messages = [
-    { MessageId: 'finish-0', ReceiptHandle: '0', Body: JSON.stringify({ Subject: 'subject0', Message: 'message0' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
-    { MessageId: 'finish-2', ReceiptHandle: '2', Body: JSON.stringify({ Subject: 'subject2', Message: 'message2' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 2, ApproximateFirstReceiveTimestamp: 20 } },
-    { MessageId: 'finish-3', ReceiptHandle: '3', Body: JSON.stringify({ Subject: 'subject3', Message: 'message3' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
-    { MessageId: 'finish-4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-  ];
-
-  context.sqs.eventMessages = context.sqs.messages.map((message) => {
-    return {
-      MessageId: `${message.MessageId}-event`,
-      ReceiptHandle: `${message.ReceiptHandle}-event`,
-      Attributes: {
-        SentTimestamp: message.Attributes.SentTimestamp,
-        ApproximateReceiveCount: 0
-      },
-      Body: JSON.stringify({
-        detail: {
-          clusterArn: 'cluster-arn',
-          containerInstanceArn: 'instance-arn',
-          taskArn: util.expectedArn(message, config.TaskDefinition, config.ContainerName, config.StackName),
-          lastStatus: 'STOPPED',
-          stoppedReason: message.MessageId.split('-')[1],
-          overrides: {
-            containerOverrides: [
-              {
-                environment: [
-                  { name: 'MessageId', value: message.MessageId },
-                  { name: 'Subject', value: JSON.parse(message.Body).Subject },
-                  { name: 'Message', value: JSON.parse(message.Body).Message },
-                  { name: 'SentTimestamp', value: message.Attributes.SentTimestamp },
-                  { name: 'ApproximateFirstReceiveTimestamp', value: message.Attributes.ApproximateFirstReceiveTimestamp },
-                  { name: 'ApproximateReceiveCount', value: message.Attributes.ApproximateReceiveCount + 1 }
-                ]
-              }
-            ]
-          },
-          containers: [{ exitCode: Number(message.MessageId.split('-')[1]) }],
-          createdAt: 1484155844718,
-          startedAt: 1484155849718,
-          stoppedAt: 1484155857691
-        }
-      })
-    };
-  });
-
-  var testConfig = Object.assign({}, config, {
-    Concurrency: '5',
-    NotifyAfterRetries: '1'
-  });
-
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(testConfig).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-    assert.equal(context.ecs.runTask.length, 4, 'four ecs.runTask requests');
-    util.collectionsEqual(assert, context.sqs.deleteMessage, [
-      { ReceiptHandle: '0-event' },
-      { ReceiptHandle: '2-event' },
-      { ReceiptHandle: '3-event' },
-      { ReceiptHandle: '4-event' },
-      { ReceiptHandle: '0' },
-      { ReceiptHandle: '3' }
-    ], ' sqs.deleteMessage for all event messages, and for expected job messages');
-    util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-      { ReceiptHandle: '2', VisibilityTimeout: 8 },
-      { ReceiptHandle: '4', VisibilityTimeout: 2 }
-    ], 'expected sqs.changeMessageVisibility requests');
-    util.collectionsEqual(assert, context.sns.publish, [
-      {
-        Subject: config.StackName + ' failed processing message finish-2',
-        Message: 'At ${date}, processing message finish-2 failed on ' + config.StackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: 2\n\nMessage information:\nMessageId: finish-2\nSubject: subject2\nMessage: message2\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 3\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 3120b788edc53b003f3ebb8afc557f07\n'
-      },
-      {
-        Subject: config.StackName + ' failed processing message finish-3',
-        Message: 'At ${date}, processing message finish-3 failed on ' + config.StackName + '\n\nTask outcome: delete & notify\n\nTask stopped reason: 3\n\nMessage information:\nMessageId: finish-3\nSubject: subject3\nMessage: message3\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 496a1bbc7db7ef69c5b024bed0fa66e7\n'
-      }
-    ], 'expected sns.publish requests');
-
-    assert.end();
-  });
-});
-
-util.mock('[main] message completion error', function(assert) {
-  var context = this;
-
-  context.sqs.messages = [
-    { MessageId: 'finish-0', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject0', Message: 'message0' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-  ];
-
-  context.sqs.eventMessages = context.sqs.messages.map((message) => {
-    return {
-      MessageId: `${message.MessageId}-event`,
-      ReceiptHandle: `${message.ReceiptHandle}-event`,
-      Attributes: {
-        SentTimestamp: message.Attributes.SentTimestamp,
-        ApproximateReceiveCount: 0
-      },
-      Body: JSON.stringify({
-        detail: {
-          clusterArn: 'cluster-arn',
-          containerInstanceArn: 'instance-arn',
-          taskArn: util.expectedArn(message, config.TaskDefinition, config.ContainerName, config.StackName),
-          lastStatus: 'STOPPED',
-          stoppedReason: message.MessageId.split('-')[1],
-          overrides: {
-            containerOverrides: [
-              {
-                environment: [
-                  { name: 'MessageId', value: message.MessageId },
-                  { name: 'Subject', value: JSON.parse(message.Body).Subject },
-                  { name: 'Message', value: JSON.parse(message.Body).Message },
-                  { name: 'SentTimestamp', value: message.Attributes.SentTimestamp },
-                  { name: 'ApproximateFirstReceiveTimestamp', value: message.Attributes.ApproximateFirstReceiveTimestamp },
-                  { name: 'ApproximateReceiveCount', value: message.Attributes.ApproximateReceiveCount + 1 }
-                ]
-              }
-            ]
-          },
-          containers: [{ exitCode: Number(message.MessageId.split('-')[1]) }],
-          createdAt: 1484155844718,
-          startedAt: 1484155849718,
-          stoppedAt: 1484155857691
-        }
-      })
-    };
-  });
-
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-    assert.equal(context.ecs.runTask.length, 1, 'one ecs.runTask requests');
-    assert.equal(context.sqs.changeMessageVisibility.length, 0, 'no sqs.changeMessageVisibility requests');
-    var errorMsg = context.logs.find(function(log) {
-      return /Mock SQS error/.test(log);
-    });
-    assert.ok(errorMsg, 'logged error');
-    util.collectionsEqual(assert, context.sqs.deleteMessage, [
-      { ReceiptHandle: 'error' }, { ReceiptHandle: 'error-event' }
-    ], 'expected sqs.deleteMessage request');
-
-    util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
-    assert.end();
-  });
-});
-
-util.mock('[main] LogLevel', function(assert){
-  config.LogLevel = 'debug';
-  var context = this;
-  setTimeout(watchbot.main.end, 1800);
-  watchbot.main(config).on('finish', function() {
-    assert.ok(context.logs.find(function(log) {
-      return /\[debug\]/.test(log);
-    }), 'logs debug messages');
-    delete config.LogLevel;
+  watchbot.main(Object.assign({}, config, { Concurrency: 20 })).on('finish', function() {
+    assert.deepEqual(context.ecs.describeTasks, [
+      { tasks: ['3b80fe64b7d8278090a63a16e5908ad9'] }
+    ], 'called describeTasks on the right task arn');
+    assert.deepEqual(context.ecs.stopTask, [
+      { task: '3b80fe64b7d8278090a63a16e5908ad9' }
+    ], 'called stopTask on the right task arn');
     assert.end();
   });
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -13,358 +13,358 @@ var config = {
   // , LogLevel: 'debug'
 };
 
-// util.mock('[main] message polling error', function(assert) {
-//   var context = this;
-//
-//   context.sqs.messages = [
-//     { MessageId: 'error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0 } }
-//   ];
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-//     var errorMsg = context.logs.find(function(log) {
-//       return /Mock SQS error/.test(log);
-//     });
-//     assert.deepEqual(context.sns.publish, [], 'sent no error notification');
-//     assert.ok(errorMsg, 'logged error message');
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] nothing to do', function(assert) {
-//   var context = this;
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] run a task', function(assert) {
-//   var context = this;
-//
-//   context.sqs.messages = [
-//     { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-//   ];
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-//     assert.deepEqual(context.ecs.runTask, [
-//       {
-//         startedBy: config.StackName,
-//         taskDefinition: config.TaskDefinition,
-//         overrides: {
-//           containerOverrides: [
-//             {
-//               name: config.ContainerName,
-//               environment: [
-//                 { name: 'MessageId', value: '1' },
-//                 { name: 'Subject', value: 'subject1' },
-//                 { name: 'Message', value: 'message1' },
-//                 { name: 'SentTimestamp', value: '10' },
-//                 { name: 'ApproximateFirstReceiveTimestamp', value: '20' },
-//                 { name: 'ApproximateReceiveCount', value: '1' }
-//               ]
-//             }
-//           ]
-//         }
-//       }
-//     ], 'expected ecs.runTask request');
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] task running error', function(assert) {
-//   var context = this;
-//
-//   context.sqs.messages = [
-//     { MessageId: 'ecs-error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-//   ];
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-//     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
-//     assert.ok(context.logs.find(function(log) {
-//       return /Mock ECS error/.test(log);
-//     }), 'printed error message');
-//
-//     util.collectionsEqual(assert, context.sns.publish, [
-//       {
-//         Subject: config.StackName + ' failed processing message ecs-error',
-//         Message: 'At ${date}, processing message ecs-error failed on ' + config.StackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: Mock ECS error\n\nMessage information:\nMessageId: ecs-error\nSubject: subject1\nMessage: message1\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: undefined\nInstance ARN: undefined\nTask ARN: undefined\n'
-//       }
-//     ], 'sent expected error notification');
-//     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-//       { ReceiptHandle: '1', VisibilityTimeout: 2 }
-//     ], 'expected sqs.changeMessageVisibility requests');
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] task running failure (out of memory)', function(assert) {
-//   var context = this;
-//
-//   context.sqs.messages = [
-//     { MessageId: 'ecs-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-//   ];
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-//     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
-//     assert.deepEqual(context.sns.publish, [], 'does not send failure notification');
-//     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-//       { ReceiptHandle: '1', VisibilityTimeout: 2 }
-//     ], 'expected sqs.changeMessageVisibility requests');
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] task running failure (unrecognized reason)', function(assert) {
-//   var context = this;
-//
-//   context.sqs.messages = [
-//     { MessageId: 'ecs-unrecognized', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-//   ];
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-//     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
-//     assert.deepEqual(context.sns.publish, [], 'does not send failure notification');
-//     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-//       { ReceiptHandle: '1', VisibilityTimeout: 2 }
-//     ], 'expected sqs.changeMessageVisibility requests');
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] message completion error after task run failure', function(assert) {
-//   var context = this;
-//
-//   context.sqs.messages = [
-//     { MessageId: 'ecs-error', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-//   ];
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-//     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
-//     assert.ok(context.logs.find(function(log) {
-//       return /Mock ECS error/.test(log);
-//     }), 'printed error message');
-//     util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
-//     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-//       { ReceiptHandle: 'error', VisibilityTimeout: 2 }
-//     ], 'expected sqs.changeMessageVisibility requests');
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] task polling error', function(assert) {
-//   var context = this;
-//
-//   context.sqs.messages = [
-//     { MessageId: 'task-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-//   ];
-//
-//   context.sqs.eventMessages = [
-//     { MessageId: 'error', Attributes: { ApproximateReceiveCount: 0 } }
-//   ];
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-//     assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
-//     assert.ok(context.logs.find(function(log) {
-//       return /Mock SQS error/.test(log);
-//     }), 'printed error message');
-//     assert.deepEqual(context.sns.publish, [], 'sent no error notification');
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] no free tasks', function(assert) {
-//   var context = this;
-//
-//   context.sqs.messages = [
-//     { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
-//     { MessageId: '2', ReceiptHandle: '2', Body: JSON.stringify({ Subject: 'subject2', Message: 'message2' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
-//     { MessageId: '3', ReceiptHandle: '3', Body: JSON.stringify({ Subject: 'subject3', Message: 'message3' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
-//     { MessageId: '4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-//   ];
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 1, 'one sqs.receiveMessage requests');
-//     assert.equal(context.ecs.runTask.length, 3, 'three ecs.runTask requests');
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] manage messages for completed tasks', function(assert) {
-//   var context = this;
-//
-//   context.sqs.messages = [
-//     { MessageId: 'finish-0', ReceiptHandle: '0', Body: JSON.stringify({ Subject: 'subject0', Message: 'message0' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
-//     { MessageId: 'finish-2', ReceiptHandle: '2', Body: JSON.stringify({ Subject: 'subject2', Message: 'message2' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 2, ApproximateFirstReceiveTimestamp: 20 } },
-//     { MessageId: 'finish-3', ReceiptHandle: '3', Body: JSON.stringify({ Subject: 'subject3', Message: 'message3' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
-//     { MessageId: 'finish-4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-//   ];
-//
-//   context.sqs.eventMessages = context.sqs.messages.map((message) => {
-//     return {
-//       MessageId: `${message.MessageId}-event`,
-//       ReceiptHandle: `${message.ReceiptHandle}-event`,
-//       Attributes: {
-//         SentTimestamp: message.Attributes.SentTimestamp,
-//         ApproximateReceiveCount: 0
-//       },
-//       Body: JSON.stringify({
-//         detail: {
-//           clusterArn: 'cluster-arn',
-//           containerInstanceArn: 'instance-arn',
-//           taskArn: util.expectedArn(message, config.TaskDefinition, config.ContainerName, config.StackName),
-//           lastStatus: 'STOPPED',
-//           stoppedReason: message.MessageId.split('-')[1],
-//           overrides: {
-//             containerOverrides: [
-//               {
-//                 environment: [
-//                   { name: 'MessageId', value: message.MessageId },
-//                   { name: 'Subject', value: JSON.parse(message.Body).Subject },
-//                   { name: 'Message', value: JSON.parse(message.Body).Message },
-//                   { name: 'SentTimestamp', value: message.Attributes.SentTimestamp },
-//                   { name: 'ApproximateFirstReceiveTimestamp', value: message.Attributes.ApproximateFirstReceiveTimestamp },
-//                   { name: 'ApproximateReceiveCount', value: message.Attributes.ApproximateReceiveCount + 1 }
-//                 ]
-//               }
-//             ]
-//           },
-//           containers: [{ exitCode: Number(message.MessageId.split('-')[1]) }],
-//           createdAt: 1484155844718,
-//           startedAt: 1484155849718,
-//           stoppedAt: 1484155857691
-//         }
-//       })
-//     };
-//   });
-//
-//   var testConfig = Object.assign({}, config, {
-//     Concurrency: '5',
-//     NotifyAfterRetries: '1'
-//   });
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(testConfig).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-//     assert.equal(context.ecs.runTask.length, 4, 'four ecs.runTask requests');
-//     util.collectionsEqual(assert, context.sqs.deleteMessage, [
-//       { ReceiptHandle: '0-event' },
-//       { ReceiptHandle: '2-event' },
-//       { ReceiptHandle: '3-event' },
-//       { ReceiptHandle: '4-event' },
-//       { ReceiptHandle: '0' },
-//       { ReceiptHandle: '3' }
-//     ], ' sqs.deleteMessage for all event messages, and for expected job messages');
-//     util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
-//       { ReceiptHandle: '2', VisibilityTimeout: 8 },
-//       { ReceiptHandle: '4', VisibilityTimeout: 2 }
-//     ], 'expected sqs.changeMessageVisibility requests');
-//     util.collectionsEqual(assert, context.sns.publish, [
-//       {
-//         Subject: config.StackName + ' failed processing message finish-2',
-//         Message: 'At ${date}, processing message finish-2 failed on ' + config.StackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: 2\n\nMessage information:\nMessageId: finish-2\nSubject: subject2\nMessage: message2\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 3\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 3120b788edc53b003f3ebb8afc557f07\n'
-//       },
-//       {
-//         Subject: config.StackName + ' failed processing message finish-3',
-//         Message: 'At ${date}, processing message finish-3 failed on ' + config.StackName + '\n\nTask outcome: delete & notify\n\nTask stopped reason: 3\n\nMessage information:\nMessageId: finish-3\nSubject: subject3\nMessage: message3\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 496a1bbc7db7ef69c5b024bed0fa66e7\n'
-//       }
-//     ], 'expected sns.publish requests');
-//
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] message completion error', function(assert) {
-//   var context = this;
-//
-//   context.sqs.messages = [
-//     { MessageId: 'finish-0', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject0', Message: 'message0' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
-//   ];
-//
-//   context.sqs.eventMessages = context.sqs.messages.map((message) => {
-//     return {
-//       MessageId: `${message.MessageId}-event`,
-//       ReceiptHandle: `${message.ReceiptHandle}-event`,
-//       Attributes: {
-//         SentTimestamp: message.Attributes.SentTimestamp,
-//         ApproximateReceiveCount: 0
-//       },
-//       Body: JSON.stringify({
-//         detail: {
-//           clusterArn: 'cluster-arn',
-//           containerInstanceArn: 'instance-arn',
-//           taskArn: util.expectedArn(message, config.TaskDefinition, config.ContainerName, config.StackName),
-//           lastStatus: 'STOPPED',
-//           stoppedReason: message.MessageId.split('-')[1],
-//           overrides: {
-//             containerOverrides: [
-//               {
-//                 environment: [
-//                   { name: 'MessageId', value: message.MessageId },
-//                   { name: 'Subject', value: JSON.parse(message.Body).Subject },
-//                   { name: 'Message', value: JSON.parse(message.Body).Message },
-//                   { name: 'SentTimestamp', value: message.Attributes.SentTimestamp },
-//                   { name: 'ApproximateFirstReceiveTimestamp', value: message.Attributes.ApproximateFirstReceiveTimestamp },
-//                   { name: 'ApproximateReceiveCount', value: message.Attributes.ApproximateReceiveCount + 1 }
-//                 ]
-//               }
-//             ]
-//           },
-//           containers: [{ exitCode: Number(message.MessageId.split('-')[1]) }],
-//           createdAt: 1484155844718,
-//           startedAt: 1484155849718,
-//           stoppedAt: 1484155857691
-//         }
-//       })
-//     };
-//   });
-//
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
-//     assert.equal(context.ecs.runTask.length, 1, 'one ecs.runTask requests');
-//     assert.equal(context.sqs.changeMessageVisibility.length, 0, 'no sqs.changeMessageVisibility requests');
-//     var errorMsg = context.logs.find(function(log) {
-//       return /Mock SQS error/.test(log);
-//     });
-//     assert.ok(errorMsg, 'logged error');
-//     util.collectionsEqual(assert, context.sqs.deleteMessage, [
-//       { ReceiptHandle: 'error' }, { ReceiptHandle: 'error-event' }
-//     ], 'expected sqs.deleteMessage request');
-//
-//     util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
-//     assert.end();
-//   });
-// });
-//
-// util.mock('[main] LogLevel', function(assert){
-//   config.LogLevel = 'debug';
-//   var context = this;
-//   setTimeout(watchbot.main.end, 1800);
-//   watchbot.main(config).on('finish', function() {
-//     assert.ok(context.logs.find(function(log) {
-//       return /\[debug\]/.test(log);
-//     }), 'logs debug messages');
-//     delete config.LogLevel;
-//     assert.end();
-//   });
-// });
+util.mock('[main] message polling error', function(assert) {
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: 'error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0 } }
+  ];
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+    var errorMsg = context.logs.find(function(log) {
+      return /Mock SQS error/.test(log);
+    });
+    assert.deepEqual(context.sns.publish, [], 'sent no error notification');
+    assert.ok(errorMsg, 'logged error message');
+    assert.end();
+  });
+});
+
+util.mock('[main] nothing to do', function(assert) {
+  var context = this;
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+    assert.end();
+  });
+});
+
+util.mock('[main] run a task', function(assert) {
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+    assert.deepEqual(context.ecs.runTask, [
+      {
+        startedBy: config.StackName,
+        taskDefinition: config.TaskDefinition,
+        overrides: {
+          containerOverrides: [
+            {
+              name: config.ContainerName,
+              environment: [
+                { name: 'MessageId', value: '1' },
+                { name: 'Subject', value: 'subject1' },
+                { name: 'Message', value: 'message1' },
+                { name: 'SentTimestamp', value: '10' },
+                { name: 'ApproximateFirstReceiveTimestamp', value: '20' },
+                { name: 'ApproximateReceiveCount', value: '1' }
+              ]
+            }
+          ]
+        }
+      }
+    ], 'expected ecs.runTask request');
+    assert.end();
+  });
+});
+
+util.mock('[main] task running error', function(assert) {
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: 'ecs-error', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+    assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
+    assert.ok(context.logs.find(function(log) {
+      return /Mock ECS error/.test(log);
+    }), 'printed error message');
+
+    util.collectionsEqual(assert, context.sns.publish, [
+      {
+        Subject: config.StackName + ' failed processing message ecs-error',
+        Message: 'At ${date}, processing message ecs-error failed on ' + config.StackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: Mock ECS error\n\nMessage information:\nMessageId: ecs-error\nSubject: subject1\nMessage: message1\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: undefined\nInstance ARN: undefined\nTask ARN: undefined\n'
+      }
+    ], 'sent expected error notification');
+    util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
+      { ReceiptHandle: '1', VisibilityTimeout: 2 }
+    ], 'expected sqs.changeMessageVisibility requests');
+    assert.end();
+  });
+});
+
+util.mock('[main] task running failure (out of memory)', function(assert) {
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: 'ecs-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+    assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
+    assert.deepEqual(context.sns.publish, [], 'does not send failure notification');
+    util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
+      { ReceiptHandle: '1', VisibilityTimeout: 2 }
+    ], 'expected sqs.changeMessageVisibility requests');
+    assert.end();
+  });
+});
+
+util.mock('[main] task running failure (unrecognized reason)', function(assert) {
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: 'ecs-unrecognized', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+    assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
+    assert.deepEqual(context.sns.publish, [], 'does not send failure notification');
+    util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
+      { ReceiptHandle: '1', VisibilityTimeout: 2 }
+    ], 'expected sqs.changeMessageVisibility requests');
+    assert.end();
+  });
+});
+
+util.mock('[main] message completion error after task run failure', function(assert) {
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: 'ecs-error', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+    assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
+    assert.ok(context.logs.find(function(log) {
+      return /Mock ECS error/.test(log);
+    }), 'printed error message');
+    util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
+    util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
+      { ReceiptHandle: 'error', VisibilityTimeout: 2 }
+    ], 'expected sqs.changeMessageVisibility requests');
+    assert.end();
+  });
+});
+
+util.mock('[main] task polling error', function(assert) {
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: 'task-failure', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  context.sqs.eventMessages = [
+    { MessageId: 'error', Attributes: { ApproximateReceiveCount: 0 } }
+  ];
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+    assert.equal(context.ecs.runTask.length, 1, '1 ecs.runTask request');
+    assert.ok(context.logs.find(function(log) {
+      return /Mock SQS error/.test(log);
+    }), 'printed error message');
+    assert.deepEqual(context.sns.publish, [], 'sent no error notification');
+    assert.end();
+  });
+});
+
+util.mock('[main] no free tasks', function(assert) {
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: '2', ReceiptHandle: '2', Body: JSON.stringify({ Subject: 'subject2', Message: 'message2' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: '3', ReceiptHandle: '3', Body: JSON.stringify({ Subject: 'subject3', Message: 'message3' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: '4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 1, 'one sqs.receiveMessage requests');
+    assert.equal(context.ecs.runTask.length, 3, 'three ecs.runTask requests');
+    assert.end();
+  });
+});
+
+util.mock('[main] manage messages for completed tasks', function(assert) {
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: 'finish-0', ReceiptHandle: '0', Body: JSON.stringify({ Subject: 'subject0', Message: 'message0' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: 'finish-2', ReceiptHandle: '2', Body: JSON.stringify({ Subject: 'subject2', Message: 'message2' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 2, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: 'finish-3', ReceiptHandle: '3', Body: JSON.stringify({ Subject: 'subject3', Message: 'message3' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
+    { MessageId: 'finish-4', ReceiptHandle: '4', Body: JSON.stringify({ Subject: 'subject4', Message: 'message4' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  context.sqs.eventMessages = context.sqs.messages.map((message) => {
+    return {
+      MessageId: `${message.MessageId}-event`,
+      ReceiptHandle: `${message.ReceiptHandle}-event`,
+      Attributes: {
+        SentTimestamp: message.Attributes.SentTimestamp,
+        ApproximateReceiveCount: 0
+      },
+      Body: JSON.stringify({
+        detail: {
+          clusterArn: 'cluster-arn',
+          containerInstanceArn: 'instance-arn',
+          taskArn: util.expectedArn(message, config.TaskDefinition, config.ContainerName, config.StackName),
+          lastStatus: 'STOPPED',
+          stoppedReason: message.MessageId.split('-')[1],
+          overrides: {
+            containerOverrides: [
+              {
+                environment: [
+                  { name: 'MessageId', value: message.MessageId },
+                  { name: 'Subject', value: JSON.parse(message.Body).Subject },
+                  { name: 'Message', value: JSON.parse(message.Body).Message },
+                  { name: 'SentTimestamp', value: message.Attributes.SentTimestamp },
+                  { name: 'ApproximateFirstReceiveTimestamp', value: message.Attributes.ApproximateFirstReceiveTimestamp },
+                  { name: 'ApproximateReceiveCount', value: message.Attributes.ApproximateReceiveCount + 1 }
+                ]
+              }
+            ]
+          },
+          containers: [{ exitCode: Number(message.MessageId.split('-')[1]) }],
+          createdAt: 1484155844718,
+          startedAt: 1484155849718,
+          stoppedAt: 1484155857691
+        }
+      })
+    };
+  });
+
+  var testConfig = Object.assign({}, config, {
+    Concurrency: '5',
+    NotifyAfterRetries: '1'
+  });
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(testConfig).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+    assert.equal(context.ecs.runTask.length, 4, 'four ecs.runTask requests');
+    util.collectionsEqual(assert, context.sqs.deleteMessage, [
+      { ReceiptHandle: '0-event' },
+      { ReceiptHandle: '2-event' },
+      { ReceiptHandle: '3-event' },
+      { ReceiptHandle: '4-event' },
+      { ReceiptHandle: '0' },
+      { ReceiptHandle: '3' }
+    ], ' sqs.deleteMessage for all event messages, and for expected job messages');
+    util.collectionsEqual(assert, context.sqs.changeMessageVisibility, [
+      { ReceiptHandle: '2', VisibilityTimeout: 8 },
+      { ReceiptHandle: '4', VisibilityTimeout: 2 }
+    ], 'expected sqs.changeMessageVisibility requests');
+    util.collectionsEqual(assert, context.sns.publish, [
+      {
+        Subject: config.StackName + ' failed processing message finish-2',
+        Message: 'At ${date}, processing message finish-2 failed on ' + config.StackName + '\n\nTask outcome: return & notify\n\nTask stopped reason: 2\n\nMessage information:\nMessageId: finish-2\nSubject: subject2\nMessage: message2\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 3\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 3120b788edc53b003f3ebb8afc557f07\n'
+      },
+      {
+        Subject: config.StackName + ' failed processing message finish-3',
+        Message: 'At ${date}, processing message finish-3 failed on ' + config.StackName + '\n\nTask outcome: delete & notify\n\nTask stopped reason: 3\n\nMessage information:\nMessageId: finish-3\nSubject: subject3\nMessage: message3\nSentTimestamp: 10\nApproximateFirstReceiveTimestamp: 20\nApproximateReceiveCount: 1\n\nRuntime resources:\nCluster ARN: cluster-arn\nInstance ARN: instance-arn\nTask ARN: 496a1bbc7db7ef69c5b024bed0fa66e7\n'
+      }
+    ], 'expected sns.publish requests');
+
+    assert.end();
+  });
+});
+
+util.mock('[main] message completion error', function(assert) {
+  var context = this;
+
+  context.sqs.messages = [
+    { MessageId: 'finish-0', ReceiptHandle: 'error', Body: JSON.stringify({ Subject: 'subject0', Message: 'message0' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+  ];
+
+  context.sqs.eventMessages = context.sqs.messages.map((message) => {
+    return {
+      MessageId: `${message.MessageId}-event`,
+      ReceiptHandle: `${message.ReceiptHandle}-event`,
+      Attributes: {
+        SentTimestamp: message.Attributes.SentTimestamp,
+        ApproximateReceiveCount: 0
+      },
+      Body: JSON.stringify({
+        detail: {
+          clusterArn: 'cluster-arn',
+          containerInstanceArn: 'instance-arn',
+          taskArn: util.expectedArn(message, config.TaskDefinition, config.ContainerName, config.StackName),
+          lastStatus: 'STOPPED',
+          stoppedReason: message.MessageId.split('-')[1],
+          overrides: {
+            containerOverrides: [
+              {
+                environment: [
+                  { name: 'MessageId', value: message.MessageId },
+                  { name: 'Subject', value: JSON.parse(message.Body).Subject },
+                  { name: 'Message', value: JSON.parse(message.Body).Message },
+                  { name: 'SentTimestamp', value: message.Attributes.SentTimestamp },
+                  { name: 'ApproximateFirstReceiveTimestamp', value: message.Attributes.ApproximateFirstReceiveTimestamp },
+                  { name: 'ApproximateReceiveCount', value: message.Attributes.ApproximateReceiveCount + 1 }
+                ]
+              }
+            ]
+          },
+          containers: [{ exitCode: Number(message.MessageId.split('-')[1]) }],
+          createdAt: 1484155844718,
+          startedAt: 1484155849718,
+          stoppedAt: 1484155857691
+        }
+      })
+    };
+  });
+
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.equal(context.sqs.receiveMessage.length, 2, 'two sqs.receiveMessage requests');
+    assert.equal(context.ecs.runTask.length, 1, 'one ecs.runTask requests');
+    assert.equal(context.sqs.changeMessageVisibility.length, 0, 'no sqs.changeMessageVisibility requests');
+    var errorMsg = context.logs.find(function(log) {
+      return /Mock SQS error/.test(log);
+    });
+    assert.ok(errorMsg, 'logged error');
+    util.collectionsEqual(assert, context.sqs.deleteMessage, [
+      { ReceiptHandle: 'error' }, { ReceiptHandle: 'error-event' }
+    ], 'expected sqs.deleteMessage request');
+
+    util.collectionsEqual(assert, context.sns.publish, [], 'sent no error notifications');
+    assert.end();
+  });
+});
+
+util.mock('[main] LogLevel', function(assert){
+  config.LogLevel = 'debug';
+  var context = this;
+  setTimeout(watchbot.main.end, 1800);
+  watchbot.main(config).on('finish', function() {
+    assert.ok(context.logs.find(function(log) {
+      return /\[debug\]/.test(log);
+    }), 'logs debug messages');
+    delete config.LogLevel;
+    assert.end();
+  });
+});
 
 util.mock('[main] duplicated receives', function(assert) {
   var context = this;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -380,7 +380,7 @@ util.mock('[main] duplicated receives', function(assert) {
     { MessageId: '8', ReceiptHandle: '8', Body: JSON.stringify({ Subject: 'subject8', Message: 'message8' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
     { MessageId: '9', ReceiptHandle: '9', Body: JSON.stringify({ Subject: 'subject9', Message: 'message9' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
     { MessageId: '10', ReceiptHandle: '10', Body: JSON.stringify({ Subject: 'subject10', Message: 'message10' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } },
-    { MessageId: '1', ReceiptHandle: '1', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 0, ApproximateFirstReceiveTimestamp: 20 } }
+    { MessageId: '1', ReceiptHandle: '11', Body: JSON.stringify({ Subject: 'subject1', Message: 'message1' }), Attributes: { SentTimestamp: 10, ApproximateReceiveCount: 1, ApproximateFirstReceiveTimestamp: 20 } }
   ];
 
   setTimeout(watchbot.main.end, 1800);
@@ -391,6 +391,12 @@ util.mock('[main] duplicated receives', function(assert) {
     assert.deepEqual(context.ecs.stopTask, [
       { task: '3b80fe64b7d8278090a63a16e5908ad9' }
     ], 'called stopTask on the right task arn');
+    assert.deepEqual(context.sqs.changeMessageVisibility, [
+      {
+        ReceiptHandle: '11',
+        VisibilityTimeout: Math.pow(2, 2)
+      }
+    ], 'returns the message to SQS, using the new receipt handle');
     assert.end();
   });
 });

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -102,9 +102,20 @@ util.mock('[messages] poll - message still processing', function(assert) {
     // receive the same message again, with a new handle
     context.sqs.messages = [JSON.parse(JSON.stringify(msg))];
     context.sqs.messages[0].ReceiptHandle = '2';
-    messages.poll(1, function(err) {
+    messages.poll(1, function(err, envs, skips) {
       if (err) return assert.end(err);
 
+      assert.deepEqual(skips, [
+        {
+          MessageId: '1',
+          Subject: 'subject1',
+          Message: 'message1',
+          SentTimestamp: '10',
+          ApproximateFirstReceiveTimestamp: '20',
+          ApproximateReceiveCount: '1'
+        }
+      ], 'provides a record of skipped message');
+      
       // complete the message
       messages.complete({ reason: 'success', env: { MessageId: '1' }, outcome: 'delete' }, function(err) {
         if (err) return assert.end(err);

--- a/test/util.js
+++ b/test/util.js
@@ -174,7 +174,8 @@ module.exports.mock = function(name, callback) {
         return callback(null, { tasks: [{ lastStatus: 'RUNNING' }] });
 
       if (params.tasks[0] === '9f5d92d144855210733d560d83759e11'
-          || params.tasks[0] === 'e3278f8cf0a7f9b795d5f91d3739f72d')
+          || params.tasks[0] === 'e3278f8cf0a7f9b795d5f91d3739f72d'
+          || params.tasks[0] === '3b80fe64b7d8278090a63a16e5908ad9')
         return callback(null, { tasks: [{ lastStatus: 'PENDING' }] });
 
       callback();
@@ -186,7 +187,8 @@ module.exports.mock = function(name, callback) {
       if (params.task === '9f5d92d144855210733d560d83759e11')
         return callback(new Error('stop-task-failure'));
 
-      if (params.task === 'e3278f8cf0a7f9b795d5f91d3739f72d')
+      if (params.task === 'e3278f8cf0a7f9b795d5f91d3739f72d'
+          || params.task === '3b80fe64b7d8278090a63a16e5908ad9')
         return callback();
 
       callback();

--- a/test/util.js
+++ b/test/util.js
@@ -26,6 +26,7 @@ module.exports.mock = function(name, callback) {
       },
       ecs: {
         runTask: [],
+        stopTask: [],
         describeTasks: [],
         describeTaskDefinition: [],
         describeContainerInstances: [],
@@ -161,6 +162,34 @@ module.exports.mock = function(name, callback) {
       console.log = log;
       if (err) end(err);
       else end();
+    };
+
+    AWS.ECS.prototype.describeTasks = function(params, callback) {
+      context.ecs.describeTasks.push(params);
+
+      if (params.tasks[0] === '5452a86a162f3603a9b7b5f0d3396d40')
+        return callback(new Error('pending-describe-fail'));
+
+      if (params.tasks[0] === '5328c55acbea9eb7c23336b0718f3324')
+        return callback(null, { tasks: [{ lastStatus: 'RUNNING' }] });
+
+      if (params.tasks[0] === '9f5d92d144855210733d560d83759e11'
+          || params.tasks[0] === 'e3278f8cf0a7f9b795d5f91d3739f72d')
+        return callback(null, { tasks: [{ lastStatus: 'PENDING' }] });
+
+      callback();
+    };
+
+    AWS.ECS.prototype.stopTask = function(params, callback) {
+      context.ecs.stopTask.push(params);
+
+      if (params.task === '9f5d92d144855210733d560d83759e11')
+        return callback(new Error('stop-task-failure'));
+
+      if (params.task === 'e3278f8cf0a7f9b795d5f91d3739f72d')
+        return callback();
+
+      callback();
     };
 
     callback.call(context, assert);


### PR DESCRIPTION
This PR adds logging of SQS messages that are received multiple times while a previous task is already in flight.

This is only half of what I said I'd implement in #175, but I'm second-guessing myself on the the other half, and will follow up in that ticket.