### PR TITLE
Add every* AWS region to Watchbot ECR support

### DIFF
--- a/mappings/ecr-region.json
+++ b/mappings/ecr-region.json
@@ -11,7 +11,19 @@
     "eu-west-1": {
         "Region": "eu-west-1"
     },
+    "eu-west-2": {
+        "Region": "eu-west-2"
+    },
+    "eu-west-3": {
+        "Region": "eu-west-3"
+    },
     "ap-northeast-1": {
+        "Region": "us-west-2"
+    },
+    "ap-northeast-2": {
+        "Region": "us-west-2"
+    },
+    "ap-south-1": {
         "Region": "us-west-2"
     },
     "ap-southeast-1": {
@@ -20,7 +32,25 @@
     "ap-southeast-2": {
         "Region": "us-west-2"
     },
+    "ca-central-1": {
+        "Region": "us-east-1"
+    },
+    "cn-north-1": {
+        "Region": "cn-north-1"
+    },
+    "cn-northwest-1": {
+        "Region": "cn-northwest-1"
+    },
+    "sa-east-1": {
+        "Region": "us-west-2"
+    },
     "us-east-2": {
         "Region": "us-east-1"
+    },
+    "us-gov-west-1": {
+        "Region": "us-gov-west-1"
+    },
+    "us-west-1": {
+        "Region": "us-west-2"
     }
 }

--- a/mappings/ecr-region.json
+++ b/mappings/ecr-region.json
@@ -17,12 +17,6 @@
     "ca-central-1": {
         "Region": "us-east-1"
     },
-    "cn-north-1": {
-        "Region": "cn-north-1"
-    },
-    "cn-northwest-1": {
-        "Region": "cn-northwest-1"
-    },
     "eu-central-1": {
         "Region": "eu-west-1"
     },
@@ -43,9 +37,6 @@
     },
     "us-east-2": {
         "Region": "us-east-1"
-    },
-    "us-gov-west-1": {
-        "Region": "us-gov-west-1"
     },
     "us-west-1": {
         "Region": "us-west-2"

--- a/mappings/ecr-region.json
+++ b/mappings/ecr-region.json
@@ -1,22 +1,4 @@
 {
-    "us-east-1": {
-        "Region": "us-east-1"
-    },
-    "us-west-2": {
-        "Region": "us-west-2"
-    },
-    "eu-central-1": {
-        "Region": "eu-west-1"
-    },
-    "eu-west-1": {
-        "Region": "eu-west-1"
-    },
-    "eu-west-2": {
-        "Region": "eu-west-2"
-    },
-    "eu-west-3": {
-        "Region": "eu-west-3"
-    },
     "ap-northeast-1": {
         "Region": "us-west-2"
     },
@@ -41,8 +23,23 @@
     "cn-northwest-1": {
         "Region": "cn-northwest-1"
     },
+    "eu-central-1": {
+        "Region": "eu-west-1"
+    },
+    "eu-west-1": {
+        "Region": "eu-west-1"
+    },
+    "eu-west-2": {
+        "Region": "eu-west-2"
+    },
+    "eu-west-3": {
+        "Region": "eu-west-3"
+    },
     "sa-east-1": {
         "Region": "us-west-2"
+    },
+    "us-east-1": {
+        "Region": "us-east-1"
     },
     "us-east-2": {
         "Region": "us-east-1"
@@ -51,6 +48,9 @@
         "Region": "us-gov-west-1"
     },
     "us-west-1": {
+        "Region": "us-west-2"
+    },
+    "us-west-2": {
         "Region": "us-west-2"
     }
 }


### PR DESCRIPTION
[* not adding GovCloud or China]

Because there's no Cloudformation support to provide a default value to `Fn::FindInMap` we must explicitly create a mapping for each AWS region in our ECR region map.
I've added the missing regions and for compliance-restricted locations (GovCloud, China) the mapping points to the given region (GovCloud -> GovCloud, China -> China).
For all other regions the mapping points to the geographically nearest region that already has Watchbot ECR support.

If this seems reasonable then this PR supercedes [this PR](https://github.com/mapbox/ecs-watchbot/pull/177) that only added one US region.
  