### PR TITLE
Only add /tmp if it's not there already

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -164,8 +164,8 @@ module.exports = (options = {}) => {
   const mount = (mountInputs) => {
     let formatted = [];
     const mounts = {
-      mountPoints: [{ ContainerPath: '/tmp', SourceVolume: 'tmp' }],
-      volumes: [{ Name: 'tmp' }]
+      mountPoints: [],
+      volumes: []
     };
 
     if (typeof mountInputs === 'object') formatted = mountInputs;
@@ -178,6 +178,11 @@ module.exports = (options = {}) => {
           persistent ? mountStr.split(':')[1] : mountStr
         );
       });
+    }
+
+    if (formatted.indexOf('/tmp') === -1) {
+      mounts.mountPoints.push({ ContainerPath: '/tmp', SourceVolume: 'tmp' });
+      mounts.volumes.push({ Name: 'tmp' });
     }
 
     formatted.forEach((container, i) => {


### PR DESCRIPTION
If `/tmp` is specified as a mount, let's not add it on top. It causes a very strange error.

Closes #254. 

cc/ @mapbox/platform-engine-room 