### PR TITLE
[WIP] Disk monitoring and quotas

### DIFF
--- a/lib/file-system.js
+++ b/lib/file-system.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const rmdir = require('fs').rmdir;
+const chmod = require('fs').chmod;
+const spawn = require('child_process').spawn;
+
 class FileSystem {
   /**
    * @name Watcher
@@ -10,6 +14,7 @@ class FileSystem {
   constructor(options = { volumes: [], autoClean: true }) {
     this.autoClean = options.autoClean;
     this.volumes = options.volumes;
+    this.maxDiskSpace = options.maxDiskSpace;
   }
 
   clean() {
@@ -26,6 +31,24 @@ class FileSystem {
     } else {
       return Promise.resolve();
     }
+  }
+
+  checkDisk() {
+    return new Promise((resolve, reject) =>
+      let output = '';
+
+      spawn('du', ['-s', '/'])
+        .on('error', (err) => reject(err))
+        .on('exit', (code, signal) => {
+          console.log(output);
+          const match = output.match(/(\d+)\s+\//);
+          const size = Number(match[1]);
+
+          if (size > this.maxDiskSpace) resolve('full');
+          resolve();
+        })
+        .stdout.on('data', (data) => output.concat(data));
+    );
   }
 
   init() {

--- a/lib/file-system.js
+++ b/lib/file-system.js
@@ -1,0 +1,47 @@
+'use strict';
+
+class FileSystem {
+  /**
+   * @name Watcher
+   * @param {Object} options - configuration
+   * @param {Array} options.volumes - array of container paths for docker volumes
+   * @param {Boolean} options.autoClean - whether or not to delete files after every worker run. default true.
+   */
+  constructor(options = { volumes: [], autoClean: true }) {
+    this.autoClean = options.autoClean;
+    this.volumes = options.volumes;
+  }
+
+  clean() {
+    if (this.autoClean) {
+      const rms = this.volumes.concat(['/tmp']).map((volume) =>
+        new Promise((resolve, reject) => {
+          rmdir(volume, (err) => {
+            if (err) return reject(err);
+            resolve();
+          });
+        });
+      );
+      return Promise.all(rms);
+    } else {
+      return Promise.resolve();
+    }
+  }
+
+  init() {
+    const chmods = this.volumes.map((volume) =>
+      new Promise((resolve, reject) => {
+        chmod(volume, 0o777, (err) => {
+          if (err) return reject(err);
+          resolve();
+        });
+      });
+    );
+
+    await Promise.all(chmods);
+  }
+
+  static create(options) {
+    return new FileSystem(options);
+  }
+}

--- a/lib/file-system.js
+++ b/lib/file-system.js
@@ -11,21 +11,21 @@ class FileSystem {
    * @param {Array} options.volumes - array of container paths for docker volumes
    * @param {Boolean} options.autoClean - whether or not to delete files after every worker run. default true.
    */
-  constructor(options = { volumes: [], autoClean: true }) {
-    this.autoClean = options.autoClean;
-    this.volumes = options.volumes;
-    this.maxDiskSpace = options.maxDiskSpace;
+  constructor(options = {}) {
+    this.autoClean = options.autoClean || true;
+    this.volumes = options.volumes || [];
+    this.maxDiskSpace = options.maxDiskSpace || 5000000;
   }
 
   clean() {
     if (this.autoClean) {
       const rms = this.volumes.concat(['/tmp']).map((volume) =>
-        new Promise((resolve, reject) => {
+        new Promise((resolve, reject) =>
           rmdir(volume, (err) => {
             if (err) return reject(err);
             resolve();
-          });
-        });
+          })
+        )
       );
       return Promise.all(rms);
     } else {
@@ -34,13 +34,14 @@ class FileSystem {
   }
 
   checkDisk() {
-    return new Promise((resolve, reject) =>
+    return new Promise((resolve, reject) => {
       let output = '';
 
       spawn('du', ['-s', '/'])
-        .on('error', (err) => reject(err))
+        .on('error', (err) => {
+          reject(err)
+        })
         .on('exit', (code, signal) => {
-          console.log(output);
           const match = output.match(/(\d+)\s+\//);
           const size = Number(match[1]);
 
@@ -48,23 +49,25 @@ class FileSystem {
           resolve();
         })
         .stdout.on('data', (data) => output.concat(data));
-    );
+    });
   }
 
-  init() {
+  async init() {
     const chmods = this.volumes.map((volume) =>
       new Promise((resolve, reject) => {
         chmod(volume, 0o777, (err) => {
           if (err) return reject(err);
           resolve();
         });
-      });
+      })
     );
 
-    await Promise.all(chmods);
+    return await Promise.all(chmods);
   }
 
   static create(options) {
     return new FileSystem(options);
   }
 }
+
+module.exports = FileSystem;

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -19,7 +19,7 @@ class Watcher {
     this.workerOptions = options.workerOptions;
     this.queueUrl = options.queueUrl;
     this.messages = Messages.create({ queueUrl: options.queueUrl });
-    this.fileSystem = FileSystem.create({ volumes: options.volumes, autoClean: options.autoClean });
+    this.fileSystem = FileSystem.create({ volumes: options.volumes, autoClean: options.autoClean, maxDiskSpace: options.maxDiskSpace });
   }
 
   listen() {
@@ -40,7 +40,18 @@ class Watcher {
         setImmediate(loop);
       };
 
+      const diskLoop = async () => {
+        if (this.stop) return resolve();
+
+        const diskStatus = await this.fileSystem.checkDisk();
+
+        if (diskStatus === 'full') return reject(new Error('The disk is full'));
+
+        setTimeout(diskLoop, 60000).unref();
+      };
+
       setImmediate(loop);
+      setImmediate(diskLoop);
     });
   }
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -2,6 +2,7 @@
 
 const Messages = require('./messages');
 const Worker = require('./worker');
+const FileSystem = require('./file-system');
 
 class Watcher {
   /**
@@ -18,9 +19,12 @@ class Watcher {
     this.workerOptions = options.workerOptions;
     this.queueUrl = options.queueUrl;
     this.messages = Messages.create({ queueUrl: options.queueUrl });
+    this.fileSystem = FileSystem.create({ volumes: options.volumes, autoClean: options.autoClean });
   }
 
   listen() {
+    await this.fileSystem.init();
+
     return new Promise((resolve) => {
       const loop = async () => {
         if (this.stop) return resolve();
@@ -28,7 +32,7 @@ class Watcher {
         const messages = await this.messages.waitFor();
 
         const workers = messages.map((message) =>
-          Worker.create(message, this.workerOptions).waitFor()
+          Worker.create(message, this.workerOptions, this.fileSystem).waitFor()
         );
 
         await Promise.all(workers);

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -19,21 +19,23 @@ class Watcher {
     this.workerOptions = options.workerOptions;
     this.queueUrl = options.queueUrl;
     this.messages = Messages.create({ queueUrl: options.queueUrl });
-    this.fileSystem = FileSystem.create({ volumes: options.volumes, autoClean: options.autoClean, maxDiskSpace: options.maxDiskSpace });
+    this.filesystem = FileSystem.create({ volumes: options.volumes, autoClean: options.autoClean, maxDiskSpace: options.maxDiskSpace });
   }
 
-  listen() {
-    await this.fileSystem.init();
+  async listen() {
+    await this.filesystem.init();
 
     return new Promise((resolve) => {
       const loop = async () => {
         if (this.stop) return resolve();
+        debugger;
 
         const messages = await this.messages.waitFor();
 
-        const workers = messages.map((message) =>
-          Worker.create(message, this.workerOptions, this.fileSystem).waitFor()
-        );
+        const workers = messages.map((message) => {
+          debugger;
+          return Worker.create(message, this.workerOptions, this.filesystem).waitFor()
+        });
 
         await Promise.all(workers);
 
@@ -43,7 +45,7 @@ class Watcher {
       const diskLoop = async () => {
         if (this.stop) return resolve();
 
-        const diskStatus = await this.fileSystem.checkDisk();
+        const diskStatus = await this.filesystem.checkDisk();
 
         if (diskStatus === 'full') return reject(new Error('The disk is full'));
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -13,7 +13,7 @@ const child = async (command, options, filesystem, logger) =>
       .on('error', (err) => reject(err))
       .on('exit', (code, signal) => {
         const duration = Date.now() - start;
-        this.filesystem.clean();
+        filesystem.clean();
         resolve({ code, signal, duration });
       });
 
@@ -28,6 +28,7 @@ class Worker {
 
     if (!options.command) throw new Error('Missing options: command');
 
+    debugger;
     this.command = options.command;
     this.message = message;
     this.filesystem = filesystem;
@@ -58,7 +59,7 @@ class Worker {
     const options = {
       shell: true,
       env: Object.assign({}, process.env, this.message.env),
-      gid: 100
+      //gid: 100,
       stdio: [process.stdin, 'pipe', 'pipe']
     };
 
@@ -74,8 +75,8 @@ class Worker {
     }
   }
 
-  static create(message, options) {
-    return new Worker(message, options);
+  static create(message, options, filesystem) {
+    return new Worker(message, options, filesystem);
   }
 }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -4,7 +4,7 @@ const child_process = require('child_process');
 const Message = require('./message');
 const Logger = require('./logger');
 
-const child = async (command, options, logger) =>
+const child = async (command, options, filesystem, logger) =>
   new Promise((resolve, reject) => {
     const start = Date.now();
 
@@ -13,6 +13,7 @@ const child = async (command, options, logger) =>
       .on('error', (err) => reject(err))
       .on('exit', (code, signal) => {
         const duration = Date.now() - start;
+        this.filesystem.clean();
         resolve({ code, signal, duration });
       });
 
@@ -21,7 +22,7 @@ const child = async (command, options, logger) =>
   });
 
 class Worker {
-  constructor(message = {}, options = {}) {
+  constructor(message = {}, options = {}, filesystem = {}) {
     if (!(message instanceof Message))
       throw new Error('Invalid Message object');
 
@@ -29,6 +30,7 @@ class Worker {
 
     this.command = options.command;
     this.message = message;
+    this.filesystem = filesystem;
     this.logger = Logger.create('watcher', message);
   }
 
@@ -56,11 +58,12 @@ class Worker {
     const options = {
       shell: true,
       env: Object.assign({}, process.env, this.message.env),
+      gid: 100
       stdio: [process.stdin, 'pipe', 'pipe']
     };
 
     try {
-      const results = await child(this.command, options, this.logger);
+      const results = await child(this.command, options, this.filesystem, this.logger);
       if (results.code === 0) return await this.success(results);
       if (results.code === 3) return await this.ignore(results);
       if (results.code === 4) return await this.noop(results);


### PR DESCRIPTION
## Background

The "♻️ that container" pull request #184 adds sizeable improvements to running high concurrency workloads without failed task placements by running multiple jobs in the same container. One major drawback of running multiple jobs in the same container is the potential buildup of files each worker would write and potentially not clean up - either out of developer missteps or hard-failing jobs.

While a disk buildup would have limited consequences in a single-tenant situation where the EC2 was only running one watchbot stack, we don't run in a single-tenant world - our EC2's run many diverse watchbot stacks with varying sensitivities to disk space. With the potential risk of one watchbot stack taking down an entire cluster of EC2 disk space, we can't merge #184 without first having some sort of safeguard in place.

Building a safeguard system for runaway disk writes could come in many shapes and colors, from passively monitoring and aborting when the disk space is too high, to restricting write access to a limited set of directories, to wiping certain directories after every job. This PR begins by trying to do all 3 of those. Before we merge this PR, we will need to make a few decisions (see **Open questions** below) and then implement those decisions in a way that's more in line with watchbot's new code patterns that what I've written.

It's worth mentioning here that volume driver options are on [ECS's mind](https://github.com/aws/amazon-ecs-agent/issues/236) and may allow us to make most of this code obsolete. Specifically if we design around inherently limited volumes and an inability to write to other filepaths, we will be able to work pretty well with volume driver options.

## Design thoughts

As a draft for what needs to be added to the codebase I think in general:

1. At watcher upstart, we need to parse options from the template, like volume paths, an `autoClean` or `persist` boolean option, a `maxDiskSpace` parameter and potentially other parameters.
2. If we want to actively poll the filesystem for usage information, we will need to kick off this polling at the very beginning.
3. If we need to create a user role that has limited access to the filesystem, we will need to create it at the very beginning and set the volume directories as explicitly writable.
4. If we want to initialize the volumes with built-in maximums (refs https://stackoverflow.com/questions/8148715/how-to-set-limit-on-directory-size-in-linux) we need to do that at watcher startup.
5. When we start worker sub-processes, we will need to start them with the user ID or group ID that unable to write anywhere but the volumes.
6. After the worker is complete, regardless of status code, we should clean the `tmp` directory and the volume drives if `autoClean` is specified to true.

## Testing locally and iterating

I was able to test the branch by deploying a watchbot stack with `workers: 0` and running `QueueUrl=<Queue url from deployed watchbot stack> ./bin/watchbot listen 'echo "hello"'`. I'm still in the middle of debugging problems - right now I still don't know if the filesystem polling is working, and it looks like the `gid: 100` wasn't working for restricting file writes successfully.

We still need to answer a bunch of higher-level questions before digging more into the code - I think most of the code so far is ill-planned, but from this initial cut most of the things we're thinking about seem technically possible to fit into watchbot's internal architecture.

## Open questions 🤔 

- **Preventing writes vs. allowing writes and monitoring** - There may be some tough developer friction with preventing any writes to non-volumes, although it would give us a clearer path for knowing that after each run we would be cleaning the only paths that containers could write to. We could decide to let users continue to write anywhere, and promise to clean volumes and `/tmp` after each job. A regular polling monitor could detect when the system is overfilled and quit, giving an appropriate error message when that happens.
- **Quota everything vs. just quota volumes** - We should decide whether we want the quota-ing system on only the volumes or on the entire filesystem. (The watchbot PR initially checks system-wide.) If we prevent writes to anywhere except the volumes, quotaing the entire filesystem would be redundant.
- **Debugging prevented writes** - How will local testing work for debugging filesystem issues? For instance if there's a program in the container that needs access to a file that's not granted to users, how will developers be able to try out different `chmod`'s without deploying?
- **Cleaning /tmp** - Should we automatically wipe the `/tmp` directory after every worker? I feel like we should do this just from the nature of the `/tmp` directory.
- **Allowing `persist` mode** - Some developers may appreciate the new value of sometimes having access to files created by the last worker, and we may want to provide a template parameter for keeping the files around after each job.
- **Deciding on default quota size** - Out of the gates I think we should make it large enough to handle most use cases - somewhere around 100GB or potentially tighter around 50 GB. Enough to prevent people from shooting themselves in the foot.

## Next actions

- [x] Come up with conclusions about the above questions
- [ ] If we want to prevent writes, we need to figure out what user or group id would have read-only permissions on all of the filesystem - I was hoping we could do this with a default linux group ID, but we may need to create a user at worker upstart. It seems like `gid: 100` didn't work in my initial attempts at running an `echo` command - it gave errors about permissions even with that.
- [ ] Test out `mount`-related commands on the volumes (refs https://stackoverflow.com/questions/8148715/how-to-set-limit-on-directory-size-in-linux) to see if they will work for quota-ing the volume sizes.
- [ ] Build the parameters for switching between "perisist" mode and "autoClean" modes so users can specify whether they want watchbot to keep files in volumes rather than cleaning them.

cc/ @brendanmcfarland @tapasweni-pathak @rclark @yhahn @arunasank 