### PR TITLE
Make dashboards prefix-able

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -13,8 +13,8 @@ module.exports = JSON.stringify({
         stacked: false,
         title: 'WatchbotQueue: Visible and NotVisible Messages',
         metrics: [
-          ['AWS/SQS', 'ApproximateNumberOfMessagesNotVisible', 'QueueName', '${AWS::StackName}-WatchbotQueue', { period: 60 }],
-          ['AWS/SQS', 'ApproximateNumberOfMessagesVisible', 'QueueName', '${AWS::StackName}-WatchbotQueue', { period: 60 }]
+          ['AWS/SQS', 'ApproximateNumberOfMessagesNotVisible', 'QueueName', '${WatchbotQueue}', { period: 60 }],
+          ['AWS/SQS', 'ApproximateNumberOfMessagesVisible', 'QueueName', '${WatchbotQueue}', { period: 60 }]
         ],
         stat: 'Sum',
         region: '${AWS::Region}',
@@ -37,7 +37,7 @@ module.exports = JSON.stringify({
         stacked: false,
         title: 'WatchbotQueue: Deleted messages',
         metrics: [
-          ['AWS/SQS', 'NumberOfMessagesDeleted', 'QueueName', '${AWS::StackName}-WatchbotQueue', { period: 60 }]
+          ['AWS/SQS', 'NumberOfMessagesDeleted', 'QueueName', '${WatchbotQueue}', { period: 60 }]
         ],
         stat: 'Sum',
         region: '${AWS::Region}',
@@ -80,7 +80,7 @@ module.exports = JSON.stringify({
         metrics: [
           ['Mapbox/ecs-cluster', 'RunningCapacity', 'ClusterName', '${Cluster}', 'ServiceName', '${WatchbotService}', { period: 60 , yAxis: 'right'  }],
           ['.', 'DesiredCapacity', '.', '.', '.', '.', { period: 60, yAxis: 'right'  }],
-          ['AWS/SQS', 'ApproximateNumberOfMessagesVisible', 'QueueName', '${AWS::StackName}-WatchbotQueue', { period: 60, stat: 'Sum' , yAxis: 'left' }]
+          ['AWS/SQS', 'ApproximateNumberOfMessagesVisible', 'QueueName', '${WatchbotQueue}', { period: 60, stat: 'Sum' , yAxis: 'left' }]
         ],
         region: '${AWS::Region}',
         period: 60,
@@ -120,8 +120,8 @@ module.exports = JSON.stringify({
         stacked: false,
         title: 'WatchbotDeadLetterQueue: Visible and NotVisible Messages',
         metrics: [
-          ['AWS/SQS', 'ApproximateNumberOfMessagesNotVisible', 'QueueName', '${AWS::StackName}-WatchbotDeadLetterQueue', { period: 60 }],
-          ['AWS/SQS', 'ApproximateNumberOfMessagesVisible', 'QueueName', '${AWS::StackName}-WatchbotDeadLetterQueue', { period: 60 }]
+          ['AWS/SQS', 'ApproximateNumberOfMessagesNotVisible', 'QueueName', '${WatchbotDeadLetterQueue}', { period: 60 }],
+          ['AWS/SQS', 'ApproximateNumberOfMessagesVisible', 'QueueName', '${WatchbotDeadLetterQueue}', { period: 60 }]
         ],
         stat: 'Sum',
         region: '${AWS::Region}',

--- a/lib/template.js
+++ b/lib/template.js
@@ -264,9 +264,10 @@ module.exports = (options = {}) => {
   Resources[prefixed('Dashboard')] = {
     Type: 'AWS::CloudWatch::Dashboard',
     Properties: {
-      DashboardName: cf.sub('${AWS::StackName}-${AWS::Region}'),
+      DashboardName: cf.join('-', [cf.ref('AWS::StackName'), prefixed(''), cf.region]),
       DashboardBody: cf.sub(dashboard, {
-        WatchbotQueue: cf.ref(prefixed('Queue')),
+        WatchbotQueue: cf.getAtt(prefixed('Queue'), 'QueueName'),
+        WatchbotDeadLetterQueue: cf.getAtt(prefixed('DeadLetterQueue'), 'QueueName'),
         WatchbotService: cf.getAtt(prefixed('Service'), 'Name'),
         Cluster: options.cluster
       })


### PR DESCRIPTION
Allow multiple dashboards to live in the same cloudformation template.

cc/ @mapbox/platform-engine-room @dputtick @amyjin7 