### PR TITLE
Use aws::partition for lambda scaling

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -694,7 +694,11 @@ module.exports = (options = {}) => {
               Action: [
                 'logs:*'
               ],
-              Resource: 'arn:aws:logs:*:*:*'
+              Resource: cf.join([
+                'arn:',
+                cf.partition,
+                ':logs:*:*:*'
+              ])
             }
           ]
         }

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -310,7 +310,18 @@ Object {
                     "logs:*",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:logs:*:*:*",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:",
+                        Object {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
                 },
               ],
             },
@@ -1338,7 +1349,18 @@ Object {
                     "logs:*",
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:logs:*:*:*",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:",
+                        Object {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
                 },
               ],
             },


### PR DESCRIPTION
Gnah, in #251 I forgot to check the changes of #249 in cn-north-1 again. This fell through the cracks.

- [x] Test in cn-north-1
- [x] Merge
- [ ] Release `4.7.1`