### PR TITLE
Allow empty sns Subject

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -36,7 +36,6 @@ class Message {
 
     this.env = {
       MessageId: sqsMessage.MessageId,
-      Subject: snsMessage.Subject,
       Message: snsMessage.Message,
       SentTimestamp: new Date(
         Number(sqsMessage.Attributes.SentTimestamp)
@@ -46,6 +45,8 @@ class Message {
       ).toISOString(),
       ApproximateReceiveCount: sqsMessage.Attributes.ApproximateReceiveCount.toString()
     };
+
+    if (snsMessage.Subject) this.env.Subject = snsMessage.Subject;
 
     this.sqs = new AWS.SQS({
       region: url.parse(options.queueUrl).host.split('.')[1],

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -84,6 +84,17 @@ test('[message] factory', (assert) => {
   assert.end();
 });
 
+test('[message] no SNS subject', (assert) => {
+  const sqsMessageCopy = Object.assign({}, sqsMessage);
+  sqsMessageCopy.Body = JSON.stringify({ Message: '1' }); // no Subject
+
+  const message = Message.create(sqsMessageCopy, { queueUrl });
+  assert.notOk(message.env.Subject);
+  assert.ok(message.env.Message);
+
+  assert.end();
+});
+
 test('[message] retry', async (assert) => {
   const cmv = AWS.stub('SQS', 'changeMessageVisibility', function() {
     this.request.promise.returns(Promise.resolve());


### PR DESCRIPTION
Currently, If an SNS message is sent with no Subject parameter, the `$Subject` in the worker script is set to the literal word "undefined". This could be breaking for stacks that respond to multiple Subject values that expect an empty/default subject value to be an unset variable; this was the old behaviour

cc @jakepruitt @rclark 