### PR TITLE
Move binary-split from dev to dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -563,7 +563,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/binary-split/-/binary-split-1.0.3.tgz",
       "integrity": "sha1-yqiKyNhZ0zFw9fHOa0xZCHn3UCY=",
-      "dev": true,
       "requires": {
         "through2": "2.0.3"
       }
@@ -6620,7 +6619,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true,
       "requires": {
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
@@ -7020,8 +7018,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "homepage": "https://github.com/mapbox/ecs-watchbot#readme",
   "devDependencies": {
     "@mapbox/mock-aws-sdk-js": "0.0.5",
-    "binary-split": "^1.0.3",
     "eslint": "^4.16.0",
     "eslint-plugin-node": "^5.2.1",
     "jest": "^22.2.1",
@@ -41,6 +40,7 @@
   "dependencies": {
     "@mapbox/cloudfriend": "^1.9.0",
     "aws-sdk": "^2.188.0",
+    "binary-split": "^1.0.3",
     "stream-combiner2": "^1.1.1"
   }
 }


### PR DESCRIPTION
Ran into `Error: Cannot find module 'binary-split'` when running `watchbot.log` on this branch, thinking this module needs to be a dependency.

cc: @rclark 