### PR TITLE
Adding us-west-1 support to watchbot

### DIFF
--- a/mappings/ecr-region.json
+++ b/mappings/ecr-region.json
@@ -2,6 +2,9 @@
     "us-east-1": {
         "Region": "us-east-1"
     },
+    "us-west-1": {
+        "Region": "us-west-1"
+    },
     "us-west-2": {
         "Region": "us-west-2"
     },


### PR DESCRIPTION
Prior to this change creating a new stack via cfn-config in us-west-1 failed with the following error:
```
Failed to create stack: ValidationError: Template error: Unable to get mapping for EcrRegion::us-west-1::Region
```

I've enabled support for just this one region if we'd like to make only minor changes. There's an alternative PR [here](https://github.com/mapbox/ecs-watchbot/pull/178) that adds every region.

