### PR TITLE
Use the stack-name in the `Name` property of the ContainerDefinition

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -344,7 +344,7 @@ module.exports = (options = {}) => {
       Family: options.family,
       ContainerDefinitions: [
         {
-          Name: cf.join('-', [prefixed(''), options.service]),
+          Name: cf.join('-', [prefixed(''), cf.stackName]),
           Image: cf.join([
             cf.accountId,
             '.dkr.ecr.us-east-1.amazonaws.com/',

--- a/lib/template.js
+++ b/lib/template.js
@@ -344,7 +344,7 @@ module.exports = (options = {}) => {
       Family: options.family,
       ContainerDefinitions: [
         {
-          Name: prefixed(`-${options.service}`).toLowerCase(),
+          Name: cf.join('-', [prefixed(''), options.service]),
           Image: cf.join([
             cf.accountId,
             '.dkr.ecr.us-east-1.amazonaws.com/',

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -594,7 +594,9 @@ Object {
                 "-",
                 Array [
                   "Soup",
-                  "example",
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
                 ],
               ],
             },
@@ -1262,7 +1264,9 @@ Object {
                 "-",
                 Array [
                   "Watchbot",
-                  "example",
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
                 ],
               ],
             },

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -589,7 +589,15 @@ Object {
                 "SourceVolume": "mnt-1",
               },
             ],
-            "Name": "soup-example",
+            "Name": Object {
+              "Fn::Join": Array [
+                "-",
+                Array [
+                  "Soup",
+                  "example",
+                ],
+              ],
+            },
             "Privileged": true,
             "ReadonlyRootFilesystem": true,
             "Ulimits": Array [
@@ -1249,7 +1257,15 @@ Object {
                 "SourceVolume": "tmp",
               },
             ],
-            "Name": "watchbot-example",
+            "Name": Object {
+              "Fn::Join": Array [
+                "-",
+                Array [
+                  "Watchbot",
+                  "example",
+                ],
+              ],
+            },
             "Privileged": false,
             "ReadonlyRootFilesystem": true,
             "Ulimits": Array [


### PR DESCRIPTION
Fixes https://github.com/mapbox/ecs-watchbot/issues/213

Currently, the `options.service` variable is required to be a string since it's concatenated with the `options.prefix` to create the `Name` property of the container. This PR removes that requirement and allows the `options.service` to be a Cloudformation reference. Besides the flexibility that this allowance gives us, it is also useful for differentiating containers of different stacks of the same repository, since the `options.service` can be referenced to `AWS::StackName` now, for example.