### PR TITLE
Allow users to write to any volume

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
 - '8'
+services:
+- docker

--- a/bin/watchbot-log.js
+++ b/bin/watchbot-log.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+/**
+ * watchbot-log "something that you want logged"
+ *   - or -
+ * echo "somehing that you want logged" | watchbot-log
+ */
+
+const Logger = require('..').Logger;
+const args = process.argv.slice(2);
+
+const logger = new Logger('worker');
+
+if (args[0]) {
+  return logger.log(args[0]);
+}
+
+process.stdin.pipe(logger.stream());

--- a/bin/watchbot-log.js
+++ b/bin/watchbot-log.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 /**
  * watchbot-log "something that you want logged"

--- a/bin/watchbot.js
+++ b/bin/watchbot.js
@@ -11,11 +11,12 @@ const main = async () => {
 
   const logger = Logger.create('watcher');
   const command = process.argv.slice(3).join(' ');
+  const volumes = process.env.Volumes.split(',');
 
   const options = {
     queueUrl: process.env.QueueUrl,
     fresh: process.env.fresh === 'true' ? true : false,
-    workerOptions: { command }
+    workerOptions: { command, volumes }
   };
 
   const watcher = Watcher.create(options);

--- a/lib/template.js
+++ b/lib/template.js
@@ -15,7 +15,7 @@ const pkg = require(path.resolve(__dirname, '..', 'package.json'));
  * repository where your images are stored.
  * @param {String|ref} options.serviceVersion - the version of you service to
  * deploy. This should reference a specific image in ECR.
- * @param {String} options.command - the shell command that should be executed
+ * @param {String} [options.command] - the shell command that should be executed
  * in order to process a single message.
  * @param {Array} [options.permissions=[]] - permissions that your worker will
  * need in order to complete tasks.
@@ -35,22 +35,17 @@ const pkg = require(path.resolve(__dirname, '..', 'package.json'));
  * to specify this in order to differentiate the resources.
  * @param {String} [options.family] - the name of the the task definition family
  * that watchbot will create revisions of.
- * @param {Number|ref} [options.maxSize=1] - the maximum size for the service to
- * scale up to. This parameter can be provided as either a number or a reference,
- * i.e. `{"Ref": "..."}`.
+ * @param {Number} [options.maxSize=1] - the maximum size for the service to
+ * scale up to. This parameter must be provided as a number.
  * @param {Number|ref} [options.minSize=0] - the minimum size for the service to
  * scale down to. This parameter can be provided as either a number or a reference,
  * i.e. `{"Ref": "..."}`.
- * @param {String} [options.mounts=''] - if your worker containers need to mount
- * files or folders from the host EC2 file system, specify those mounts with this parameter.
- * A single persistent mount point can be specified as `{host location}:{container location}`,
- * e.g. /root:/mnt/root. A single ephemeral mount point can be specified as `{container location}`,
- * e.g. /mnt/tmp. Separate multiple mount strings with commas if you need to mount
- * more than one location. You can also specify a mount object with `container`
- * and `host` property arrays, in which the indeces
- * correspond: `{ container: [{container location}], host: [{host location}] }`,
- * e.g. { container: [/mnt/root, /mnt/tmp], host: [/root, ''] }. A blank host
- * entry will create an ephemeral mount point at the corresponding container filepath.
+ * @param {String} [options.mounts=''] - if your worker containers need to write
+ * files or folders inside its file system, specify those locations with this parameter.
+ * A single ephemeral mount point can be specified as `{container location}`, e.g. /mnt/tmp.
+ * Separate multiple mount strings with commas if you need to mount more than one location.
+ * You can also specify a mount object as an arrays of paths. Every mounted volume will be
+ * cleaned after each job.
  * @param {Object} [options.reservation={}] - worker container resource reservations
  * @param {Number|ref} [options.reservation.memory] - the number of MB of RAM
  * to reserve as a hard limit. If your worker container tries to utilize more
@@ -135,7 +130,7 @@ module.exports = (options = {}) => {
 
   const prefixed = (name) => `${options.prefix}${name}`;
 
-  const unpackEnv = (env) => {
+  const unpackEnv = (env, mountPoints) => {
     return Object.keys(env).reduce(
       (unpacked, key) => {
         unpacked.push({ Name: key, Value: env[key] });
@@ -144,16 +139,17 @@ module.exports = (options = {}) => {
       [
         { Name: 'WorkTopic', Value: cf.ref(prefixed('Topic')) },
         { Name: 'QueueUrl', Value: cf.ref(prefixed('Queue')) },
-        { Name: 'fresh', Value: options.fresh }
+        { Name: 'fresh', Value: options.fresh },
+        { Name: 'Volumes', Value: mountPoints.map((m) => m.ContainerPath).join(',') }
       ]
     );
   };
 
   const mount = (mountInputs) => {
-    let formatted = { container: [], host: [] };
+    let formatted = [];
     const mounts = {
-      mountPoints: [],
-      volumes: []
+      mountPoints: [{ ContainerPath: '/tmp', SourceVolume: 'tmp' }],
+      volumes: [{ Name: 'tmp' }]
     };
 
     if (typeof mountInputs === 'object') formatted = mountInputs;
@@ -162,25 +158,18 @@ module.exports = (options = {}) => {
         if (!mountStr.length) return;
 
         const persistent = /:/.test(mountStr);
-        formatted.container.push(
+        formatted.push(
           persistent ? mountStr.split(':')[1] : mountStr
         );
-        formatted.host.push(persistent ? mountStr.split(':')[0] : '');
       });
     }
 
-    formatted.container.forEach((container, i) => {
+    formatted.forEach((container, i) => {
       const name = 'mnt-' + i;
-      const host = formatted.host[i] ? { SourcePath: formatted.host[i] } : {};
 
       mounts.mountPoints.push({ ContainerPath: container, SourceVolume: name });
-      mounts.volumes.push({ Name: name, Host: host });
+      mounts.volumes.push({ Name: name });
     });
-
-    if (!mounts.mountPoints.length) {
-      mounts.mountPoints = undefined;
-      mounts.volumes = undefined;
-    }
 
     return mounts;
   };
@@ -264,7 +253,7 @@ module.exports = (options = {}) => {
     }
   };
 
-  Resources[prefixed('Logs')] = {
+  Resources[prefixed('LogGroup')] = {
     Type: 'AWS::Logs::LogGroup',
     Properties: {
       LogGroupName: cf.join('-', [
@@ -314,7 +303,7 @@ module.exports = (options = {}) => {
                   'logs:PutLogEvents',
                   'logs:FilterLogEvents'
                 ],
-                Resource: cf.getAtt(prefixed('Logs'), 'Arn')
+                Resource: cf.getAtt(prefixed('LogGroup'), 'Arn')
               },
               {
                 Effect: 'Allow',
@@ -353,7 +342,7 @@ module.exports = (options = {}) => {
           ]),
           Cpu: options.reservation.cpu,
           Privileged: options.privileged,
-          Environment: unpackEnv(options.env),
+          Environment: unpackEnv(options.env, mounts.mountPoints),
           MountPoints: mounts.mountPoints,
           Command: ['watchbot', 'listen', `${options.command}`],
           Ulimits: [
@@ -366,7 +355,7 @@ module.exports = (options = {}) => {
           LogConfiguration: {
             LogDriver: 'awslogs',
             Options: {
-              'awslogs-group': cf.ref(prefixed('Logs')),
+              'awslogs-group': cf.ref(prefixed('LogGroup')),
               'awslogs-region': cf.region,
               'awslogs-stream-prefix': options.serviceVersion
             }
@@ -391,7 +380,7 @@ module.exports = (options = {}) => {
     Type: 'AWS::ECS::Service',
     Properties: {
       Cluster: options.cluster,
-      DesiredCount: 0,
+      DesiredCount: options.minSize,
       TaskDefinition: cf.ref(prefixed('Task'))
     }
   };
@@ -481,7 +470,7 @@ module.exports = (options = {}) => {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
       AlarmName: cf.sub('${AWS::StackName}-scale-up'),
-      AlarmDescription: 'Scale up workers due to visible messages in queue',
+      AlarmDescription: 'Scale up due to visible messages in queue',
       EvaluationPeriods: 1,
       Statistic: 'Maximum',
       Threshold: 0,
@@ -521,7 +510,7 @@ module.exports = (options = {}) => {
     Properties: {
       AlarmName: cf.sub('${AWS::StackName}-scale-down'),
       AlarmDescription:
-        'Scale down workers due to lack of in-flight messages in queue',
+        'Scale down due to lack of in-flight messages in queue',
       EvaluationPeriods: 1,
       Statistic: 'Maximum',
       Threshold: 1,
@@ -560,7 +549,7 @@ module.exports = (options = {}) => {
     Type: 'AWS::Logs::MetricFilter',
     Properties: {
       FilterPattern: '"[failure]"',
-      LogGroupName: cf.ref(prefixed('Logs')),
+      LogGroupName: cf.ref(prefixed('LogGroup')),
       MetricTransformations: [{
         MetricName: cf.join([prefixed('WorkerErrors-'), cf.stackName]),
         MetricNamespace: 'Mapbox/ecs-watchbot',
@@ -609,5 +598,14 @@ module.exports = (options = {}) => {
     }
   };
 
-  return cf.merge({ Resources });
+  const ref = {
+    logGroup: cf.ref(prefixed('LogGroup')),
+    topic: cf.ref(prefixed('Topic')),
+    queueUrl: cf.ref(prefixed('Queue')),
+    queueArn: cf.getAtt(prefixed('Queue'), 'Arn'),
+    queueName: cf.getAtt(prefixed('Queue'), 'QueueName'),
+    notificationTopic: cf.ref(prefixed('NotificationTopic'))
+  };
+
+  return { Resources, ref };
 };

--- a/lib/template.js
+++ b/lib/template.js
@@ -352,6 +352,7 @@ module.exports = (options = {}) => {
               HardLimit: 10240
             }
           ],
+          ReadOnlyRootFilesystem: true,
           LogConfiguration: {
             LogDriver: 'awslogs',
             Options: {

--- a/lib/template.js
+++ b/lib/template.js
@@ -352,7 +352,7 @@ module.exports = (options = {}) => {
               HardLimit: 10240
             }
           ],
-          ReadOnlyRootFilesystem: true,
+          ReadonlyRootFilesystem: true,
           LogConfiguration: {
             LogDriver: 'awslogs',
             Options: {

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -2,6 +2,10 @@
 
 const Messages = require('./messages');
 const Worker = require('./worker');
+const fs = require('fs');
+const util = require('util');
+
+const chmod = util.promisify(fs.chmod);
 
 class Watcher {
   /**
@@ -21,8 +25,14 @@ class Watcher {
     this.freshMode = options.fresh;
   }
 
+  async chmodForEveryone(volumes) {
+    return Promise.all(volumes.map((volume) => chmod(volume, 0o777)));
+  }
+
   listen() {
-    return new Promise((resolve) => {
+    return new Promise(async (resolve) => {
+      await this.chmodForEveryone(this.workerOptions.volumes);
+
       const loop = async () => {
         if (this.stop) return resolve();
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -2,10 +2,6 @@
 
 const Messages = require('./messages');
 const Worker = require('./worker');
-const fs = require('fs');
-const util = require('util');
-
-const chmod = util.promisify(fs.chmod);
 
 class Watcher {
   /**
@@ -25,14 +21,8 @@ class Watcher {
     this.freshMode = options.fresh;
   }
 
-  async chmodForEveryone(volumes) {
-    return Promise.all(volumes.map((volume) => chmod(volume, 0o777)));
-  }
-
   listen() {
     return new Promise(async (resolve) => {
-      await this.chmodForEveryone(this.workerOptions.volumes);
-
       const loop = async () => {
         if (this.stop) return resolve();
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -62,9 +62,7 @@ class Worker {
     const options = {
       shell: true,
       env: Object.assign({}, process.env, this.message.env),
-      stdio: [process.stdin, 'pipe', 'pipe'],
-      // An arbitrarily chosen UID of a non-existent user
-      uid: 200
+      stdio: [process.stdin, 'pipe', 'pipe']
     };
 
     try {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const child_process = require('child_process');
+const fsExtra = require('fs-extra');
 const Message = require('./message');
 const Logger = require('./logger');
 
@@ -28,6 +29,7 @@ class Worker {
     if (!options.command) throw new Error('Missing options: command');
 
     this.command = options.command;
+    this.volumes = options.volumes;
     this.message = message;
     this.logger = Logger.create('watcher', message);
   }
@@ -52,15 +54,24 @@ class Worker {
     return await this.message.retry();
   }
 
+  async clean(volumes) {
+    return Promise.all(volumes.map((volume) => fsExtra.emptyDir(volume)));
+  }
+
   async waitFor() {
     const options = {
       shell: true,
       env: Object.assign({}, process.env, this.message.env),
-      stdio: [process.stdin, 'pipe', 'pipe']
+      stdio: [process.stdin, 'pipe', 'pipe'],
+      // An arbitrarily chosen UID of a non-existent user
+      uid: 200
     };
 
     try {
       const results = await child(this.command, options, this.logger);
+
+      await this.clean(this.volumes);
+
       if (results.code === 0) return await this.success(results);
       if (results.code === 3) return await this.ignore(results);
       if (results.code === 4) return await this.noop(results);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1486,6 +1486,16 @@
         "samsam": "1.3.0"
       }
     },
+    "fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2485,8 +2495,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growly": {
       "version": "1.3.0",
@@ -3483,6 +3492,14 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -6773,6 +6790,11 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "url": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "pretest": "npm run lint && npm run validate-templates",
     "lint": "eslint bin lib test index.js",
-    "test": "tape test/*.test.js | tap-spec && jest test/*.jest.js",
+    "test": "docker build -q -t ecs-watchbot -f test/Dockerfile ./ && docker run -t ecs-watchbot npm run test-container",
+    "test-container": "tape test/*.test.js | tap-spec && jest test/*.jest.js",
     "validate-templates": "tape test/template.validation.js | tap-spec",
     "update-jest-snapshots": "jest -u test/*.jest.js",
     "coverage": "nyc --reporter html tape test/*.test.js && opener coverage/index.html"
@@ -42,6 +43,7 @@
     "@mapbox/cloudfriend": "^1.9.0",
     "aws-sdk": "^2.188.0",
     "binary-split": "^1.0.3",
+    "fs-extra": "^6.0.1",
     "stream-combiner2": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": ">=8"
   },
   "bin": {
-    "watchbot": "./bin/watchbot.js"
+    "watchbot": "./bin/watchbot.js",
+    "watchbot-log": "./bin/watchbot-log.js"
   },
   "scripts": {
     "pretest": "npm run lint && npm run validate-templates",

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:8.10
+
+COPY ./package.json ./package.json
+COPY ./package-lock.json ./package-lock.json
+
+RUN npm install
+
+COPY ./ ./

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -60,7 +60,7 @@ Object {
       },
       "Type": "AWS::SQS::Queue",
     },
-    "SoupLogs": Object {
+    "SoupLogGroup": Object {
       "Properties": Object {
         "LogGroupName": Object {
           "Fn::Join": Array [
@@ -242,7 +242,7 @@ Object {
                   "Effect": "Allow",
                   "Resource": Object {
                     "Fn::GetAtt": Array [
-                      "SoupLogs",
+                      "SoupLogGroup",
                       "Arn",
                     ],
                   },
@@ -324,7 +324,7 @@ Object {
             "Ref": "SoupScaleDown",
           },
         ],
-        "AlarmDescription": "Scale down workers due to lack of in-flight messages in queue",
+        "AlarmDescription": "Scale down due to lack of in-flight messages in queue",
         "AlarmName": Object {
           "Fn::Sub": "\${AWS::StackName}-scale-down",
         },
@@ -379,7 +379,7 @@ Object {
             "Ref": "SoupScaleUp",
           },
         ],
-        "AlarmDescription": "Scale up workers due to visible messages in queue",
+        "AlarmDescription": "Scale up due to visible messages in queue",
         "AlarmName": Object {
           "Fn::Sub": "\${AWS::StackName}-scale-up",
         },
@@ -514,6 +514,10 @@ Object {
                 "Value": false,
               },
               Object {
+                "Name": "Volumes",
+                "Value": "/tmp,/data,/ephemeral",
+              },
+              Object {
                 "Name": "MyKey",
                 "Value": "MyValue",
               },
@@ -536,7 +540,7 @@ Object {
               "LogDriver": "awslogs",
               "Options": Object {
                 "awslogs-group": Object {
-                  "Ref": "SoupLogs",
+                  "Ref": "SoupLogGroup",
                 },
                 "awslogs-region": Object {
                   "Ref": "AWS::Region",
@@ -547,6 +551,10 @@ Object {
             "Memory": 512,
             "MemoryReservation": 128,
             "MountPoints": Array [
+              Object {
+                "ContainerPath": "/tmp",
+                "SourceVolume": "tmp",
+              },
               Object {
                 "ContainerPath": "/data",
                 "SourceVolume": "mnt-0",
@@ -573,13 +581,12 @@ Object {
         },
         "Volumes": Array [
           Object {
-            "Host": Object {
-              "SourcePath": "/mnt/data",
-            },
+            "Name": "tmp",
+          },
+          Object {
             "Name": "mnt-0",
           },
           Object {
-            "Host": Object {},
             "Name": "mnt-1",
           },
         ],
@@ -637,7 +644,7 @@ Object {
       "Properties": Object {
         "FilterPattern": "\\"[failure]\\"",
         "LogGroupName": Object {
-          "Ref": "SoupLogs",
+          "Ref": "SoupLogGroup",
         },
         "MetricTransformations": Array [
           Object {
@@ -723,7 +730,7 @@ Object {
       },
       "Type": "AWS::SQS::Queue",
     },
-    "WatchbotLogs": Object {
+    "WatchbotLogGroup": Object {
       "Properties": Object {
         "LogGroupName": Object {
           "Fn::Join": Array [
@@ -905,7 +912,7 @@ Object {
                   "Effect": "Allow",
                   "Resource": Object {
                     "Fn::GetAtt": Array [
-                      "WatchbotLogs",
+                      "WatchbotLogGroup",
                       "Arn",
                     ],
                   },
@@ -965,7 +972,7 @@ Object {
             "Ref": "WatchbotScaleDown",
           },
         ],
-        "AlarmDescription": "Scale down workers due to lack of in-flight messages in queue",
+        "AlarmDescription": "Scale down due to lack of in-flight messages in queue",
         "AlarmName": Object {
           "Fn::Sub": "\${AWS::StackName}-scale-down",
         },
@@ -1020,7 +1027,7 @@ Object {
             "Ref": "WatchbotScaleUp",
           },
         ],
-        "AlarmDescription": "Scale up workers due to visible messages in queue",
+        "AlarmDescription": "Scale up due to visible messages in queue",
         "AlarmName": Object {
           "Fn::Sub": "\${AWS::StackName}-scale-up",
         },
@@ -1154,6 +1161,10 @@ Object {
                 "Name": "fresh",
                 "Value": false,
               },
+              Object {
+                "Name": "Volumes",
+                "Value": "/tmp",
+              },
             ],
             "Image": Object {
               "Fn::Join": Array [
@@ -1173,7 +1184,7 @@ Object {
               "LogDriver": "awslogs",
               "Options": Object {
                 "awslogs-group": Object {
-                  "Ref": "WatchbotLogs",
+                  "Ref": "WatchbotLogGroup",
                 },
                 "awslogs-region": Object {
                   "Ref": "AWS::Region",
@@ -1181,7 +1192,12 @@ Object {
                 "awslogs-stream-prefix": "1",
               },
             },
-            "MountPoints": undefined,
+            "MountPoints": Array [
+              Object {
+                "ContainerPath": "/tmp",
+                "SourceVolume": "tmp",
+              },
+            ],
             "Name": "watchbot-example",
             "Privileged": false,
             "Ulimits": Array [
@@ -1197,7 +1213,11 @@ Object {
         "TaskRoleArn": Object {
           "Ref": "WatchbotRole",
         },
-        "Volumes": undefined,
+        "Volumes": Array [
+          Object {
+            "Name": "tmp",
+          },
+        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -1252,7 +1272,7 @@ Object {
       "Properties": Object {
         "FilterPattern": "\\"[failure]\\"",
         "LogGroupName": Object {
-          "Ref": "WatchbotLogs",
+          "Ref": "WatchbotLogGroup",
         },
         "MetricTransformations": Array [
           Object {

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -566,6 +566,7 @@ Object {
             ],
             "Name": "soup-example",
             "Privileged": true,
+            "ReadOnlyRootFilesystem": true,
             "Ulimits": Array [
               Object {
                 "HardLimit": 10240,
@@ -1200,6 +1201,7 @@ Object {
             ],
             "Name": "watchbot-example",
             "Privileged": false,
+            "ReadOnlyRootFilesystem": true,
             "Ulimits": Array [
               Object {
                 "HardLimit": 10240,

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -566,7 +566,7 @@ Object {
             ],
             "Name": "soup-example",
             "Privileged": true,
-            "ReadOnlyRootFilesystem": true,
+            "ReadonlyRootFilesystem": true,
             "Ulimits": Array [
               Object {
                 "HardLimit": 10240,
@@ -1201,7 +1201,7 @@ Object {
             ],
             "Name": "watchbot-example",
             "Privileged": false,
-            "ReadOnlyRootFilesystem": true,
+            "ReadonlyRootFilesystem": true,
             "Ulimits": Array [
               Object {
                 "HardLimit": 10240,

--- a/test/bin.watchbot.test.js
+++ b/test/bin.watchbot.test.js
@@ -12,6 +12,7 @@ test('[bin.watchbot] success', async (assert) => {
   const argv = process.argv;
   process.argv = ['', '', 'listen', 'echo', 'hello', 'world'];
   process.env.QueueUrl = 'https://faker';
+  process.env.Volumes = '/tmp,/mnt';
 
   try {
     await watchbot();
@@ -22,8 +23,11 @@ test('[bin.watchbot] success', async (assert) => {
   assert.ok(
     Watcher.create.calledWith({
       queueUrl: 'https://faker',
-      workerOptions: { command: 'echo hello world' },
-      fresh: false
+      fresh: false,
+      workerOptions: {
+        command: 'echo hello world',
+        volumes: ['/tmp', '/mnt']
+      }
     }),
     'watcher created with expected arguments'
   );
@@ -31,6 +35,7 @@ test('[bin.watchbot] success', async (assert) => {
   assert.equal(watcher.listen.callCount, 1, 'called watcher.listen()');
 
   delete process.env.QueueUrl;
+  delete process.env.Volumes;
   process.argv = argv;
   watcher.teardown();
   assert.end();
@@ -45,6 +50,7 @@ test('[bin.watchbot] error handling', async (assert) => {
   const argv = process.argv;
   process.argv = ['', '', 'listen', 'echo', 'hello', 'world'];
   process.env.QueueUrl = 'https://faker';
+  process.env.Volumes = '/tmp,/mnt';
 
   try {
     await watchbot();
@@ -58,6 +64,7 @@ test('[bin.watchbot] error handling', async (assert) => {
   );
 
   delete process.env.QueueUrl;
+  delete process.env.Volumes;
   process.argv = argv;
   logger.teardown();
   watcher.teardown();
@@ -68,6 +75,7 @@ test('[bin.watchbot] bad arguments', async (assert) => {
   const argv = process.argv;
   process.argv = ['', '', 'watch', 'echo', 'hello', 'world'];
   process.env.QueueUrl = 'https://faker';
+  process.env.Volumes = '/tmp,/mnt';
 
   try {
     await watchbot();
@@ -80,6 +88,7 @@ test('[bin.watchbot] bad arguments', async (assert) => {
   }
 
   delete process.env.QueueUrl;
+  delete process.env.Volumes;
   process.argv = argv;
   assert.end();
 });

--- a/test/template.jest.js
+++ b/test/template.jest.js
@@ -4,6 +4,7 @@
 
 const assert = require('assert');
 const template = require('../lib/template');
+const cf = require('@mapbox/cloudfriend');
 
 test('[template]', () => {
   assert.throws(
@@ -12,17 +13,17 @@ test('[template]', () => {
     'throws when missing required options'
   );
 
-  const builtWithDefaults = template({
+  const builtWithDefaults = cf.merge(template({
     service: 'example',
     serviceVersion: '1',
     command: 'echo hello world',
     cluster: 'processing',
     notificationEmail: 'hello@mapbox.pagerduty.com'
-  });
+  }));
 
   expect(builtWithDefaults).toMatchSnapshot('defaults');
 
-  const setsAllOptions = template({
+  const setsAllOptions = cf.merge(template({
     service: 'example',
     serviceVersion: '1',
     command: 'echo hello world',
@@ -40,7 +41,7 @@ test('[template]', () => {
     prefix: 'Soup',
     family: 'abc-123',
     maxSize: 90,
-    mounts: '/mnt/data:/data,/ephemeral',
+    mounts: '/data,/ephemeral',
     reservation: {
       memory: 512,
       softMemory: 128,
@@ -50,7 +51,7 @@ test('[template]', () => {
     messageTimeout: 300,
     messageRetention: 1096,
     notificationEmail: 'hello@mapbox.pagerduty.com'
-  });
+  }));
 
   expect(setsAllOptions).toMatchSnapshot('all-properties');
 });

--- a/test/template.validation.js
+++ b/test/template.validation.js
@@ -9,13 +9,13 @@ const cf = require('@mapbox/cloudfriend');
 const template = require('../lib/template');
 
 test('[template validation] defaults', async (assert) => {
-  const builtWithDefaults = template({
+  const builtWithDefaults = cf.merge(template({
     service: 'example',
     serviceVersion: '1',
     command: 'echo hello world',
     cluster: 'processing',
     notificationEmail: 'hello@mapbox.pagerduty.com'
-  });
+  }));
 
   const tmp = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
   fs.writeFileSync(tmp, JSON.stringify(builtWithDefaults));
@@ -31,7 +31,7 @@ test('[template validation] defaults', async (assert) => {
 });
 
 test('[template validation] options set', async (assert) => {
-  const setsAllOptions = template({
+  const setsAllOptions = cf.merge(template({
     service: 'example',
     serviceVersion: '1',
     command: 'echo hello world',
@@ -59,7 +59,7 @@ test('[template validation] options set', async (assert) => {
     messageTimeout: 300,
     messageRetention: 1096,
     notificationEmail: 'hello@mapbox.pagerduty.com'
-  });
+  }));
 
   const tmp = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
   fs.writeFileSync(tmp, JSON.stringify(setsAllOptions));

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -8,7 +8,6 @@ const Watcher = require('../lib/watcher');
 const Message = require('../lib/message');
 const Messages = require('../lib/messages');
 const Worker = require('../lib/worker');
-const fs = require('fs');
 
 test('[watcher] constructor', (assert) => {
   const messages = stubber(Messages).setup();
@@ -122,9 +121,6 @@ test('[watcher] listen', async (assert) => {
   );
 
   assert.equal(worker.waitFor.callCount, 2, 'waits for both workers');
-
-  assert.equal((fs.statSync('/tmp').mode & parseInt('777', 8)).toString(8), '777', 'calls chmod on /tmp');
-  assert.equal((fs.statSync('/mnt').mode & parseInt('777', 8)).toString(8), '777', 'calls chmod on /mnt');
 
   messages.teardown();
   worker.teardown();

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -159,8 +159,7 @@ test('[worker] waitFor, exit 0', async (assert) => {
     child_process.spawn.calledWith('echo ${Message}', {
       env: Object.assign(message.env, process.env),
       shell: true,
-      stdio: [process.stdin, 'pipe', 'pipe'],
-      uid: 200
+      stdio: [process.stdin, 'pipe', 'pipe']
     }),
     'spawned child process properly'
   );
@@ -227,8 +226,7 @@ test('[worker] waitFor, write to /tmp, exit 0', async (assert) => {
     child_process.spawn.calledWith('echo ${Message} > /tmp/banana.txt && cat /tmp/banana.txt', {
       env: Object.assign(message.env, process.env),
       shell: true,
-      stdio: [process.stdin, 'pipe', 'pipe'],
-      uid: 200
+      stdio: [process.stdin, 'pipe', 'pipe']
     }),
     'spawned child process properly'
   );
@@ -240,69 +238,6 @@ test('[worker] waitFor, write to /tmp, exit 0', async (assert) => {
 
   const tmpFiles = fs.readdirSync('/tmp');
   assert.equal(tmpFiles.length, 0, 'all files in /tmp are cleared out after the worker complets');
-
-  Date.prototype.toGMTString.restore();
-  child_process.spawn.restore();
-  process.env = env;
-  logger.teardown();
-  assert.end();
-});
-
-test('[worker] waitFor, attempt to write to root, exit 2', async (assert) => {
-  sinon
-    .stub(Date.prototype, 'toGMTString')
-    .returns('Fri, 09 Feb 2018 21:57:55 GMT');
-
-  const logger = stubber(Logger).setup();
-  const message = sinon.createStubInstance(Message);
-  message.id = '895ab607-3767-4bbb-bd45-2a3b341cbc46';
-  message.env = { Message: 'banana' };
-
-  logger.log.restore();
-  logger.stream.restore();
-  logger.type = 'worker';
-  logger.message = message;
-
-  const options = { command: 'echo ${Message} > /banana.txt && cat /banana.txt', volumes: ['/tmp'] };
-  const worker = new Worker(message, options);
-
-  const env = process.env;
-  process.env = { fake: 'environment' };
-
-  sinon.spy(child_process, 'spawn');
-  sinon.spy(process.stdout, 'write');
-  sinon.spy(process.stderr, 'write');
-
-  try {
-    await worker.waitFor();
-  } catch (err) {
-    assert.ifError(err, 'failed');
-  }
-
-  const data = process.stdout.write.args[0][0];
-  process.stdout.write.restore();
-  process.stderr.write.restore();
-
-  assert.equal(
-    data,
-    '[Fri, 09 Feb 2018 21:57:55 GMT] [worker] [895ab607-3767-4bbb-bd45-2a3b341cbc46] /bin/sh: 1: cannot create /banana.txt: Permission denied\n',
-    'prefixed worker output'
-  );
-
-  assert.ok(
-    child_process.spawn.calledWith('echo ${Message} > /banana.txt && cat /banana.txt', {
-      env: Object.assign(message.env, process.env),
-      shell: true,
-      stdio: [process.stdin, 'pipe', 'pipe'],
-      uid: 200
-    }),
-    'spawned child process properly'
-  );
-
-  const results = logger.workerFailure.args[0][0];
-  assert.equal(results.code, 2, 'logged worker failure exit code');
-  assert.ok(results.duration, 'logged worker failure duration');
-  assert.equal(message.retry.callCount, 1, 'called message.retry()');
 
   Date.prototype.toGMTString.restore();
   child_process.spawn.restore();


### PR DESCRIPTION
Adds user-defined volumes to the tmp directory PR #199.

Things I'm not sure about:

- performing `chmod 777` in the watcher before messages begin. Should this be per-worker instead? I figured we might as well save unnecessary work.
- I feel like my tests are missing an important integration piece, but I don't want to actually make `chmod` system calls in the tests. Not sure how I feel there.
- Does this actually work? I'm going to test it out on a quick stack that performs writes to user-defined volumes.
- Code quality: I have one pyramid of doom and a few long-lines in the test code. Should I make those prettier?

Since this isn't a painful implementation (barring any testing surprises), I'm happy to go with this over #199.

cc/ @rclark @mapbox/platform-engine-room 