### PR TITLE
Add template validation tests

### DIFF
--- a/cloudformation/travis.template.js
+++ b/cloudformation/travis.template.js
@@ -1,0 +1,38 @@
+const cf = require('@mapbox/cloudfriend');
+
+module.exports = {
+  AWSTemplateFormatVersion: '2010-09-09',
+  Description: 'ecs-clusters ci resources for validating the template',
+  Resources: {
+    User: {
+      Type: 'AWS::IAM::User',
+      Properties: {
+        Policies: [
+          {
+            PolicyName: 'validate-templates',
+            PolicyDocument: {
+              Statement: [
+                {
+                  Action: ['cloudformation:ValidateTemplate'],
+                  Effect: 'Allow',
+                  Resource: '*'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    AccessKey: {
+      Type: 'AWS::IAM::AccessKey',
+      Properties: {
+        UserName: cf.ref('User')
+      }
+    }
+  },
+  Outputs: {
+    AccessKeyId: { Value: cf.ref('AccessKey') },
+    SecretAccessKey: { Value: cf.getAtt('AccessKey', 'SecretAccessKey') }
+  }
+};
+

--- a/lib/template.js
+++ b/lib/template.js
@@ -178,6 +178,7 @@ module.exports = (options = {}) => {
   const Resources = {};
 
   if (options.notificationTopic && options.notificationEmail) throw new Error('Cannot provide both notificationTopic and notificationEmail.');
+  if (!options.notificationTopic && !options.notificationEmail) throw new Error('Must provide either notificationTopic or notificationEmail.');
   const notify = options.notificationTopic || cf.ref(prefixed('NotificationTopic'));
 
   if (options.notificationEmail) Resources[prefixed('NotificationTopic')] = {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "watchbot": "./bin/watchbot.js"
   },
   "scripts": {
+    "pretest": "npm run lint && npm run validate-templates",
     "lint": "eslint bin lib test index.js",
     "test": "tape test/*.test.js | tap-spec && jest test/*.jest.js",
     "validate-templates": "tape test/template.validation.js | tap-spec",

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -80,6 +80,18 @@ Object {
       },
       "Type": "AWS::Logs::LogGroup",
     },
+    "SoupNotificationTopic": Object {
+      "Description": "Subscribe to this topic to receive emails when tasks fail or retry",
+      "Properties": Object {
+        "Subscription": Array [
+          Object {
+            "Endpoint": "hello@mapbox.pagerduty.com",
+            "Protocol": "email",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
     "SoupQueue": Object {
       "Properties": Object {
         "MessageRetentionPeriod": 1096,
@@ -726,6 +738,18 @@ Object {
         "RetentionInDays": 14,
       },
       "Type": "AWS::Logs::LogGroup",
+    },
+    "WatchbotNotificationTopic": Object {
+      "Description": "Subscribe to this topic to receive emails when tasks fail or retry",
+      "Properties": Object {
+        "Subscription": Array [
+          Object {
+            "Endpoint": "hello@mapbox.pagerduty.com",
+            "Protocol": "email",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
     },
     "WatchbotQueue": Object {
       "Properties": Object {

--- a/test/template.jest.js
+++ b/test/template.jest.js
@@ -16,7 +16,8 @@ test('[template]', () => {
     service: 'example',
     serviceVersion: '1',
     command: 'echo hello world',
-    cluster: 'processing'
+    cluster: 'processing',
+    notificationEmail: 'hello@mapbox.pagerduty.com'
   });
 
   expect(builtWithDefaults).toMatchSnapshot('defaults');
@@ -47,7 +48,8 @@ test('[template]', () => {
     },
     privileged: true,
     messageTimeout: 300,
-    messageRetention: 1096
+    messageRetention: 1096,
+    notificationEmail: 'hello@mapbox.pagerduty.com'
   });
 
   expect(setsAllOptions).toMatchSnapshot('all-properties');

--- a/test/template.validation.js
+++ b/test/template.validation.js
@@ -13,7 +13,8 @@ test('[template validation] defaults', async (assert) => {
     service: 'example',
     serviceVersion: '1',
     command: 'echo hello world',
-    cluster: 'processing'
+    cluster: 'processing',
+    notificationEmail: 'hello@mapbox.pagerduty.com'
   });
 
   const tmp = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
@@ -56,7 +57,8 @@ test('[template validation] options set', async (assert) => {
     },
     privileged: true,
     messageTimeout: 300,
-    messageRetention: 1096
+    messageRetention: 1096,
+    notificationEmail: 'hello@mapbox.pagerduty.com'
   });
 
   const tmp = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));


### PR DESCRIPTION
Adds permission for the travis user to run `cloudformation.validateTemplate` and confirms that tests pass after the validation is added.

Merges into #184 