### PR TITLE
Add options for tagging watchbot-progress dynamodb tables

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -1022,7 +1022,7 @@ function reduce(prefixed, resources, options, references) {
     readCapacityUnits: options.readCapacityUnits,
     writeCapacityUnits: options.writeCapacityUnits
   };
-  resources[prefixed('ProgressTable')] = table(tableName, tableThroughput, options.tableTags);
+  resources[prefixed('ProgressTable')] = table(tableName, tableThroughput, null, options.tableTags);
 
   var tableArn = cf.join(['arn:aws:dynamodb:', cf.region, ':', cf.accountId, ':table/', cf.ref(prefixed('ProgressTable'))]);
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -61,6 +61,8 @@ var table = require('@mapbox/watchbot-progress').table;
  * per second to DynamoDB table in reduce-mode
  * @param {number|ref} [options.writeCapacityUnits=30] - approximate number of writes
  * per second to DynamoDB table in reduce-mode
+ * @param {string|ref} [options.tableTags=''] - tags to add to the dynamodb table
+ * in reduce-mode
  * @param {number|ref} [options.watchers=1] - the number of watcher containers
  * to run. Each watcher container reads from SQS and spawns worker containers
  * when messages arrive. Each watcher is responsible for spawning and monitoring
@@ -1020,7 +1022,7 @@ function reduce(prefixed, resources, options, references) {
     readCapacityUnits: options.readCapacityUnits,
     writeCapacityUnits: options.writeCapacityUnits
   };
-  resources[prefixed('ProgressTable')] = table(tableName, tableThroughput);
+  resources[prefixed('ProgressTable')] = table(tableName, tableThroughput, options.tableTags);
 
   var tableArn = cf.join(['arn:aws:dynamodb:', cf.region, ':', cf.accountId, ':table/', cf.ref(prefixed('ProgressTable'))]);
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@mapbox/cloudfriend": "^1.8.2",
-    "@mapbox/watchbot-progress": "^1.1.3",
+    "@mapbox/watchbot-progress": "https://github.com/mapbox/watchbot-progress/tarball/add-tag-options",
     "aws-sdk": "^2.4.11",
     "binary-split": "^1.0.2",
     "cwlogs": "^1.0.2",


### PR DESCRIPTION
Adds an extra `tableTags` parameter for tagging the watchbot-progress table.

Still needs verification that this works on a watchbot stack.

cc/ @emilymcafee @taraadiseshan @tapasweni-pathak @arunasank @brendanmcfarland @kellyoung 