### PR TITLE
Restrict writes to tmp and clean after every worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
 - '8'
+services:
+- docker

--- a/lib/template.js
+++ b/lib/template.js
@@ -62,8 +62,8 @@ module.exports = (options = {}) => {
   const mount = (mountInputs) => {
     let formatted = { container: [], host: [] };
     const mounts = {
-      mountPoints: [],
-      volumes: []
+      mountPoints: [{ ContainerPath: '/tmp', SourceVolume: 'tmp' }],
+      volumes: [{ Name: 'tmp' }]
     };
 
     if (typeof mountInputs === 'object') formatted = mountInputs;
@@ -86,11 +86,6 @@ module.exports = (options = {}) => {
       mounts.mountPoints.push({ ContainerPath: container, SourceVolume: name });
       mounts.volumes.push({ Name: name, Host: host });
     });
-
-    if (!mounts.mountPoints.length) {
-      mounts.mountPoints = undefined;
-      mounts.volumes = undefined;
-    }
 
     return mounts;
   };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -56,7 +56,8 @@ class Worker {
     const options = {
       shell: true,
       env: Object.assign({}, process.env, this.message.env),
-      stdio: [process.stdin, 'pipe', 'pipe']
+      stdio: [process.stdin, 'pipe', 'pipe'],
+      uid: 200
     };
 
     try {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const child_process = require('child_process');
+const fsExtra = require('fs-extra');
 const Message = require('./message');
 const Logger = require('./logger');
 
@@ -52,6 +53,10 @@ class Worker {
     return await this.message.retry();
   }
 
+  async cleanTmp() {
+    return fsExtra.emptyDir('/tmp');
+  }
+
   async waitFor() {
     const options = {
       shell: true,
@@ -62,6 +67,9 @@ class Worker {
 
     try {
       const results = await child(this.command, options, this.logger);
+
+      await this.cleanTmp();
+
       if (results.code === 0) return await this.success(results);
       if (results.code === 3) return await this.ignore(results);
       if (results.code === 4) return await this.noop(results);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -62,6 +62,7 @@ class Worker {
       shell: true,
       env: Object.assign({}, process.env, this.message.env),
       stdio: [process.stdin, 'pipe', 'pipe'],
+      // An arbitrarily chosen UID of a non-existent user
       uid: 200
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1486,6 +1486,16 @@
         "samsam": "1.3.0"
       }
     },
+    "fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2485,8 +2495,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growly": {
       "version": "1.3.0",
@@ -3483,6 +3492,14 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -6773,6 +6790,11 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "url": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "lint": "eslint bin lib test index.js",
-    "test": "tape test/*.test.js | tap-spec && jest test/*.jest.js",
+    "test": "docker build -q -t ecs-watchbot -f test/Dockerfile ./ && docker run -t ecs-watchbot npm run test-container",
+    "test-container": "tape test/*.test.js | tap-spec && jest test/*.jest.js",
     "validate-templates": "tape test/template.validation.js | tap-spec",
     "update-jest-snapshots": "jest -u test/*.jest.js",
     "coverage": "nyc --reporter html tape test/*.test.js && opener coverage/index.html"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@mapbox/cloudfriend": "^1.9.0",
     "aws-sdk": "^2.188.0",
     "binary-split": "^1.0.3",
+    "fs-extra": "^6.0.1",
     "stream-combiner2": "^1.1.1"
   }
 }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:8.10
+
+COPY ./package.json ./package.json
+COPY ./package-lock.json ./package-lock.json
+
+RUN npm install
+
+COPY ./ ./

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -468,6 +468,10 @@ Object {
             "MemoryReservation": 128,
             "MountPoints": Array [
               Object {
+                "ContainerPath": "/tmp",
+                "SourceVolume": "tmp",
+              },
+              Object {
                 "ContainerPath": "/data",
                 "SourceVolume": "mnt-0",
               },
@@ -492,6 +496,9 @@ Object {
           "Ref": "SoupRole",
         },
         "Volumes": Array [
+          Object {
+            "Name": "tmp",
+          },
           Object {
             "Host": Object {
               "SourcePath": "/mnt/data",
@@ -964,7 +971,12 @@ Object {
                 "awslogs-stream-prefix": "1",
               },
             },
-            "MountPoints": undefined,
+            "MountPoints": Array [
+              Object {
+                "ContainerPath": "/tmp",
+                "SourceVolume": "tmp",
+              },
+            ],
             "Name": "watchbot-example",
             "Privileged": false,
             "Ulimits": Array [
@@ -980,7 +992,11 @@ Object {
         "TaskRoleArn": Object {
           "Ref": "WatchbotRole",
         },
-        "Volumes": undefined,
+        "Volumes": Array [
+          Object {
+            "Name": "tmp",
+          },
+        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -134,6 +134,7 @@ test('[worker] waitFor, exit 0', async (assert) => {
 
   sinon.spy(child_process, 'spawn');
   sinon.spy(process.stdout, 'write');
+  sinon.spy(process.stderr, 'write');
 
   try {
     await worker.waitFor();
@@ -154,7 +155,8 @@ test('[worker] waitFor, exit 0', async (assert) => {
     child_process.spawn.calledWith('echo ${Message}', {
       env: Object.assign(message.env, process.env),
       shell: true,
-      stdio: [process.stdin, 'pipe', 'pipe']
+      stdio: [process.stdin, 'pipe', 'pipe'],
+      uid: 200
     }),
     'spawned child process properly'
   );

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -144,6 +144,7 @@ test('[worker] waitFor, exit 0', async (assert) => {
 
   const data = process.stdout.write.args[0][0];
   process.stdout.write.restore();
+  process.stderr.write.restore();
 
   assert.equal(
     data,
@@ -165,6 +166,132 @@ test('[worker] waitFor, exit 0', async (assert) => {
   assert.equal(results.code, 0, 'logged worker success exit code');
   assert.ok(results.duration, 'logged worker success duration');
   assert.equal(message.complete.callCount, 1, 'called message.complete()');
+
+  Date.prototype.toGMTString.restore();
+  child_process.spawn.restore();
+  process.env = env;
+  logger.teardown();
+  assert.end();
+});
+
+test('[worker] waitFor, write to /tmp, exit 0', async (assert) => {
+  sinon
+    .stub(Date.prototype, 'toGMTString')
+    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
+
+  const logger = stubber(Logger).setup();
+  const message = sinon.createStubInstance(Message);
+  message.id = '895ab607-3767-4bbb-bd45-2a3b341cbc46';
+  message.env = { Message: 'banana' };
+
+  logger.log.restore();
+  logger.stream.restore();
+  logger.type = 'worker';
+  logger.message = message;
+
+  const options = { command: 'echo ${Message} > /tmp/banana.txt && cat /tmp/banana.txt' };
+  const worker = new Worker(message, options);
+
+  const env = process.env;
+  process.env = { fake: 'environment' };
+
+  sinon.spy(child_process, 'spawn');
+  sinon.spy(process.stdout, 'write');
+  sinon.spy(process.stderr, 'write');
+
+  try {
+    await worker.waitFor();
+  } catch (err) {
+    assert.ifError(err, 'failed');
+  }
+
+  const data = process.stdout.write.args[0][0];
+  process.stdout.write.restore();
+  process.stderr.write.restore();
+
+  assert.equal(
+    data,
+    '[Fri, 09 Feb 2018 21:57:55 GMT] [worker] [895ab607-3767-4bbb-bd45-2a3b341cbc46] banana\n',
+    'prefixed worker output'
+  );
+
+  assert.ok(
+    child_process.spawn.calledWith('echo ${Message} > /tmp/banana.txt && cat /tmp/banana.txt', {
+      env: Object.assign(message.env, process.env),
+      shell: true,
+      stdio: [process.stdin, 'pipe', 'pipe'],
+      uid: 200
+    }),
+    'spawned child process properly'
+  );
+
+  const results = logger.workerSuccess.args[0][0];
+  assert.equal(results.code, 0, 'logged worker success exit code');
+  assert.ok(results.duration, 'logged worker success duration');
+  assert.equal(message.complete.callCount, 1, 'called message.complete()');
+
+  Date.prototype.toGMTString.restore();
+  child_process.spawn.restore();
+  process.env = env;
+  logger.teardown();
+  assert.end();
+});
+
+test('[worker] waitFor, attempt to write to root, exit 1', async (assert) => {
+  sinon
+    .stub(Date.prototype, 'toGMTString')
+    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
+
+  const logger = stubber(Logger).setup();
+  const message = sinon.createStubInstance(Message);
+  message.id = '895ab607-3767-4bbb-bd45-2a3b341cbc46';
+  message.env = { Message: 'banana' };
+
+  logger.log.restore();
+  logger.stream.restore();
+  logger.type = 'worker';
+  logger.message = message;
+
+  const options = { command: 'echo ${Message} > /banana.txt && cat /banana.txt' };
+  const worker = new Worker(message, options);
+
+  const env = process.env;
+  process.env = { fake: 'environment' };
+
+  sinon.spy(child_process, 'spawn');
+  sinon.spy(process.stdout, 'write');
+  sinon.spy(process.stderr, 'write');
+
+  try {
+    await worker.waitFor();
+  } catch (err) {
+    assert.ifError(err, 'failed');
+  }
+
+  const data = process.stdout.write.args[0][0];
+  process.stdout.write.restore();
+  process.stderr.write.restore();
+
+  assert.equal(
+    data,
+    '[Fri, 09 Feb 2018 21:57:55 GMT] [worker] [895ab607-3767-4bbb-bd45-2a3b341cbc46] /bin/sh: 1: cannot create /banana.txt: Permission denied\n',
+    'prefixed worker output'
+  );
+
+  assert.ok(
+    child_process.spawn.calledWith('echo ${Message} > /banana.txt && cat /banana.txt', {
+      env: Object.assign(message.env, process.env),
+      shell: true,
+      stdio: [process.stdin, 'pipe', 'pipe'],
+      uid: 200
+    }),
+    'spawned child process properly'
+  );
+
+  const results = logger.workerFailure.args[0][0];
+  assert.equal(results.code, 2, 'logged worker failure exit code');
+  assert.ok(results.duration, 'logged worker failure duration');
+  assert.equal(message.retry.callCount, 1, 'called message.retry()');
 
   Date.prototype.toGMTString.restore();
   child_process.spawn.restore();

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -237,6 +237,67 @@ test('[worker] waitFor, write to /tmp, exit 0', async (assert) => {
   assert.end();
 });
 
+test('[worker] waitFor, /tmp is empty, exit 0', async (assert) => {
+  sinon
+    .stub(Date.prototype, 'toGMTString')
+    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
+
+  const logger = stubber(Logger).setup();
+  const message = sinon.createStubInstance(Message);
+  message.id = '895ab607-3767-4bbb-bd45-2a3b341cbc46';
+  message.env = { Message: 'banana' };
+
+  logger.log.restore();
+  logger.stream.restore();
+  logger.type = 'worker';
+  logger.message = message;
+
+  const options = { command: 'ls /tmp' };
+  const worker = new Worker(message, options);
+
+  const env = process.env;
+  process.env = { fake: 'environment' };
+
+  sinon.spy(child_process, 'spawn');
+  sinon.spy(process.stdout, 'write');
+  sinon.spy(process.stderr, 'write');
+
+  try {
+    await worker.waitFor();
+  } catch (err) {
+    assert.ifError(err, 'failed');
+  }
+
+  assert.deepEquals(
+    process.stdout.write.args,
+    [],
+    'no worker output'
+  );
+  process.stdout.write.restore();
+  process.stderr.write.restore();
+
+  assert.ok(
+    child_process.spawn.calledWith('ls /tmp', {
+      env: Object.assign(message.env, process.env),
+      shell: true,
+      stdio: [process.stdin, 'pipe', 'pipe'],
+      uid: 200
+    }),
+    'spawned child process properly'
+  );
+
+  const results = logger.workerSuccess.args[0][0];
+  assert.equal(results.code, 0, 'logged worker success exit code');
+  assert.ok(results.duration, 'logged worker success duration');
+  assert.equal(message.complete.callCount, 1, 'called message.complete()');
+
+  Date.prototype.toGMTString.restore();
+  child_process.spawn.restore();
+  process.env = env;
+  logger.teardown();
+  assert.end();
+});
+
 test('[worker] waitFor, attempt to write to root, exit 1', async (assert) => {
   sinon
     .stub(Date.prototype, 'toGMTString')


### PR DESCRIPTION
Proves out the ability to restrict writes to the `/tmp` directory, with purging of the `/tmp` contents after every job. Refs #197 

Now that we know it's easy to do this for `/tmp`, we need to find out if it's possible to restrict writes to a list of user-defined volumes. If it seems possible, we should go with that for developer flexibility. If it doesn't seem possible, at least we have this as a fallback now.

## Next actions

- Create a branch off this PR that experiments with restricting writes to user-defined writable volumes. If it seems possible and manageable, let's go with that.

cc/ @mapbox/platform-engine-room @rclark 