### PR TITLE
Prefix the alarm names

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -478,7 +478,7 @@ module.exports = (options = {}) => {
   Resources[prefixed('ScaleUpTrigger')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      AlarmName: cf.sub('${AWS::StackName}-scale-up'),
+      AlarmName: cf.join('-', [cf.ref('AWS::StackName'), prefixed('-scale-up')]),
       AlarmDescription: 'Scale up due to visible messages in queue',
       EvaluationPeriods: 1,
       Statistic: 'Maximum',
@@ -498,7 +498,7 @@ module.exports = (options = {}) => {
     Type: 'AWS::ApplicationAutoScaling::ScalingPolicy',
     Properties: {
       ScalingTargetId: cf.ref(prefixed('ScalingTarget')),
-      PolicyName: cf.sub('${AWS::StackName}-scale-down'),
+      PolicyName: cf.sub(prefixed('${AWS::StackName}-scale-down')),
       PolicyType: 'StepScaling',
       StepScalingPolicyConfiguration: {
         AdjustmentType: 'PercentChangeInCapacity',
@@ -517,7 +517,7 @@ module.exports = (options = {}) => {
   Resources[prefixed('ScaleDownTrigger')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      AlarmName: cf.sub('${AWS::StackName}-scale-down'),
+      AlarmName: cf.join('-', [cf.ref('AWS::StackName'), prefixed('-scale-down')]),
       AlarmDescription:
         'Scale down due to lack of in-flight messages in queue',
       EvaluationPeriods: 1,
@@ -537,7 +537,7 @@ module.exports = (options = {}) => {
   Resources[prefixed('DeadLetterAlarm')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      AlarmName: cf.sub('${AWS::StackName}-dead-letter'),
+      AlarmName: cf.join('-', [cf.ref('AWS::StackName'), prefixed('-dead-letter')]),
       AlarmDescription:
         'Provides notification when messages are visible in the dead letter queue',
       EvaluationPeriods: 1,
@@ -570,7 +570,7 @@ module.exports = (options = {}) => {
   Resources[prefixed('WorkerErrorsAlarm')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      AlarmName: cf.sub('${AWS::StackName}-worker-errors'),
+      AlarmName: cf.join('-', [cf.ref('AWS::StackName'), prefixed('-worker-errors')]),
       AlarmDescription:
         `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/docs/alarms.md#workererrors`,
       EvaluationPeriods: 1,
@@ -587,7 +587,7 @@ module.exports = (options = {}) => {
   Resources[prefixed('QueueSizeAlarm')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      AlarmName: cf.sub('${AWS::StackName}-queue-size'),
+      AlarmName: cf.join('-', [cf.ref('AWS::StackName'), prefixed('-queue-size')]),
       AlarmDescription:
         `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/docs/alarms.md#queuesize`,
       EvaluationPeriods: options.alarmPeriods,
@@ -610,7 +610,7 @@ module.exports = (options = {}) => {
   Resources[prefixed('AlarmMemoryUtilization')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      AlarmName: cf.join('-', [cf.ref('AWS::StackName'), 'MemoryUtilization']),
+      AlarmName: cf.join('-', [cf.ref('AWS::StackName'), prefixed('MemoryUtilization')]),
       AlarmDescription:
         `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/docs/alarms.md#memoryutilization`,
       Namespace: 'AWS/ECS',
@@ -637,7 +637,7 @@ module.exports = (options = {}) => {
   Resources[prefixed('AlarmCPUUtilization')] = {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      AlarmName: cf.join('-', [cf.ref('AWS::StackName'), 'CPUUtilization']),
+      AlarmName: cf.join('-', [cf.ref('AWS::StackName'), prefixed('CPUUtilization')]),
       AlarmDescription:
         `https://github.com/mapbox/ecs-watchbot/blob/${options.watchbotVersion}/docs/alarms.md#cpuutilization`,
       Namespace: 'AWS/ECS',

--- a/test/__snapshots__/template.jest.js.snap
+++ b/test/__snapshots__/template.jest.js.snap
@@ -24,7 +24,7 @@ Object {
               Object {
                 "Ref": "AWS::StackName",
               },
-              "CPUUtilization",
+              "SoupCPUUtilization",
             ],
           ],
         },
@@ -68,7 +68,7 @@ Object {
               Object {
                 "Ref": "AWS::StackName",
               },
-              "MemoryUtilization",
+              "SoupMemoryUtilization",
             ],
           ],
         },
@@ -131,7 +131,15 @@ Object {
         ],
         "AlarmDescription": "Provides notification when messages are visible in the dead letter queue",
         "AlarmName": Object {
-          "Fn::Sub": "\${AWS::StackName}-dead-letter",
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Soup-dead-letter",
+            ],
+          ],
         },
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": Array [
@@ -281,7 +289,15 @@ Object {
         ],
         "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.5.1/docs/alarms.md#queuesize",
         "AlarmName": Object {
-          "Fn::Sub": "\${AWS::StackName}-queue-size",
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Soup-queue-size",
+            ],
+          ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": Array [
@@ -410,7 +426,7 @@ Object {
     "SoupScaleDown": Object {
       "Properties": Object {
         "PolicyName": Object {
-          "Fn::Sub": "\${AWS::StackName}-scale-down",
+          "Fn::Sub": "Soup\${AWS::StackName}-scale-down",
         },
         "PolicyType": "StepScaling",
         "ScalingTargetId": Object {
@@ -439,7 +455,15 @@ Object {
         ],
         "AlarmDescription": "Scale down due to lack of in-flight messages in queue",
         "AlarmName": Object {
-          "Fn::Sub": "\${AWS::StackName}-scale-down",
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Soup-scale-down",
+            ],
+          ],
         },
         "ComparisonOperator": "LessThanThreshold",
         "Dimensions": Array [
@@ -494,7 +518,15 @@ Object {
         ],
         "AlarmDescription": "Scale up due to visible messages in queue",
         "AlarmName": Object {
-          "Fn::Sub": "\${AWS::StackName}-scale-up",
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Soup-scale-up",
+            ],
+          ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": Array [
@@ -746,7 +778,15 @@ Object {
         ],
         "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.5.1/docs/alarms.md#workererrors",
         "AlarmName": Object {
-          "Fn::Sub": "\${AWS::StackName}-worker-errors",
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Soup-worker-errors",
+            ],
+          ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
@@ -822,7 +862,7 @@ Object {
               Object {
                 "Ref": "AWS::StackName",
               },
-              "CPUUtilization",
+              "WatchbotCPUUtilization",
             ],
           ],
         },
@@ -866,7 +906,7 @@ Object {
               Object {
                 "Ref": "AWS::StackName",
               },
-              "MemoryUtilization",
+              "WatchbotMemoryUtilization",
             ],
           ],
         },
@@ -929,7 +969,15 @@ Object {
         ],
         "AlarmDescription": "Provides notification when messages are visible in the dead letter queue",
         "AlarmName": Object {
-          "Fn::Sub": "\${AWS::StackName}-dead-letter",
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-dead-letter",
+            ],
+          ],
         },
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": Array [
@@ -1079,7 +1127,15 @@ Object {
         ],
         "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.5.1/docs/alarms.md#queuesize",
         "AlarmName": Object {
-          "Fn::Sub": "\${AWS::StackName}-queue-size",
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-queue-size",
+            ],
+          ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": Array [
@@ -1186,7 +1242,7 @@ Object {
     "WatchbotScaleDown": Object {
       "Properties": Object {
         "PolicyName": Object {
-          "Fn::Sub": "\${AWS::StackName}-scale-down",
+          "Fn::Sub": "Watchbot\${AWS::StackName}-scale-down",
         },
         "PolicyType": "StepScaling",
         "ScalingTargetId": Object {
@@ -1215,7 +1271,15 @@ Object {
         ],
         "AlarmDescription": "Scale down due to lack of in-flight messages in queue",
         "AlarmName": Object {
-          "Fn::Sub": "\${AWS::StackName}-scale-down",
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-scale-down",
+            ],
+          ],
         },
         "ComparisonOperator": "LessThanThreshold",
         "Dimensions": Array [
@@ -1270,7 +1334,15 @@ Object {
         ],
         "AlarmDescription": "Scale up due to visible messages in queue",
         "AlarmName": Object {
-          "Fn::Sub": "\${AWS::StackName}-scale-up",
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-scale-up",
+            ],
+          ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": Array [
@@ -1502,7 +1574,15 @@ Object {
         ],
         "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.5.1/docs/alarms.md#workererrors",
         "AlarmName": Object {
-          "Fn::Sub": "\${AWS::StackName}-worker-errors",
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-worker-errors",
+            ],
+          ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,


### PR DESCRIPTION
So there's no conflict when creating multiple watchbots in the same stack.

cc/ @dputtick 