### PR TITLE
Scale down threshold

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -403,7 +403,7 @@ module.exports = (options = {}) => {
         StepAdjustments: [
           {
             ScalingAdjustment: -100,
-            MetricIntervalLowerBound: 0.0
+            MetricIntervalLowerBound: -1.1
           }
         ]
       }

--- a/lib/template.js
+++ b/lib/template.js
@@ -403,7 +403,7 @@ module.exports = (options = {}) => {
         StepAdjustments: [
           {
             ScalingAdjustment: -100,
-            MetricIntervalLowerBound: -1.1
+            MetricIntervalUpperBound: 0.0
           }
         ]
       }

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -233,7 +233,7 @@ Object {
           "MetricAggregationType": "Average",
           "StepAdjustments": Array [
             Object {
-              "MetricIntervalLowerBound": -1.1,
+              "MetricIntervalUpperBound": 0,
               "ScalingAdjustment": -100,
             },
           ],
@@ -737,7 +737,7 @@ Object {
           "MetricAggregationType": "Average",
           "StepAdjustments": Array [
             Object {
-              "MetricIntervalLowerBound": -1.1,
+              "MetricIntervalUpperBound": 0,
               "ScalingAdjustment": -100,
             },
           ],

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -233,7 +233,7 @@ Object {
           "MetricAggregationType": "Average",
           "StepAdjustments": Array [
             Object {
-              "MetricIntervalLowerBound": 0,
+              "MetricIntervalLowerBound": -1.1,
               "ScalingAdjustment": -100,
             },
           ],
@@ -737,7 +737,7 @@ Object {
           "MetricAggregationType": "Average",
           "StepAdjustments": Array [
             Object {
-              "MetricIntervalLowerBound": 0,
+              "MetricIntervalLowerBound": -1.1,
               "ScalingAdjustment": -100,
             },
           ],


### PR DESCRIPTION
Was getting an error from the scale down alarm

```"error": "No step adjustment found for metric value [0.0] and breach threshold 1.0",```

I think this is due to the lower bound being set at 0.0. Reading step adjustment docs, [a threshold of 1 and lowerbound of 0.0 ](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_StepAdjustment.html) is effectively only a policy for thresholds at `1.0` or above. This pr adjusts the LowerBound to include  `0.0`.

We could do this a billion ways (I think a MetricIntervalUpperBound of 0.0 would also work); I'm pretty agnostic on the cleanest way to define the step adjustment.