### PR TITLE
Add docs back

### DIFF
--- a/docs/building-a-template.md
+++ b/docs/building-a-template.md
@@ -1,0 +1,128 @@
+## Building a Watchbot template
+
+Watchbot provides two important methods to help you build a CloudFormation template:
+
+- **watchbot.template(options)** creates CloudFormation JSON objects for the various Resources that Watchbot needs in order to do its job.
+- **watchbot.merge(...templates)** takes multiple CloudFormation templates and merges them together into a single JSON template.
+
+With those two tools in hand, creating a Watchbot stack will generally involve:
+- determine the appropriate `options` to provide to `watchbot.template` for your situation. See the table below for more details on the various required options, optional ones, and default values.
+- write a CloudFormation template that defines the configuration parameters, stack outputs, permissions required by your worker containers, and any additional resources that are required in order to process jobs.
+- write a script which merges the two templates, adding Watchbot's resources to your template.
+- use [cfn-config](https://github.com/mapbox/cfn-config) to deploy the template by referencing the script that you've written.
+
+As an example, consider a service where the workers are expected to manipulate objects in an S3 bucket. In the CloudFormation template, we wish to create the S3 bucket that our workers will interact with, and then build the Watchbot resources required to perform the task in response to SNS events.
+
+```js
+var watchbot = require('@mapbox/watchbot');
+
+// Build the parameters, resources, and outputs that your service needs
+var myTemplate = {
+  Parameters: {
+    GitSha: { Type: 'String' },
+    Cluster: { Type: 'String' },
+    AlarmEmail: { Type: 'String' }
+  },
+  Resources: {
+    MyBucket: {
+      Type: 'AWS::S3::Bucket',
+      Properties: {
+        Name: 'my-bucket'
+      }
+    }
+  }
+};
+
+// Generate Watchbot resources. You can use references to parameters and
+// resources that were defined above.
+var watch = watchbot.template({
+  cluster: { Ref: 'Cluster' },
+  service: 'my-repo-name',
+  serviceVersion: { Ref: 'GitSha' },
+  env: { BucketName: 'my-bucket' },
+  workers: 5,
+  reservation: { memory: 512 },
+  notificationEmail: { Ref: 'AlarmEmail' },
+  permissions: [
+    {
+      Effect: 'Allow',
+      Action: ['s3:*'],
+      Resource: {
+        'Fn::Join': ['', ['arn:aws:s3:::', { Ref: 'MyBucket' }]]
+      }
+    }
+  ]
+});
+
+module.exports = watchbot.merge(myTemplate, watch);
+```
+
+### watchbot.template options
+
+Use the following configuration options to adjust the resources that Watchbot will provide. Bold options must be provided.
+
+Name | Default | Description
+--- | --- | ---
+**cluster** | | the ARN for an ECS cluster
+**service** | | the name of the worker service
+**serviceVersion** | | the version of the worker service to use
+**notificationEmail** | | the email address to receive failure notifications. Should not be provided if notificationTopic exists.
+**notificationTopic** | | the ARN of an SNS topic to receive failure notifications. Should not be provided if notificationEmail exists.
+alarmOnEachFailure | false | send a notification email each time a worker errors
+alarmPeriods | 24 | number of 5-min intervals SQS must be above threshold to alarm
+alarmThreshold | 40 | number of jobs in SQS to trigger alarm
+command | | overrides a Dockerfile's `CMD`
+debugLogs | false | enable verbose watcher logging
+env | {} | environment variables to set on worker containers
+family | service name | the name of the the task definition family that watchbot will create revisions of
+errorThreshold | 10 | number of failed workers to trigger alarm
+failedPlacementAlarmPeriods | 1 | number of 1-min intervals for which failed placements exceeds the threshold of 5 in order to alarm
+logAggregationFunction | | the ARN of the log collection Lambda function
+messageRetention | 1209600 | max seconds a message can remain in SQS
+messageTimeout | 600 | max seconds it takes to process a job
+mounts | | defines persistent container mount points from host EC2s or ephemeral mount points on the container
+permissions | [] | permissions to any AWS resources that the worker will need to perform a task. Be sure to unwrap any `PolicyDocument` objects. The use of `PolicyDocument` here will pass `aws cloudformation validate-template`, but will prevent your stack from being created successfully.
+placementConstraints | false | Add any [ECS task placement constraints](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html)
+prefix | `Watchbot` | a prefix for logical resource names
+privileged | false | give the worker container elevated privileges on the host EC2
+reduce | false | enable reduce-mode (see below)
+readCapacityUnits | 30 | approximate reads per second to progress table in reduce-mode
+reservation | {} | specify desired memory/cpu reservations for worker containers
+reservation.cpu | | specify a soft CPU limit
+reservation.memory | 64 | specify a hard memory limit
+reservation.softMemory | | specify a soft memory limit
+user | false | create an IAM user with permission to publish
+watchbotVersion | installed version | the version of watchbot to use
+watchers | 1 | number of watcher containers
+webhook | false | create an HTTPS endpoint to accept jobs
+webbhookKey | false | require an access token on the webhook endpoint
+workers | 1 | number of concurrent worker containers per watcher
+writeCapacityUnits | 30 | approximate writes per second to progress table in reduce-mode
+
+### watchbot.template references
+
+After building Watchbot resources using `watchbot.template()`, you may wish to reference some of those resources. The object returned from `watchbot.template()` provides references to a few of its resources through a `.ref` property:
+
+Name | Description
+--- | ---
+.ref.logGroup | the CloudWatch LogGroup where watcher and worker container's logs are written
+.ref.topic | the SNS topic that you can publish messages to in order to have them processed by Watchbot
+.ref.queueUrl | the URL of the SQS Queue Watchbot built
+.ref.queueArn | the ARN of the SQS Queue Watchbot built
+.ref.queueName | the name of the SQS Queue Watchbot built
+.ref.notificationTopic | the SNS topic that receives notifications when processing fails
+.ref.webhookEnpoint | [conditional] if requested, the URL for the webhook endpoint
+.ref.webhookKey | [conditional] if requested, the access token for making webhook requests
+.ref.accessKeyId | [conditional] if requested, an AccessKeyId with permission to publish to Watchbot's SNS topic
+.ref.secretAccessKey | [conditional] if requested, a SecretAccessKey with permission to publish to Watchbot's SNS topic
+.ref.progressTable | [conditional] if running in reduce-mode, the name of the DynamoDB table that tracks job progress
+
+These properties each return CloudFormation references (i.e. `{ "Ref": "..." }` objects) that can be used in your template. In the above example, if I wanted my stack to output the SNS topic built by Watchbot, I could:
+
+```js
+var outputs = {
+  Outputs: { SnsTopic: { Value: watcher.ref.topic } }
+};
+
+module.exports.watchbot.merge(myTemplate, watcher, outputs);
+```

--- a/docs/command-line-utilities.md
+++ b/docs/command-line-utilities.md
@@ -1,0 +1,58 @@
+## Command-line utilities
+
+```
+> watchbot --help
+
+  Build an AWS stack to do your work for you
+
+  USAGE: watchbot <command> [OPTIONS]
+
+  Commands:
+    worker-capacity     assess available resources on the cluster
+    dead-letter         triage messages in dead letter queue
+
+  Options:
+    -h, --help          show this help message
+    -s, --stack-name    the full name of a watchbot stack
+    -r, --region        the region of the stack (default us-east-1)
+```
+
+### worker-capacity
+
+`worker-capacity` helps estimate how many additional workers can be placed in
+your service's cluster at its current capacity using the CPU and memory
+reservations provided in your `watchbot.template`.
+
+You must provide both a service region and stack name to execute this command. Note
+that your stack will need to expose the cluster ARN in your Watchbot stack `Outputs`
+property. Pre-2.0 versions of Watchbot do not expose these outputs.
+
+### dead-letter
+
+`dead-letter` is an interactive tool for dealing with messages in Watchbot's [dead letter queue](./worker-retry-cycle.md#the-dead-letter-queue).
+
+You must provide both a service region and stack name to execute this command. Note
+that your stack will need to expose the cluster ARN in your Watchbot stack `Outputs`
+property. Pre-2.0 versions of Watchbot do not expose these outputs.
+
+### Dead letter workflow
+
+First, if your stack contains more than one watchbot system, you will first be prompted to select which one you wish to work with. If your stack contains only one watchbot system, you will proceed straight to the next step.
+
+You'll be asked with action you wish to take. Your choices are:
+
+  - **Triage dead messages individually?**: interact with messages one-by-one
+  - **Print out all dead messages?**: This will print the subject and message of every job in the dead letter queue as line-delimited JSON strings
+  - **Return all dead messages to the work queue?**: Every message in the dead letter queue is sent back to Watchbot's primary work queue for another attempt. You will be asked to confirm before this will proceed.  
+  - **Purge the dead letter queue?**: Deletes every message from the dead letter queue. If messages in the dead letter queue still need to be processed, you will have to send them to Watchbot's primary work queue again manually. You will be asked to confirm before this will proceed.
+
+If you selected individual triage, you'll be presented with a set of options for each message in the dead letter queue.
+
+  - **View this message's recent logs?**: Queries CloudWatch Logs to try and find the most recent 50kb worth of logs related to the message. *Warning:* this can be quite slow.
+  - **Return this message to the work queue?**: Sends this message back to Watchbot's primary work queue for reprocessing.
+  - **Return this message to the dead letter queue?**: Puts the message back into the dead letter queue to be investigated later.
+  - **Delete this message entirely?**: Removes the message from the dead letter queue. If the message still needs to be processed, you will have to send it to Watchbot's primary work queue again manually.
+  - **Stop individual triage?**: Stop triaging and exit the CLI.
+
+Once all the messages in the dead letter queue have been either sent back to primary work queue or deleted, the CLI will exit.
+

--- a/docs/logging-and-metrics.md
+++ b/docs/logging-and-metrics.md
@@ -1,0 +1,54 @@
+## Logging
+
+Each Watchbot stack will write all its logs to a single CloudWatch LogGroup. The [awscli](http://docs.aws.amazon.com/cli/latest/reference/logs/index.html) or [cwlogs](https://github.com/mapbox/cwlogs) are a couple of tools that can be used to view log events in a LogGroup.
+
+If your host EC2s **are not** built from [ECS-optimized AMIs](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html), make sure that the `awslogs` driver is enabled on the ecs-agent by setting the following agent configuration:
+
+```
+ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","awslogs"]
+```
+
+See [the AWS documentation](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html) for more information.
+
+### Formatting log messages
+
+In order to help isolate and aggregate logs from any single message, watchbot provides a logging helper that will prefix each line with the ID of the message being processed. Use these utilities in your worker scripts to make sure that your logs are consistent and easy to search.
+
+```js
+var watchbot = require('@mapbox/watchbot');
+
+// watchbot.log() works just like console.log()
+var breakfast = 'eggs and beans';
+watchbot.log('This is something that I want logged: %s', breakfast);
+// [Thu, 28 Jul 2016 00:12:37 GMT] [worker] [e2c045cc-5606-4950-964b-20877900bccb] This is something that I want logged: eggs and beans
+
+// watchbot.logStream() creates a writable stream that will log everything with watchbot.log
+var logstream = watchbot.logStream();
+require('child_process').exec('cat ~/.bashrc').stdout.pipe(logstream);
+```
+
+There is also a CLI tool to accomplish the same task:
+
+```bash
+# Perform this global installation in your Dockerfile
+$ npm install -g watchbot
+
+# Log a single line instead of using `echo`
+$ watchbot-log "This is something that I want logged: eggs and beans"
+
+# Pipe another command's output into watchbot-log
+$ echo "This is something that I want logged: eggs and beans" | watchbot-log
+```
+
+## Custom metrics
+
+Custom metrics are collected under the namespace `Mapbox/ecs-watchbot`. They are mined via filters on CloudWatch logs, and can help you learn about the state of your Watchbot stack. Each custom metric is suffixed with your stack's name, e.g. `-MyWatchbotStack`.
+
+Metric | Description | Statistics
+--- | --- | ---
+**FailedWorkerPlacement** | The total number of times a watcher had difficulty placing a worker on the cluster - This probably means your concurrency is too high, your reservations are too high, or your cluster is too small | Sum
+**WorkerErrors** | The total number of failed workers per minute. High levels of this error trigger the `WorkerErrors` alarm | Sum
+**MessageReceives** | A metric collected for every received message that indicates how many times the message has been pulled from the queue | Maximum
+**WatcherConcurrency** | The number of workers running per watcher | `Sum`and `Average`
+**WorkerDuration** | The amount of time taken by a worker to run a task | `Average`, `Minimum` and `Maximum`
+

--- a/docs/reduce-mode.md
+++ b/docs/reduce-mode.md
@@ -1,0 +1,64 @@
+## Reduce mode
+
+By setting the `Reduce` parameter to true, Watchbot will be capable of helping track the
+progress of distributed map-reduce operations. This is useful if your stack performs
+a bunch of individual jobs that need to be "rolled up" into a final output of some sort.
+
+### Messaging patterns
+
+Generally, a reduce-enabled Watchbot stack should be built in order to process three types
+of messages: one type that kicks of a map-reduce operation, one type that processes
+individual parts, and another type that performs the reduce or "roll up" operation.
+
+Your code should include all the logic required to interpret these different types
+of messages. The flow of messages will generally be as follows:
+
+1. You (or some AWS resource) sends the initial message to your Watchbot stack's SNS
+topic. When your code receives this message, it should:
+  - determine how the work will be split across multiple parts
+  - generate an identifier for the entire map-reduce operation
+  - report to Watchbot the identifier, and the number of parts
+  - send SNS messages to Watchbot's SNS topic for each part, providing the identifier
+  for the operation, and the part number. Part numbers start a `1` and increase up
+  to the total number of parts.
+2. Watchbot will receive the "work" jobs that were sent by your initial message processor.
+When your code receives these messages, it should:
+  - perform appropriate processing
+  - once processing is complete, report the identifier and the part number of the job
+  to Watchbot. In response, Watchbot will inform your code as to whether or not all
+  the parts in the map-reduce operation are completed.
+  - if the worker receives the notification that all parts are complete, the worker
+  should send a single message to Watchbot's SNS topic to trigger the reduce step
+3. Upon receiving the reduce message, your code should take any appropriate roll-up
+action.
+
+### Using watchbot-progress
+
+`watchbot-progress` is a CLI command that is available to use on a reduce-enabled
+stack. This is one mechanism by which you can report progress to Watchbot as part
+ofthe above messaging flow.
+
+For usage examples and and additional documentation, see [watchbot-progress](https://github.com/mapbox/watchbot-progress).
+
+Install Watchbot globally as part of your worker's Dockerfile to gain access to the
+CLI command on your workers at runtime:
+
+```
+RUN npm install -g watchbot
+```
+
+```
+$ watchbot-progress <command> <job-id> [options]
+```
+
+Note that by default, workers in reduce-enabled Watchbot stacks will have the `$ProgressTable`
+environment variable set automatically. For more information on this command, see
+
+#### Reporting progress in JavaScript
+
+A JavaScript module is also available as a mechanism for progress reporting.
+
+```js
+var progress = require('@mapbox/watchbot').progress();
+```
+

--- a/docs/worker-runtime-details.md
+++ b/docs/worker-runtime-details.md
@@ -1,0 +1,41 @@
+## Worker runtime environment
+
+In addition to any environment variables pre-configured for your worker via `watchbot.template()` (see below), Watchbot will provide each worker with a set of environment variables representing the details of the message which it should process:
+
+Name | Description
+--- | ---
+Subject | the message's subject
+Message | the message's body
+MessageId | the message's ID defined by SQS
+SentTimestamp | the time the message was sent
+ApproximateFirstReceiveTimestamp | the time the message was first attempted
+ApproximateReceiveCount | the number of times the message has been attempted
+
+The environment will also contain some variables referencing resources that Watchbot created:
+
+Name | Description
+--- | ---
+WorkTopic | the ARN of the SNS topic that provides messages to SQS
+LogGroup | the name of the CloudWatch LogGroup where logs are sent
+
+**:lock: Encrypting & decrypting environment variables**
+
+The recommended flow for deploying Watchbot stacks is to use [cfn-config(http://github.com/mapbox/cfn-config) which provides a `--kms` option for automatically encrypting CloudFormation parameters marked with `[secure]`. To decrypt at runtime, install [decrypt-kms-env](https://github.com/mapbox/decrypt-kms-env) as a dependency in your Dockerfile and invoke it in your `CMD`. Example:
+
+```Dockerfile
+RUN eval $(./node_modules/.bin/decrypt-kms-env) && npm start
+```
+
+## Worker completion
+
+The exit code from your worker determines what the watcher will do with the message that was being processed. Your options are:
+
+Exit code | Description | Outcome
+--- | --- | ---
+0 | completed successfully | message is removed from the queue without notification
+3 | rejected the message | message is removed from the queue and a notification is sent
+4 | no-op | message is returned to the queue without notification
+other | failure | message is returned to the queue and a notification is sent
+
+When a message is returned to the queue, it will be retried. [See the worker retry documentation](./worker-retry-cycle.md) for more info.
+

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,52 @@
-# ecs-watchbot
+[![Build Status](https://travis-ci.org/mapbox/ecs-watchbot.svg?branch=master)](https://travis-ci.org/mapbox/ecs-watchbot)
 
-[wip] Container re-use means we don't make any RunTask API calls. We launch a container or set of containers, and they keep processing SQS messages until there are no messages left to process.
+# watchbot
+
+A library to help run a highly-scalable AWS service that performs data processing tasks in response to external events. You provide the messages and the logic to process them, while Watchbot handles making sure that your processing task is run at least once for each message. Watchbot is similar in many regards to AWS Lambda, but is more configurable, more focused on data processing, and not subject to several of Lambda's limitations.
+
+## Helpful lingo
+
+- **queue**: [An SQS queue](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSConcepts.html) is a "backlog" of messages for your stack to process that helps to guarantee every message gets processed at least once.
+- **message**: A message in the queue represents some job to be processed. Generally, you are responsible for sending messages to your stack by [publishing to Watchbot's SNS topic](http://docs.aws.amazon.com/sns/latest/dg/PublishTopic.html), or optionally by POST to a webhook endpoint (see `WatchbotUseWebhooks` in the parameters section below).
+- **worker**: CLI command/subprocess responsible for processing a single message. You define the work performed by the worker through the `command` property in the cloudformation template. Watchbot sets environment variables for the subprocess that represent the content of a single message.
+- **watcher**: The main process in the container that polls the queue, spawns worker subprocesses to process messages, and tracks results.
+- **task**: The [ECS task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html) that contains both the watcher main process and all of the worker subprocesses. You specify how many tasks to run using the `maxSize` and `minSize` parameters in the cloudformation template. The service scales the number of tasks based on the existence of messages in the queue.
+- **cluster**: [An ECS cluster](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_clusters.html) of EC2s that are used to run the watcher and worker containers that make up your service.
+- **template**: [A CloudFormation template](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-whatis-concepts.html#d0e3428) defining the resources Watchbot needs
+
+## What you provide:
+
+- a cluster that Watchbot will run on
+- a docker image representing your task, housed in [an ECR repository](http://docs.aws.amazon.com/AmazonECR/latest/userguide/Repositories.html) and tagged with a git sha or a git tag
+- a CloudFormation template defining any configuration Parameters, Resources, and Outputs that your service needs in order to perform its processing.
+
+**:bulb: Other prerequisites:**
+
+- `cloudformation-kms-production` deployed according to the instructions in [cloudformation-kms](https://github.com/mapbox/cloudformation-kms). Makes encryption of sensitive environment variables that need to be passed to ECS simple using [cfn-config](https://github.com/mapbox/cfn-config).
+
+## What Watchbot provides:
+
+- a queue for you to send messages to in order to trigger your workers to run
+- [optionally] [an AWS access key](http://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) with permission to send messages to the queue
+- [an ECS TaskDefinition](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html) for your worker, using the image you provide
+- one or more watcher containers that run continuously on your cluster, polling the queue, running a worker for each message, removing messages from the queue as workers complete, and managing worker failures and retries
+- a script to help you include the resources Watchbot needs to run in your template
+
+
+## Building a Watchbot service
+
+1. Create a Github repository for your code.
+2. Write and test the code that a worker will perform in response to a message.
+3. Write a Dockerfile at the root of your repository which defines the steps required to bootstrap a worker. Rather than specifying a `CMD` instructions, use the `command` property in the cloudformation template to indicate what will be executed when your worker is launched in response to a message. Note that message details will be provided as environment variables to your worker subprocess, and that your worker's exit code will determine whether the message is deleted or returned to the queue (see below).
+4. Use the Dockerfile to build an image and store it in an ECR repository. See [ecs-conex](https://github.com/mapbox/ecs-conex) for a CI framework to do this for you whenever you commit to the repository.
+5. Write and deploy your service using a CloudFormation template that watchbot helps you to build.
+
+## More documentation
+
+1. [Building a Watchbot template](./docs/building-a-template.md)
+2. [The worker's runtime environment](./docs/worker-runtime-details.md)
+3. [What happens when workers fail?](./docs/worker-retry-cycle.md)
+4. [Logging and metrics](./docs/logging-and-metrics.md)
+5. [Using Watchbot's reduce-mode](./docs/reduce-mode.md)
+6. [Watchbot's command-line utilities](./docs/command-line-utilities.md)
+7. [Watchbot's CloudWatch alarms](./docs/alarms.md)


### PR DESCRIPTION
Adds the docs from their form in watchbot 3 with a few tweaks.

Going to merge this as a temporary solution until we can refactor them to be up to date with watchbot 4.

cc/ @mapbox/platform-engine-room 