### PR TITLE
Fresh mode: Gracefully exit from the container when a batch of jobs finish processing.

### DIFF
--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -14,7 +14,7 @@ const main = async () => {
 
   const options = {
     queueUrl: process.env.QueueUrl,
-    fresh: process.env.fresh,
+    fresh: process.env.fresh === 'true' ? true : false,
     workerOptions: { command }
   };
 

--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -24,7 +24,7 @@ const main = async () => {
   } catch (err) {
     logger.log(`[error] ${err.stack}`);
   }
-  console.log('exiting now. bye!');
+  logger.log('exiting now. bye!');
 };
 
 module.exports = main;

--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -24,6 +24,7 @@ const main = async () => {
   } catch (err) {
     logger.log(`[error] ${err.stack}`);
   }
+  console.log('exiting now. bye!');
 };
 
 module.exports = main;

--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -24,7 +24,6 @@ const main = async () => {
   } catch (err) {
     logger.log(`[error] ${err.stack}`);
   }
-  logger.log('exiting now. bye!');
 };
 
 module.exports = main;

--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -14,6 +14,7 @@ const main = async () => {
 
   const options = {
     queueUrl: process.env.QueueUrl,
+    fresh: process.env.fresh,
     workerOptions: { command }
   };
 

--- a/lib/message.js
+++ b/lib/message.js
@@ -74,7 +74,6 @@ class Message {
   async complete() {
     const params = { ReceiptHandle: this.handle };
     try {
-      this.logger.log('Message finished processing');
       return await this.sqs.deleteMessage(params).promise();
     } catch (err) {
       this.logger.queueError(err);

--- a/lib/message.js
+++ b/lib/message.js
@@ -74,7 +74,7 @@ class Message {
   async complete() {
     const params = { ReceiptHandle: this.handle };
     try {
-      this.logger.log('[message]: Message finished processing');
+      this.logger.log('Message finished processing');
       return await this.sqs.deleteMessage(params).promise();
     } catch (err) {
       this.logger.queueError(err);

--- a/lib/message.js
+++ b/lib/message.js
@@ -74,6 +74,7 @@ class Message {
   async complete() {
     const params = { ReceiptHandle: this.handle };
     try {
+      this.logger.log('[message]: Message finished processing');
       return await this.sqs.deleteMessage(params).promise();
     } catch (err) {
       this.logger.queueError(err);

--- a/lib/template.js
+++ b/lib/template.js
@@ -122,6 +122,7 @@ module.exports = (options = {}) => {
       minSize: 0,
       mounts: '',
       privileged: false,
+      fresh: false,
       family: options.service,
       errorThreshold: 10,
       alarmThreshold: 40,
@@ -142,7 +143,8 @@ module.exports = (options = {}) => {
       },
       [
         { Name: 'WorkTopic', Value: cf.ref(prefixed('Topic')) },
-        { Name: 'QueueUrl', Value: cf.ref(prefixed('Queue')) }
+        { Name: 'QueueUrl', Value: cf.ref(prefixed('Queue')) },
+        { Name: 'fresh', Value: options.fresh }
       ]
     );
   };

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -32,7 +32,7 @@ class Watcher {
           Worker.create(message, this.workerOptions).waitFor()
         );
         await Promise.all(workers);
-        console.log('fresh ', this.freshMode);
+        console.log('fresh ', this.freshMode, typeof this.freshMode);
         if (this.freshMode) {
           console.log('in fresh mode');
           resolve();

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -31,7 +31,7 @@ class Watcher {
           Worker.create(message, this.workerOptions).waitFor()
         );
         await Promise.all(workers);
-        console.log('finished processing workers');
+        process.stdout.write('finished processing workers');
         resolve();
       };
       setImmediate(loop);

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -32,7 +32,11 @@ class Watcher {
           Worker.create(message, this.workerOptions).waitFor()
         );
         await Promise.all(workers);
-        return this.freshMode ? resolve() : setImmediate(loop);
+        if (this.freshMode) {
+          resolve();
+        } else {
+          setImmediate(loop);
+        }
       };
       setImmediate(loop);
     });

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -18,6 +18,7 @@ class Watcher {
     this.workerOptions = options.workerOptions;
     this.queueUrl = options.queueUrl;
     this.messages = Messages.create({ queueUrl: options.queueUrl });
+    this.freshMode = options.fresh;
   }
 
   listen() {
@@ -31,8 +32,7 @@ class Watcher {
           Worker.create(message, this.workerOptions).waitFor()
         );
         await Promise.all(workers);
-        process.stdout.write('finished processing workers');
-        resolve();
+        return this.freshMode ? resolve() : setImmediate(loop);
       };
       setImmediate(loop);
     });

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -2,7 +2,6 @@
 
 const Messages = require('./messages');
 const Worker = require('./worker');
-const Logger = require('./logger');
 
 class Watcher {
   /**
@@ -19,7 +18,6 @@ class Watcher {
     this.workerOptions = options.workerOptions;
     this.queueUrl = options.queueUrl;
     this.messages = Messages.create({ queueUrl: options.queueUrl });
-    this.logger = Logger.create('watcher', this);
   }
 
   listen() {
@@ -28,15 +26,14 @@ class Watcher {
         if (this.stop) return resolve();
 
         const messages = await this.messages.waitFor();
-        this.logger.log('[watcher]: Initialising workers.');
+
         const workers = messages.map((message) =>
           Worker.create(message, this.workerOptions).waitFor()
         );
         await Promise.all(workers);
-        this.logger.log('[watcher]: Finished processing workers');
+        process.stdout.write('finished processing workers');
         resolve();
       };
-      this.logger.log('[watcher]: Starting the loop');
       setImmediate(loop);
     });
   }

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -30,9 +30,8 @@ class Watcher {
         const workers = messages.map((message) =>
           Worker.create(message, this.workerOptions).waitFor()
         );
-
         await Promise.all(workers);
-        process.exit();
+        resolve();
       };
       setImmediate(loop);
     });

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -32,6 +32,7 @@ class Watcher {
           Worker.create(message, this.workerOptions).waitFor()
         );
         await Promise.all(workers);
+        console.log('fresh ', this.freshMode);
         if (this.freshMode) {
           resolve();
         } else {

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -34,8 +34,10 @@ class Watcher {
         await Promise.all(workers);
         console.log('fresh ', this.freshMode);
         if (this.freshMode) {
+          console.log('in fresh mode');
           resolve();
         } else {
+          console.log('clling setImmediate');
           setImmediate(loop);
         }
       };

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -32,14 +32,7 @@ class Watcher {
           Worker.create(message, this.workerOptions).waitFor()
         );
         await Promise.all(workers);
-        console.log('fresh ', this.freshMode, typeof this.freshMode);
-        if (this.freshMode) {
-          console.log('in fresh mode');
-          resolve();
-        } else {
-          console.log('clling setImmediate');
-          setImmediate(loop);
-        }
+        return this.freshMode ? resolve() : setImmediate(loop);
       };
       setImmediate(loop);
     });

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -31,6 +31,7 @@ class Watcher {
           Worker.create(message, this.workerOptions).waitFor()
         );
         await Promise.all(workers);
+        console.log('finished processing workers');
         resolve();
       };
       setImmediate(loop);

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -32,10 +32,8 @@ class Watcher {
         );
 
         await Promise.all(workers);
-
-        setImmediate(loop);
+        process.exit();
       };
-
       setImmediate(loop);
     });
   }

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -2,6 +2,7 @@
 
 const Messages = require('./messages');
 const Worker = require('./worker');
+const Logger = require('./logger');
 
 class Watcher {
   /**
@@ -18,6 +19,7 @@ class Watcher {
     this.workerOptions = options.workerOptions;
     this.queueUrl = options.queueUrl;
     this.messages = Messages.create({ queueUrl: options.queueUrl });
+    this.logger = Logger.create('watcher', this);
   }
 
   listen() {
@@ -26,14 +28,15 @@ class Watcher {
         if (this.stop) return resolve();
 
         const messages = await this.messages.waitFor();
-
+        this.logger.log('[watcher]: Initialising workers.');
         const workers = messages.map((message) =>
           Worker.create(message, this.workerOptions).waitFor()
         );
         await Promise.all(workers);
-        process.stdout.write('finished processing workers');
+        this.logger.log('[watcher]: Finished processing workers');
         resolve();
       };
+      this.logger.log('[watcher]: Starting the loop');
       setImmediate(loop);
     });
   }

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -510,6 +510,10 @@ Object {
                 },
               },
               Object {
+                "Name": "fresh",
+                "Value": false,
+              },
+              Object {
                 "Name": "MyKey",
                 "Value": "MyValue",
               },
@@ -1145,6 +1149,10 @@ Object {
                 "Value": Object {
                   "Ref": "WatchbotQueue",
                 },
+              },
+              Object {
+                "Name": "fresh",
+                "Value": false,
               },
             ],
             "Image": Object {

--- a/test/bin.watchbot.test.js
+++ b/test/bin.watchbot.test.js
@@ -22,7 +22,8 @@ test('[bin.watchbot] success', async (assert) => {
   assert.ok(
     Watcher.create.calledWith({
       queueUrl: 'https://faker',
-      workerOptions: { command: 'echo hello world' }
+      workerOptions: { command: 'echo hello world' },
+      fresh: false
     }),
     'watcher created with expected arguments'
   );

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -84,8 +84,14 @@ test('[watcher] listen', async (assert) => {
   const message2 = sinon.createStubInstance(Message);
 
   messages.waitFor
-    .onCall(0)
-    .returns(Promise.resolve([message1, message2]));
+    .returns(Promise.resolve([]))
+    .onCall(1)
+    .returns(Promise.resolve([message1, message2]))
+    .onCall(2)
+    .callsFake(() => {
+      watcher.stop = true;
+      return Promise.resolve([]);
+    });
 
   worker.waitFor.returns(Promise.resolve());
 

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -55,7 +55,8 @@ test('[watcher] listens exactly once', async (assert) => {
 
   const watcher = new Watcher({
     queueUrl: 'https://faker',
-    workerOptions: { command: 'echo hello world' }
+    workerOptions: { command: 'echo hello world' },
+    fresh: true
   });
 
   await watcher.listen();

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -8,6 +8,7 @@ const Watcher = require('../lib/watcher');
 const Message = require('../lib/message');
 const Messages = require('../lib/messages');
 const Worker = require('../lib/worker');
+
 test('[watcher] constructor', (assert) => {
   const messages = stubber(Messages).setup();
 
@@ -68,7 +69,6 @@ test('[watcher] listens exactly once', async (assert) => {
 });
 
 test('[watcher] listen', async (assert) => {
-  let count = 0;
 
   const messages = stubber(Messages).setup();
   const worker = stubber(Worker).setup();
@@ -91,7 +91,7 @@ test('[watcher] listen', async (assert) => {
   try {
     await watcher.listen();
   } catch (err) {
-    assert.ifError(err, 'blahblah');
+    assert.ifError(err, 'failed');
   }
 
   assert.ok(


### PR DESCRIPTION
Fixes https://github.com/mapbox/ecs-watchbot/issues/190 when done.

# TODO
* [x] Exit after workers are done running in `watcher.js`
* [x] Write tests to mock the entire workflow and make sure that `process.exit()` is called at the end of each container run.
* [x] Confirm that this code runs on ecs-telephone
* [x] Load test with a watchbot stack with high concurrency and fast tasks to look at failed task placement metrics

cc/ @mapbox/platform-engine-room 