### PR TITLE
Trigger binary creation when tags are created manually

### DIFF
--- a/bin/watchbot-binary-generator.js
+++ b/bin/watchbot-binary-generator.js
@@ -21,7 +21,7 @@ const getTagForSha = async (sha) => {
     data.forEach((ref) => {
       ref = ref.split('\t');
       if (ref[0] !== sha) return;
-      const tagRegex = /refs\/tags\/(v[0-9.-]+)(\^\{(.*)\})*/;
+      const tagRegex = /refs\/tags\/(v?[0-9.-]+)(\^\{(.*)\})*/;
       return resolve(tagRegex.exec(ref[1])[1]);
     });
     return resolve(null);

--- a/test/bin.watchbot-binary-generator.test.js
+++ b/test/bin.watchbot-binary-generator.test.js
@@ -34,7 +34,7 @@ test('getTagForSha: commit not found', async (assert) => {
   assert.end();
 });
 
-test('uploadBundle: tag found', async (assert) => {
+test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major>`)', async (assert) => {
   process.env.CODEBUILD_RESOLVED_SOURCE_VERSION = 'f4815eb9f3bcfba88930bbe12d0888254af7cfa6';
 
   // stubs and spies
@@ -75,6 +75,56 @@ test('uploadBundle: tag found', async (assert) => {
   assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/linux/v4.1.1/watchbot'));
   assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/macosx/v4.1.1/watchbot'));
   assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/windows/v4.1.1/watchbot'));
+
+  fsCreateReadStreamStub.restore();
+  log.restore();
+  execStub.restore();
+  s3Stub.restore();
+  assert.end();
+});
+
+
+test('uploadBundle: tag found (Tag created manually)', async (assert) => {
+  process.env.CODEBUILD_RESOLVED_SOURCE_VERSION = 'f4815eb9f3bcfba88930bbe12d0888254af7cfa6';
+
+  // stubs and spies
+  const execStub = sinon.stub(wbg, 'exec').callsFake(() => {
+    return Promise.resolve({ stdout: 'f4815eb9f3bcfba88930bbe12d0888254af7cfa6\t/refs/tags/4.1.1' });
+  });
+  const fsCreateReadStreamStub = sinon.stub(fs, 'createReadStream').callsFake((file) => file);
+  const s3Stub = AWS.stub('S3', 'putObject', function () {
+    this.request.promise.returns(Promise.resolve());
+  });
+  const log = sinon.spy(console, 'log');
+
+  await wbg.uploadBundle();
+
+  assert.ok(execStub.calledWith('npm ci --production'));
+  assert.ok(execStub.calledWith('npm install -g pkg'));
+  assert.ok(execStub.calledWith('pkg .'));
+  assert.ok(execStub.calledWith('git ls-remote --tags https://github.com/mapbox/ecs-watchbot'));
+
+  assert.ok(s3Stub.calledWith({
+    Bucket: 'watchbot-binaries',
+    Key: 'linux/4.1.1/watchbot',
+    Body: fs.createReadStream('watchbot-linux'),
+    ACL: 'public-read'
+  }));
+  assert.ok(s3Stub.calledWith({
+    Bucket: 'watchbot-binaries',
+    Key: 'macosx/4.1.1/watchbot',
+    Body: fs.createReadStream('watchbot-macos'),
+    ACL: 'public-read'
+  }));
+  assert.ok(s3Stub.calledWith({
+    Bucket: 'watchbot-binaries',
+    Key: 'windows/4.1.1/watchbot',
+    Body: fs.createReadStream('watchbot-win.exe'),
+    ACL: 'public-read'
+  }));
+  assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/linux/4.1.1/watchbot'));
+  assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/macosx/4.1.1/watchbot'));
+  assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/windows/4.1.1/watchbot'));
 
   fsCreateReadStreamStub.restore();
   log.restore();


### PR DESCRIPTION
Fixes https://github.com/mapbox/ecs-watchbot/issues/258

I created a fresh "prerelease" version (4.7.2-0), and saw that the build was successful. To reproduce the error:
* I set the `sha` variable on https://github.com/mapbox/ecs-watchbot/blob/master/bin/watchbot-binary-generator.js#L17 to `4506f753e0955ee3683e8c396cdeea58e4442c5e`
* This caused the same error to be thrown 

On adding more debugging, I found that the error is thrown when we create tags manually using `git tag -m ....` because these tags look like `4.7.0`, whereas the ones created using the `npm version...` command look like `v4.7.0`. 

I've modified the regex to allow numeric tags that are created manually as well, but strongly recommend creating tags using `npm version <patch|minor|major|prerelease>`.

Thanks for creating https://github.com/mapbox/ecs-watchbot/pull/256/files @freenerd  - it should help clarify a lot of this. 🙂 

cc/ @mapbox/platform-engine-room 