### PR TITLE
Only expose template, which can run on node 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,5 @@
 'use strict';
 
 module.exports = {
-  template: require('./lib/template'),
-  Messages: require('./lib/messages'),
-  Message: require('./lib/message'),
-  Worker: require('./lib/worker'),
-  Watcher: require('./lib/watcher'),
-  Logger: require('./lib/logger')
+  template: require('./lib/template')
 };


### PR DESCRIPTION
Exposes the template, but removes the exposed modules that rely on node 8. People can now locally run node 6 and compile the template.

cc/ @mapbox/platform-engine-room 