### PR TITLE
Add logging

### DIFF
--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -3,11 +3,13 @@
 'use strict';
 
 const Watcher = require('../lib/watcher');
+const Logger = require('../lib/logger');
 
 const main = async () => {
   if (process.argv[2] !== 'listen')
     throw new Error(`Invalid arguments: ${process.argv.slice(2).join(' ')}`);
 
+  const logger = Logger.create('watcher');
   const command = process.argv.slice(3).join(' ');
 
   const options = {
@@ -16,14 +18,14 @@ const main = async () => {
   };
 
   const watcher = Watcher.create(options);
-  watcher.on('error', (err) => console.log(err));
 
-  console.log(`Launching watcher for command: ${command}`);
-
-  return await watcher.listen();
+  try {
+    await watcher.listen();
+  } catch (err) {
+    logger.log(`[error] ${err.stack}`);
+  }
 };
 
 module.exports = main;
 
-if (require.main === module) main()
-  .catch((err) => console.log(err.stack));
+if (require.main === module) main();

--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ module.exports = {
   Messages: require('./lib/messages'),
   Message: require('./lib/message'),
   Worker: require('./lib/worker'),
-  Watcher: require('./lib/watcher')
+  Watcher: require('./lib/watcher'),
+  Logger: require('./lib/logger')
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const stream = require('stream');
+const split = require('binary-split');
+const combiner = require('stream-combiner2');
+
+class Logger {
+  constructor(type, message) {
+    if (type !== 'watcher' && type !== 'worker')
+      throw new Error(`Invalid logger type: ${type}`);
+
+    if (message && !(message instanceof require('./message')))
+      throw new Error('Invalid message');
+
+    this.type = type;
+    this.message = message;
+  }
+
+  messageReceived() {
+    this.log(
+      JSON.stringify({
+        subject: this.message.env.Subject,
+        message: this.message.env.Message,
+        receives: this.message.env.ApproximateReceiveCount
+      })
+    );
+  }
+
+  workerSuccess(results) {
+    this.log(JSON.stringify(results));
+  }
+
+  workerFailure(results) {
+    this.log(`[failure] ${JSON.stringify(results)}`);
+  }
+
+  workerError(err) {
+    this.log(`[error] [worker] ${err.message}`);
+  }
+
+  queueError(err) {
+    this.log(`[error] [sqs] ${err.message}`);
+  }
+
+  log(line) {
+    let leader = '';
+    leader += `[${new Date().toGMTString()}] `;
+    leader += `[${this.type}] `;
+    if (this.message) leader += `[${this.message.id}] `;
+    process.stdout.write(`${leader}${line}\n`);
+  }
+
+  stream() {
+    const writable = new stream.Writable();
+    const splitter = split();
+
+    writable._write = (line, enc, callback) => {
+      this.log(line.toString());
+      callback();
+    };
+
+    return combiner([splitter, writable]);
+  }
+
+  static create(options) {
+    return new Logger(options);
+  }
+}
+
+module.exports = Logger;

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,13 +1,11 @@
 'use strict';
 
 const url = require('url');
-const events = require('events');
 const AWS = require('aws-sdk');
+const Logger = require('./logger');
 
-class Message extends events.EventEmitter {
+class Message {
   constructor(sqsMessage = {}, options = {}) {
-    super();
-
     let valid = ['Body', 'MessageId', 'ReceiptHandle', 'Attributes'].reduce(
       (valid, key) => {
         if (!valid) return valid;
@@ -53,6 +51,8 @@ class Message extends events.EventEmitter {
       region: url.parse(options.queueUrl).host.split('.')[1],
       params: { QueueUrl: options.queueUrl }
     });
+
+    this.logger = Logger.create('watcher', this);
   }
 
   async retry() {
@@ -67,7 +67,7 @@ class Message extends events.EventEmitter {
     try {
       return await this.sqs.changeMessageVisibility(params).promise();
     } catch (err) {
-      this.emit('error', err);
+      this.logger.queueError(err);
     }
   }
 
@@ -76,7 +76,7 @@ class Message extends events.EventEmitter {
     try {
       return await this.sqs.deleteMessage(params).promise();
     } catch (err) {
-      this.emit('error', err);
+      this.logger.queueError(err);
     }
   }
 

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,14 +1,12 @@
 'use strict';
 
 const url = require('url');
-const events = require('events');
 const AWS = require('aws-sdk');
+const Logger = require('./logger');
 const Message = require('./message');
 
-class Messages extends events.EventEmitter {
+class Messages {
   constructor(options = {}) {
-    super();
-
     if (!options.queueUrl) throw new Error('Missing options: queueUrl');
     this.options = options;
 
@@ -16,6 +14,8 @@ class Messages extends events.EventEmitter {
       region: url.parse(options.queueUrl).host.split('.')[1],
       params: { QueueUrl: options.queueUrl }
     });
+
+    this.logger = Logger.create('watcher');
   }
 
   async waitFor(num = 1) {
@@ -37,15 +37,17 @@ class Messages extends events.EventEmitter {
         try {
           data = await this.sqs.receiveMessage(params).promise();
         } catch (err) {
-          this.emit('error', err);
+          this.logger.queueError(err);
           return setImmediate(poll);
         }
 
         if (!data.Messages || !data.Messages.length) return setImmediate(poll);
 
-        const messages = data.Messages.map((msg) =>
-          Message.create(msg, this.options)
-        );
+        const messages = data.Messages.map((msg) => {
+          const message = Message.create(msg, this.options);
+          message.logger.messageReceived();
+          return message;
+        });
 
         return resolve(messages);
       };

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,10 +1,9 @@
 'use strict';
 
-const events = require('events');
 const Messages = require('./messages');
 const Worker = require('./worker');
 
-class Watcher extends events.EventEmitter {
+class Watcher {
   /**
    * @name Watcher
    * @param {Object} options - configuration
@@ -12,8 +11,6 @@ class Watcher extends events.EventEmitter {
    * @param {String} options.queueUrl - the SQS queue URL
    */
   constructor(options = {}) {
-    super();
-
     if (!options.workerOptions)
       throw new Error('Missing options: workerOptions');
     if (!options.queueUrl) throw new Error('Missing options: queueUrl');
@@ -21,7 +18,6 @@ class Watcher extends events.EventEmitter {
     this.workerOptions = options.workerOptions;
     this.queueUrl = options.queueUrl;
     this.messages = Messages.create({ queueUrl: options.queueUrl });
-    this.messages.on('error', (err) => this.emit('error', err));
   }
 
   listen() {
@@ -31,20 +27,11 @@ class Watcher extends events.EventEmitter {
 
         const messages = await this.messages.waitFor();
 
-        const workers = messages.map((message) => {
-          const worker = Worker.create(message, this.workerOptions);
+        const workers = messages.map((message) =>
+          Worker.create(message, this.workerOptions).waitFor()
+        );
 
-          worker.on('error', (err) => this.emit('error', err));
-          message.on('error', (err) => this.emit('error', err));
-
-          return worker.waitFor();
-        });
-
-        try {
-          await Promise.all(workers);
-        } catch (err) {
-          this.emit('error', err);
-        }
+        await Promise.all(workers);
 
         setImmediate(loop);
       };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -4,16 +4,20 @@ const child_process = require('child_process');
 const Message = require('./message');
 const Logger = require('./logger');
 
-const child = async (command, options) =>
+const child = async (command, options, logger) =>
   new Promise((resolve, reject) => {
     const start = Date.now();
-    child_process
+
+    const child = child_process
       .spawn(command, options)
       .on('error', (err) => reject(err))
       .on('exit', (code, signal) => {
         const duration = Date.now() - start;
         resolve({ code, signal, duration });
       });
+
+    child.stdout.pipe(logger.stream());
+    child.stderr.pipe(logger.stream());
   });
 
 class Worker {
@@ -52,11 +56,11 @@ class Worker {
     const options = {
       shell: true,
       env: Object.assign({}, process.env, this.message.env),
-      stdio: 'inherit'
+      stdio: [process.stdin, 'pipe', 'pipe']
     };
 
     try {
-      const results = await child(this.command, options);
+      const results = await child(this.command, options, this.logger);
       if (results.code === 0) return await this.success(results);
       if (results.code === 3) return await this.ignore(results);
       if (results.code === 4) return await this.noop(results);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,45 +1,51 @@
 'use strict';
 
-const events = require('events');
 const child_process = require('child_process');
 const Message = require('./message');
+const Logger = require('./logger');
 
-const child = async (command, options) => new Promise((resolve, reject) => {
-  child_process.spawn(command, options)
-    .on('error', (err) => reject(err))
-    .on('exit', (code, signal) => {
-      if (code === 0) return resolve();
-      if (code === 3) return resolve();
-      if (code === 4) return reject();
+const child = async (command, options) =>
+  new Promise((resolve, reject) => {
+    const start = Date.now();
+    child_process
+      .spawn(command, options)
+      .on('error', (err) => reject(err))
+      .on('exit', (code, signal) => {
+        const duration = Date.now() - start;
+        resolve({ code, signal, duration });
+      });
+  });
 
-      const err = new Error('Unexpected worker exit code');
-      err.exitCode = code;
-      err.signal = signal;
-      return reject(err);
-    });
-});
-
-class Worker extends events.EventEmitter {
+class Worker {
   constructor(message = {}, options = {}) {
-    super();
-
     if (!(message instanceof Message))
       throw new Error('Invalid Message object');
 
-    if (!options.command)
-      throw new Error('Missing options: command');
+    if (!options.command) throw new Error('Missing options: command');
 
     this.command = options.command;
     this.message = message;
+    this.logger = Logger.create('watcher', message);
   }
 
-  async fail(err) {
-    if (err) this.emit('error', err);
+  async success(results) {
+    this.logger.workerSuccess(results);
+    return await this.message.complete();
+  }
+
+  async ignore(results) {
+    this.logger.workerSuccess(results);
+    return await this.message.complete();
+  }
+
+  async noop(results) {
+    this.logger.workerSuccess(results);
     return await this.message.retry();
   }
 
-  async success() {
-    return await this.message.complete();
+  async fail(results) {
+    this.logger.workerFailure(results);
+    return await this.message.retry();
   }
 
   async waitFor() {
@@ -50,10 +56,14 @@ class Worker extends events.EventEmitter {
     };
 
     try {
-      await child(this.command, options);
-      return await this.success();
+      const results = await child(this.command, options);
+      if (results.code === 0) return await this.success(results);
+      if (results.code === 3) return await this.ignore(results);
+      if (results.code === 4) return await this.noop(results);
+      return await this.fail(results);
     } catch (err) {
-      return await this.fail(err);
+      this.logger.workerError(err);
+      return await this.message.retry();
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "1.0.0",
+  "version": "3.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -559,6 +559,15 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "binary-split": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/binary-split/-/binary-split-1.0.3.tgz",
+      "integrity": "sha1-yqiKyNhZ0zFw9fHOa0xZCHn3UCY=",
+      "dev": true,
+      "requires": {
+        "through2": "2.0.3"
+      }
+    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -835,8 +844,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -1010,6 +1018,14 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2648,8 +2664,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -5766,8 +5781,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.0",
@@ -5890,7 +5904,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -6121,8 +6134,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
       "version": "1.3.0",
@@ -6332,6 +6344,15 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "requires": {
+        "duplexer2": "0.1.4",
+        "readable-stream": "2.3.3"
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -6367,7 +6388,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -6768,8 +6788,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/mapbox/ecs-watchbot#readme",
   "devDependencies": {
     "@mapbox/mock-aws-sdk-js": "0.0.5",
+    "binary-split": "^1.0.3",
     "eslint": "^4.16.0",
     "eslint-plugin-node": "^5.2.1",
     "jest": "^22.2.1",
@@ -39,6 +40,7 @@
   },
   "dependencies": {
     "@mapbox/cloudfriend": "^1.9.0",
-    "aws-sdk": "^2.188.0"
+    "aws-sdk": "^2.188.0",
+    "stream-combiner2": "^1.1.1"
   }
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+const test = require('tape');
+const sinon = require('sinon');
+const Logger = require('../lib/logger');
+const Message = require('../lib/message');
+
+const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789012/fake';
+const sqsMessage = {
+  MessageId: '895ab607-3767-4bbb-bd45-2a3b341cbc46',
+  ReceiptHandle: 'a',
+  Body: JSON.stringify({ Subject: 'one', Message: '1' }),
+  Attributes: {
+    SentTimestamp: '1518027533772',
+    ApproximateFirstReceiveTimestamp: '1518027533772',
+    ApproximateReceiveCount: 3
+  }
+};
+const message = new Message(sqsMessage, { queueUrl });
+
+test('[logger] constructor', (assert) => {
+  assert.throws(
+    () => new Logger('pie'),
+    /Invalid logger type/,
+    'throws error on invalid type'
+  );
+
+  assert.throws(
+    () => new Logger('watcher', {}),
+    /Invalid message/,
+    'throws error on invalid message'
+  );
+
+  assert.doesNotThrow(() => new Logger('watcher'), 'message is not required');
+
+  const logger = new Logger('worker', message);
+
+  assert.equal(logger.type, 'worker', 'sets .type');
+  assert.equal(logger.message, message, 'sets .message');
+
+  assert.end();
+});
+
+test('[logger] factory', (assert) => {
+  const logger = Logger.create('watcher');
+  assert.ok(logger instanceof Logger, 'returns a Logger object');
+  assert.end();
+});
+
+test('[logger] messageReceived', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toGMTString')
+    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger('watcher', message);
+  logger.messageReceived();
+
+  const data = process.stdout.write.args[0][0];
+  assert.equal(
+    data,
+    '[Fri, 09 Feb 2018 21:57:55 GMT] [watcher] [895ab607-3767-4bbb-bd45-2a3b341cbc46] {"subject":"one","message":"1","receives":"3"}\n',
+    'expected message'
+  );
+
+  Date.prototype.toGMTString.restore();
+  process.stdout.write.restore();
+  assert.end();
+});
+
+test('[logger] workerSuccess', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toGMTString')
+    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger('watcher', message);
+  logger.workerSuccess({ code: 0, duration: 12345 });
+
+  const data = process.stdout.write.args[0][0];
+  assert.equal(
+    data,
+    '[Fri, 09 Feb 2018 21:57:55 GMT] [watcher] [895ab607-3767-4bbb-bd45-2a3b341cbc46] {"code":0,"duration":12345}\n',
+    'expected message'
+  );
+
+  Date.prototype.toGMTString.restore();
+  process.stdout.write.restore();
+  assert.end();
+});
+
+test('[logger] workerFailure', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toGMTString')
+    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger('watcher', message);
+  logger.workerFailure({ code: 124, signal: 'SIGTERM', duration: 12345 });
+
+  const data = process.stdout.write.args[0][0];
+  assert.equal(
+    data,
+    '[Fri, 09 Feb 2018 21:57:55 GMT] [watcher] [895ab607-3767-4bbb-bd45-2a3b341cbc46] [failure] {"code":124,"signal":"SIGTERM","duration":12345}\n',
+    'expected message'
+  );
+
+  Date.prototype.toGMTString.restore();
+  process.stdout.write.restore();
+  assert.end();
+});
+
+test('[logger] workerError', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toGMTString')
+    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger('watcher', message);
+  logger.workerError(new Error('foo'));
+
+  const data = process.stdout.write.args[0][0];
+  assert.equal(
+    data,
+    '[Fri, 09 Feb 2018 21:57:55 GMT] [watcher] [895ab607-3767-4bbb-bd45-2a3b341cbc46] [error] [worker] foo\n',
+    'expected message'
+  );
+
+  Date.prototype.toGMTString.restore();
+  process.stdout.write.restore();
+  assert.end();
+});
+
+test('[logger] queueError', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toGMTString')
+    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger('watcher');
+  logger.queueError(new Error('foo'));
+
+  const data = process.stdout.write.args[0][0];
+  assert.equal(
+    data,
+    '[Fri, 09 Feb 2018 21:57:55 GMT] [watcher] [error] [sqs] foo\n',
+    'expected message'
+  );
+
+  Date.prototype.toGMTString.restore();
+  process.stdout.write.restore();
+  assert.end();
+});
+
+test('[logger] log', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toGMTString')
+    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
+  sinon.spy(process.stdout, 'write');
+
+  let logger = new Logger('worker', message);
+  logger.log('hello there');
+
+  let data = process.stdout.write.args[0][0];
+  process.stdout.write.restore();
+  assert.equal(
+    data,
+    '[Fri, 09 Feb 2018 21:57:55 GMT] [worker] [895ab607-3767-4bbb-bd45-2a3b341cbc46] hello there\n',
+    'prefixed with timestamp, type, and message id'
+  );
+
+  sinon.spy(process.stdout, 'write');
+  logger = new Logger('watcher');
+  logger.log('ok then');
+
+  data = process.stdout.write.args[0][0];
+  process.stdout.write.restore();
+  assert.equal(
+    data,
+    '[Fri, 09 Feb 2018 21:57:55 GMT] [watcher] ok then\n',
+    'prefixed with timestamp, and type'
+  );
+
+  Date.prototype.toGMTString.restore();
+  assert.end();
+});
+
+test('[logger] stream', async (assert) => {
+  sinon
+    .stub(Date.prototype, 'toGMTString')
+    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger('worker', message);
+  const writable = logger.stream();
+
+  writable.write('hello there\nhow are you');
+  writable
+    .on('finish', () => {
+      const first = process.stdout.write.args[0][0];
+      const second = process.stdout.write.args[1][0];
+      process.stdout.write.restore();
+      assert.equal(
+        first,
+        '[Fri, 09 Feb 2018 21:57:55 GMT] [worker] [895ab607-3767-4bbb-bd45-2a3b341cbc46] hello there\n',
+        'prefixed first line with timestamp, type, and message id'
+      );
+
+      assert.equal(
+        second,
+        '[Fri, 09 Feb 2018 21:57:55 GMT] [worker] [895ab607-3767-4bbb-bd45-2a3b341cbc46] how are you\n',
+        'splits on newline, prefixed second line with timestamp, type, and message id'
+      );
+
+      Date.prototype.toGMTString.restore();
+      assert.end();
+    })
+    .end();
+});

--- a/test/stubber.js
+++ b/test/stubber.js
@@ -1,15 +1,11 @@
 'use strict';
 
 const sinon = require('sinon');
+const Logger = require('../lib/logger');
 
 module.exports = (cls) => {
   const stub = sinon.createStubInstance(cls);
-
-  // spy on, don't stub, event emitter functionality
-  stub.on.restore();
-  sinon.spy(stub, 'on');
-  stub.emit.restore();
-  sinon.spy(stub, 'emit');
+  stub.logger = sinon.createStubInstance(Logger);
 
   stub.setup = () => {
     sinon.stub(cls, 'create').returns(stub);

--- a/test/template.validation.js
+++ b/test/template.validation.js
@@ -30,7 +30,7 @@ test('[template validation] defaults', async (assert) => {
 });
 
 test('[template validation] options set', async (assert) => {
-  const setsAllOptions = template( {
+  const setsAllOptions = template({
     service: 'example',
     serviceVersion: '1',
     command: 'echo hello world',


### PR DESCRIPTION
Adds some prefixed logging to #184:

- when watcher receives a message
- when a message completes
- when there's an error involving SQS
- when there's an error launching a child process
- prefixed logs for everything on child process' stdout