### PR TITLE
FIFO queues

### DIFF
--- a/docs/building-a-template.md
+++ b/docs/building-a-template.md
@@ -89,6 +89,7 @@ When creating your watchbot stacks with the `watchbot.template()` method, you no
 **errorThreshold** | Watchbot creates a CloudWatch alarm that will fire if there have been more than this number of failed worker invocations in a 60 second period. This parameter can be provided as either a number or a reference, i.e. `{"Ref": "..."}`. | Number/Ref | No | 10
 **deadletterThreshold** | Use this parameter to control the number of times a message is delivered to the source queue before being moved to the dead-letter queue. This parameter can be provided as either a number or a reference, i.e. `{"Ref": "..."}`. | Number/Ref | No | 10
 **dashboard** | Watchbot creates a Cloudwatch Dashboard called `<cloudformation-stack>-<region>`. If running in cn-north-1, this may need to be disabled | Boolean | No | `true`
+**fifo** | Whether you want Watchbot's SQS queue to be first-in-first-out (FIFO). By default, Watchbot creates a standard SQS queue, in which the order of jobs is not guaranteed to match the order of messages. If your program requires more precise ordering and the limitations of a FIFO queue will be acceptable, set this option to `true`. Learn more in ["Using a FIFO queue"](./using-a-fifo-queue.md) | Boolean | No | `false`
 
 ### writableFilesystem mode explained
 

--- a/docs/using-a-fifo-queue.md
+++ b/docs/using-a-fifo-queue.md
@@ -1,0 +1,27 @@
+## Using a first-in-first-out (FIFO) queue
+
+By default, Watchbot creates a standard SQS queue, in which the order of jobs is not guaranteed to match the order of messages. If your program requires more precise ordering, you can use [a first-in-first-out (FIFO) queue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html), instead.
+
+To use a FIFO queue, set the template option `fifo: true`.
+
+A FIFO queue behaves differently and has some limitations, so you should read [the AWS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html) and the details below if you are considering the switch.
+
+### Triggering FIFO workers
+
+With a standard queue, you trigger a Watchbot worker by sending an SNS message to the watcher's topic. With a FIFO queue, you send a message directly to the watcher's FIFO queue, instead. Make sure you have read [the AWS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html) about the expected format of FIFO queue messages (for example, you need to include a `MessageGroupId`).
+
+### Scaling FIFO workers
+
+[Scaling behavior](./scaling-in-watchbot.md) in Watchbot is based on the total number of messages in the queue. If there are 50 messages, concurrent processing scales up to 50 (or the configured `maxSize`, if lower). In a FIFO queue, this scaling will not always make sense. For example, if your queue includes 50 messages but they only span 2 `MessageGroupId`s, then you will only be able to process 2 messages at a time and 48 worker machines will sit idle.
+
+For this reason, it's important that you plan for the number of `MessageGroupId`s you will use and set the template option `maxSize` accordingly. If you are only going to use 2 `MessageGroupId`s, you should set `maxSize: 2`.
+
+### Dead-letter queues and FIFO
+
+[The AWS documentation for dead-letter queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html) suggests the following:
+
+> Don’t use a dead-letter queue with a FIFO queue if you don’t want to break the exact order of messages or operations.
+
+If exact ordering is absolutely necessary for your program, you may prefer that the whole system stall if one message fails, instead of dropping the failed message into a dead-letter queue and moving on to the next one.
+
+Currently there is no way to turn off Watchbot's dead-letter queue. If you need this feature, please submit an issue or pull request.

--- a/lib/message.js
+++ b/lib/message.js
@@ -29,14 +29,31 @@ class Message {
 
     if (!options.queueUrl) throw new Error('Missing options: queueUrl');
 
-    const snsMessage = JSON.parse(sqsMessage.Body);
+    // If the Watchbot instance uses a regular SQS queue, sqsMessage
+    // will have come from an SNS topic, so the body will be a JSON object
+    // with Message and Subject properties.
+    //
+    // If the SQS message is for a FIFO queue, it did not come from SNS
+    // so will not have the same structure and might not be JSON
+    // parseable. If it is, we'll parse it; if not, we'll just pass it on.
+    let envMessage = sqsMessage.Body;
+    let envSubject;
+    try {
+      const parsedBody = JSON.parse(sqsMessage.Body);
+      if (parsedBody.Subject)  {
+        envMessage = parsedBody.Message;
+        envSubject = parsedBody.Subject;
+      }
+    } catch (error) {
+      // JSON-parsing failure means we can leave the body as it is.
+    }
 
     this.id = sqsMessage.MessageId;
     this.handle = sqsMessage.ReceiptHandle;
 
     this.env = {
       MessageId: sqsMessage.MessageId,
-      Message: snsMessage.Message,
+      Message: envMessage,
       SentTimestamp: new Date(
         Number(sqsMessage.Attributes.SentTimestamp)
       ).toISOString(),
@@ -46,7 +63,7 @@ class Message {
       ApproximateReceiveCount: sqsMessage.Attributes.ApproximateReceiveCount.toString()
     };
 
-    if (snsMessage.Subject) this.env.Subject = snsMessage.Subject;
+    if (envSubject) this.env.Subject = envSubject;
 
     this.sqs = new AWS.SQS({
       region: url.parse(options.queueUrl).host.split('.')[1],

--- a/lib/template.js
+++ b/lib/template.js
@@ -103,6 +103,11 @@ const dashboard = require(path.resolve(__dirname, 'dashboard.js'));
  * a number or a reference, i.e. `{"Ref": "..."}`.
  * @param {boolean} [options.deadletterAlarm=true] - Use this parameter to disable
  * creating an alarm for the dead letter queue threshold going from 0-1 messages.
+ * @param {Boolean} [options.fifo=false] - Whether you want Watchbot's SQS queue
+ * to be first-in-first-out (FIFO). By default, Watchbot creates a standard SQS queue,
+ * in which the order of jobs is not guaranteed to match the order of messages.
+ * If your program requires more precise ordering and the limitations of a FIFO queue
+ * will be acceptable, set this option to `true`.
  */
 module.exports = (options = {}) => {
   ['service', 'serviceVersion', 'command', 'cluster'].forEach((required) => {
@@ -131,7 +136,8 @@ module.exports = (options = {}) => {
       failedPlacementAlarmPeriods: 1,
       deadletterThreshold: 10,
       deadletterAlarm: true,
-      dashboard: true
+      dashboard: true,
+      fifo: false
     },
     options
   );
@@ -140,7 +146,7 @@ module.exports = (options = {}) => {
 
   const ref = {
     logGroup: cf.ref(prefixed('LogGroup')),
-    topic: cf.ref(prefixed('Topic')),
+    topic: options.fifo ? undefined : cf.ref(prefixed('Topic')),
     queueUrl: cf.ref(prefixed('Queue')),
     queueArn: cf.getAtt(prefixed('Queue'), 'Arn'),
     queueName: cf.getAtt(prefixed('Queue'), 'QueueName'),
@@ -154,11 +160,13 @@ module.exports = (options = {}) => {
         return unpacked;
       },
       [
-        { Name: 'WorkTopic', Value: cf.ref(prefixed('Topic')) },
+        { Name: 'WorkTopic', Value: options.fifo ? undefined : cf.ref(prefixed('Topic')) },
         { Name: 'QueueUrl', Value: cf.ref(prefixed('Queue')) },
+        { Name: 'LogGroup', Value: cf.ref(prefixed('LogGroup')) },
         { Name: 'writableFilesystem', Value: options.writableFilesystem },
         { Name: 'maxJobDuration', Value: options.maxJobDuration },
-        { Name: 'Volumes', Value: mountPoints.map((m) => m.ContainerPath).join(',') }
+        { Name: 'Volumes', Value: mountPoints.map((m) => m.ContainerPath).join(',') },
+        { Name: 'Fifo', Value: options.fifo.toString() }
       ]
     );
   };
@@ -226,6 +234,12 @@ module.exports = (options = {}) => {
     }
   };
 
+  if (options.fifo) {
+    Resources[prefixed('DeadLetterQueue')].Properties.FifoQueue = true;
+    Resources[prefixed('DeadLetterQueue')].Properties.ContentBasedDeduplication = true;
+    Resources[prefixed('DeadLetterQueue')].Properties.QueueName = cf.join([cf.stackName, '-', prefixed('DeadLetterQueue'), '.fifo']);
+  }
+
   Resources[prefixed('Queue')] = {
     Type: 'AWS::SQS::Queue',
     Properties: {
@@ -239,7 +253,13 @@ module.exports = (options = {}) => {
     }
   };
 
-  Resources[prefixed('Topic')] = {
+  if (options.fifo) {
+    Resources[prefixed('Queue')].Properties.FifoQueue = true;
+    Resources[prefixed('Queue')].Properties.ContentBasedDeduplication = true;
+    Resources[prefixed('Queue')].Properties.QueueName = cf.join([cf.stackName, '-', prefixed('Queue'), '.fifo']);
+  }
+
+  if (!options.fifo) Resources[prefixed('Topic')] = {
     Type: 'AWS::SNS::Topic',
     Properties: {
       Subscription: [
@@ -251,7 +271,7 @@ module.exports = (options = {}) => {
     }
   };
 
-  Resources[prefixed('QueuePolicy')] = {
+  if (!options.fifo) Resources[prefixed('QueuePolicy')] = {
     Type: 'AWS::SQS::QueuePolicy',
     Properties: {
       Queues: [cf.ref(prefixed('Queue'))],
@@ -322,11 +342,6 @@ module.exports = (options = {}) => {
             Statement: [
               {
                 Effect: 'Allow',
-                Action: 'sns:Publish',
-                Resource: cf.ref(prefixed('Topic'))
-              },
-              {
-                Effect: 'Allow',
                 Action: [
                   'sqs:ReceiveMessage',
                   'sqs:DeleteMessage',
@@ -358,6 +373,13 @@ module.exports = (options = {}) => {
       ]
     }
   };
+
+  if (!options.fifo)
+    Resources[prefixed('Role')].Properties.Policies.push({
+      Effect: 'Allow',
+      Action: 'sns:Publish',
+      Resource: cf.ref(prefixed('Topic'))
+    });
 
   if (options.permissions)
     Resources[prefixed('Role')].Properties.Policies.push({
@@ -776,7 +798,7 @@ module.exports = (options = {}) => {
         }
       }]
     }
-  },
+  };
 
   Resources[prefixed('ScalingLambda')] = {
     Type: 'AWS::Lambda::Function',

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ RUN chmod +x /usr/local/bin/watchbot
 
 ## Helpful lingo
 
-- **queue**: [An SQS queue](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSConcepts.html) is a "backlog" of messages for your stack to process that helps to guarantee every message gets processed at least once.
+- **queue**: [An SQS queue](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSConcepts.html) is a "backlog" of messages for your stack to process that helps to guarantee every message gets processed at least once. It can be a standard queue or [a first-in-first-out (FIFO) queue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html).
 - **message**: A message in the queue represents some job to be processed. Generally, you are responsible for sending messages to your stack by [publishing to Watchbot's SNS topic](http://docs.aws.amazon.com/sns/latest/dg/PublishTopic.html), or optionally by POST to a webhook endpoint (see `WatchbotUseWebhooks` in the parameters section below).
 - **worker**: CLI command/subprocess responsible for processing a single message. You define the work performed by the worker through the `command` property in the cloudformation template. Watchbot sets environment variables for the subprocess that represent the content of a single message.
 - **watcher**: The main process in the container that polls the queue, spawns worker subprocesses to process messages, and tracks results.
@@ -39,8 +39,9 @@ RUN chmod +x /usr/local/bin/watchbot
 
 ## What Watchbot provides:
 
-- a queue for you to send messages to in order to trigger your workers to run
-- [optionally] [an AWS access key](http://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) with permission to send messages to the queue
+- a queue that triggers your workers
+- an SNS topic through which you'll send messages to the queue, unless you have a FIFO queue
+- [optionally] [an AWS access key](http://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) with permission to send messages to the SNS topic or FIFO queue
 - [an ECS TaskDefinition](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html) for your worker, using the image you provide
 - one or more watcher containers that run continuously on your cluster, polling the queue, running a worker for each message, removing messages from the queue as workers complete, and managing worker failures and retries
 - a script to help you include the resources Watchbot needs to run in your template

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,6 @@ RUN chmod +x /usr/local/bin/watchbot
 
 - a queue that triggers your workers
 - an SNS topic through which you'll send messages to the queue, unless you have a FIFO queue
-- [optionally] [an AWS access key](http://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) with permission to send messages to the SNS topic or FIFO queue
 - [an ECS TaskDefinition](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html) for your worker, using the image you provide
 - one or more watcher containers that run continuously on your cluster, polling the queue, running a worker for each message, removing messages from the queue as workers complete, and managing worker failures and retries
 - a script to help you include the resources Watchbot needs to run in your template

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -633,13 +633,6 @@ Object {
             "PolicyDocument": Object {
               "Statement": Array [
                 Object {
-                  "Action": "sns:Publish",
-                  "Effect": "Allow",
-                  "Resource": Object {
-                    "Ref": "SoupTopic",
-                  },
-                },
-                Object {
                   "Action": Array [
                     "sqs:ReceiveMessage",
                     "sqs:DeleteMessage",
@@ -694,6 +687,13 @@ Object {
                   "-default-worker",
                 ],
               ],
+            },
+          },
+          Object {
+            "Action": "sns:Publish",
+            "Effect": "Allow",
+            "Resource": Object {
+              "Ref": "SoupTopic",
             },
           },
           Object {
@@ -985,6 +985,12 @@ Object {
                 },
               },
               Object {
+                "Name": "LogGroup",
+                "Value": Object {
+                  "Ref": "SoupLogGroup",
+                },
+              },
+              Object {
                 "Name": "writableFilesystem",
                 "Value": false,
               },
@@ -995,6 +1001,10 @@ Object {
               Object {
                 "Name": "Volumes",
                 "Value": "/tmp,/data,/ephemeral",
+              },
+              Object {
+                "Name": "Fifo",
+                "Value": "false",
               },
               Object {
                 "Name": "MyKey",
@@ -1948,13 +1958,6 @@ Object {
             "PolicyDocument": Object {
               "Statement": Array [
                 Object {
-                  "Action": "sns:Publish",
-                  "Effect": "Allow",
-                  "Resource": Object {
-                    "Ref": "SoupTopic",
-                  },
-                },
-                Object {
                   "Action": Array [
                     "sqs:ReceiveMessage",
                     "sqs:DeleteMessage",
@@ -2009,6 +2012,13 @@ Object {
                   "-default-worker",
                 ],
               ],
+            },
+          },
+          Object {
+            "Action": "sns:Publish",
+            "Effect": "Allow",
+            "Resource": Object {
+              "Ref": "SoupTopic",
             },
           },
           Object {
@@ -2298,6 +2308,12 @@ Object {
                 },
               },
               Object {
+                "Name": "LogGroup",
+                "Value": Object {
+                  "Ref": "SoupLogGroup",
+                },
+              },
+              Object {
                 "Name": "writableFilesystem",
                 "Value": false,
               },
@@ -2308,6 +2324,10 @@ Object {
               Object {
                 "Name": "Volumes",
                 "Value": "/tmp,/data,/ephemeral",
+              },
+              Object {
+                "Name": "Fifo",
+                "Value": "false",
               },
               Object {
                 "Name": "MyKey",
@@ -3261,13 +3281,6 @@ Object {
             "PolicyDocument": Object {
               "Statement": Array [
                 Object {
-                  "Action": "sns:Publish",
-                  "Effect": "Allow",
-                  "Resource": Object {
-                    "Ref": "SoupTopic",
-                  },
-                },
-                Object {
                   "Action": Array [
                     "sqs:ReceiveMessage",
                     "sqs:DeleteMessage",
@@ -3322,6 +3335,13 @@ Object {
                   "-default-worker",
                 ],
               ],
+            },
+          },
+          Object {
+            "Action": "sns:Publish",
+            "Effect": "Allow",
+            "Resource": Object {
+              "Ref": "SoupTopic",
             },
           },
           Object {
@@ -3611,6 +3631,12 @@ Object {
                 },
               },
               Object {
+                "Name": "LogGroup",
+                "Value": Object {
+                  "Ref": "SoupLogGroup",
+                },
+              },
+              Object {
                 "Name": "writableFilesystem",
                 "Value": false,
               },
@@ -3621,6 +3647,10 @@ Object {
               Object {
                 "Name": "Volumes",
                 "Value": "/tmp,/data,/ephemeral",
+              },
+              Object {
+                "Name": "Fifo",
+                "Value": "false",
               },
               Object {
                 "Name": "MyKey",
@@ -4574,13 +4604,6 @@ Object {
             "PolicyDocument": Object {
               "Statement": Array [
                 Object {
-                  "Action": "sns:Publish",
-                  "Effect": "Allow",
-                  "Resource": Object {
-                    "Ref": "SoupTopic",
-                  },
-                },
-                Object {
                   "Action": Array [
                     "sqs:ReceiveMessage",
                     "sqs:DeleteMessage",
@@ -4635,6 +4658,13 @@ Object {
                   "-default-worker",
                 ],
               ],
+            },
+          },
+          Object {
+            "Action": "sns:Publish",
+            "Effect": "Allow",
+            "Resource": Object {
+              "Ref": "SoupTopic",
             },
           },
           Object {
@@ -4924,6 +4954,12 @@ Object {
                 },
               },
               Object {
+                "Name": "LogGroup",
+                "Value": Object {
+                  "Ref": "SoupLogGroup",
+                },
+              },
+              Object {
                 "Name": "writableFilesystem",
                 "Value": false,
               },
@@ -4934,6 +4970,10 @@ Object {
               Object {
                 "Name": "Volumes",
                 "Value": "/tmp,/data,/ephemeral",
+              },
+              Object {
+                "Name": "Fifo",
+                "Value": "false",
               },
               Object {
                 "Name": "MyKey",
@@ -5813,12 +5853,1157 @@ Object {
             "PolicyDocument": Object {
               "Statement": Array [
                 Object {
-                  "Action": "sns:Publish",
+                  "Action": Array [
+                    "sqs:ReceiveMessage",
+                    "sqs:DeleteMessage",
+                    "sqs:ChangeMessageVisibility",
+                  ],
                   "Effect": "Allow",
                   "Resource": Object {
-                    "Ref": "WatchbotTopic",
+                    "Fn::GetAtt": Array [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
                   },
                 },
+                Object {
+                  "Action": Array [
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "logs:FilterLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::GetAtt": Array [
+                      "WatchbotLogGroup",
+                      "Arn",
+                    ],
+                  },
+                },
+                Object {
+                  "Fn::If": Array [
+                    "NotInChina",
+                    Object {
+                      "Action": "kms:Decrypt",
+                      "Effect": "Allow",
+                      "Resource": Object {
+                        "Fn::ImportValue": "cloudformation-kms-production",
+                      },
+                    },
+                    Object {
+                      "Ref": "AWS::NoValue",
+                    },
+                  ],
+                },
+              ],
+            },
+            "PolicyName": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-default-worker",
+                ],
+              ],
+            },
+          },
+          Object {
+            "Action": "sns:Publish",
+            "Effect": "Allow",
+            "Resource": Object {
+              "Ref": "WatchbotTopic",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "WatchbotScaleDown": Object {
+      "Properties": Object {
+        "PolicyName": Object {
+          "Fn::Sub": "Watchbot\${AWS::StackName}-scale-down",
+        },
+        "PolicyType": "StepScaling",
+        "ScalingTargetId": Object {
+          "Ref": "WatchbotScalingTarget",
+        },
+        "StepScalingPolicyConfiguration": Object {
+          "AdjustmentType": "PercentChangeInCapacity",
+          "Cooldown": 300,
+          "MetricAggregationType": "Average",
+          "StepAdjustments": Array [
+            Object {
+              "MetricIntervalUpperBound": 0,
+              "ScalingAdjustment": -100,
+            },
+          ],
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
+    "WatchbotScaleDownTrigger": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotScaleDown",
+          },
+        ],
+        "AlarmDescription": "Scale down due to lack of in-flight messages in queue",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-scale-down",
+            ],
+          ],
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "TotalMessages",
+        "Namespace": "Mapbox/ecs-watchbot",
+        "Period": 600,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotScaleUp": Object {
+      "Properties": Object {
+        "PolicyName": Object {
+          "Fn::Sub": "\${AWS::StackName}-scale-up",
+        },
+        "PolicyType": "StepScaling",
+        "ScalingTargetId": Object {
+          "Ref": "WatchbotScalingTarget",
+        },
+        "StepScalingPolicyConfiguration": Object {
+          "AdjustmentType": "ChangeInCapacity",
+          "Cooldown": 300,
+          "MetricAggregationType": "Average",
+          "StepAdjustments": Array [
+            Object {
+              "MetricIntervalLowerBound": 0,
+              "ScalingAdjustment": Object {
+                "Fn::GetAtt": Array [
+                  "WatchbotCustomScalingResource",
+                  "ScalingAdjustment",
+                ],
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
+    "WatchbotScaleUpTrigger": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotScaleUp",
+          },
+        ],
+        "AlarmDescription": "Scale up due to visible messages in queue",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-scale-up",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotScalingLambda": Object {
+      "Properties": Object {
+        "Code": Object {
+          "ZipFile": Object {
+            "Fn::Sub": "
+          const response = require('cfn-response');
+          exports.handler = function(event,context){
+            const result = Math.round(Math.max(Math.min(parseInt(event.ResourceProperties.maxSize) / 10, 100), 1));
+            response.send(event, context, response.SUCCESS, { ScalingAdjustment: result });
+          }
+          ",
+          },
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotLambdaScalingRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs6.10",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "WatchbotScalingRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "application-autoscaling.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Path": "/",
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "application-autoscaling:*",
+                    "cloudwatch:DescribeAlarms",
+                    "cloudwatch:PutMetricAlarm",
+                    "ecs:UpdateService",
+                    "ecs:DescribeServices",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+            },
+            "PolicyName": "watchbot-autoscaling",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "WatchbotScalingTarget": Object {
+      "Properties": Object {
+        "MaxCapacity": 1,
+        "MinCapacity": 0,
+        "ResourceId": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "service/",
+              "processing",
+              "/",
+              Object {
+                "Fn::GetAtt": Array [
+                  "WatchbotService",
+                  "Name",
+                ],
+              },
+            ],
+          ],
+        },
+        "RoleARN": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotScalingRole",
+            "Arn",
+          ],
+        },
+        "ScalableDimension": "ecs:service:DesiredCount",
+        "ServiceNamespace": "ecs",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "WatchbotService": Object {
+      "Properties": Object {
+        "Cluster": "processing",
+        "DesiredCount": 0,
+        "TaskDefinition": Object {
+          "Ref": "WatchbotTask",
+        },
+      },
+      "Type": "AWS::ECS::Service",
+    },
+    "WatchbotTask": Object {
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Command": Array [
+              "watchbot",
+              "listen",
+              "echo hello world",
+            ],
+            "Cpu": 128,
+            "Environment": Array [
+              Object {
+                "Name": "WorkTopic",
+                "Value": Object {
+                  "Ref": "WatchbotTopic",
+                },
+              },
+              Object {
+                "Name": "QueueUrl",
+                "Value": Object {
+                  "Ref": "WatchbotQueue",
+                },
+              },
+              Object {
+                "Name": "LogGroup",
+                "Value": Object {
+                  "Ref": "WatchbotLogGroup",
+                },
+              },
+              Object {
+                "Name": "writableFilesystem",
+                "Value": false,
+              },
+              Object {
+                "Name": "maxJobDuration",
+                "Value": 0,
+              },
+              Object {
+                "Name": "Volumes",
+                "Value": "/tmp",
+              },
+              Object {
+                "Name": "Fifo",
+                "Value": "false",
+              },
+            ],
+            "Image": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ".dkr.ecr.",
+                  Object {
+                    "Fn::FindInMap": Array [
+                      "EcrRegion",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      "Region",
+                    ],
+                  },
+                  ".",
+                  Object {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/",
+                  "example",
+                  ":",
+                  "1",
+                ],
+              ],
+            },
+            "LogConfiguration": Object {
+              "LogDriver": "awslogs",
+              "Options": Object {
+                "awslogs-group": Object {
+                  "Ref": "WatchbotLogGroup",
+                },
+                "awslogs-region": Object {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "1",
+              },
+            },
+            "MountPoints": Array [
+              Object {
+                "ContainerPath": "/tmp",
+                "SourceVolume": "tmp",
+              },
+            ],
+            "Name": Object {
+              "Fn::Join": Array [
+                "-",
+                Array [
+                  "Watchbot",
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "Privileged": false,
+            "ReadonlyRootFilesystem": true,
+            "Ulimits": Array [
+              Object {
+                "HardLimit": 10240,
+                "Name": "nofile",
+                "SoftLimit": 10240,
+              },
+            ],
+          },
+        ],
+        "Family": "example",
+        "TaskRoleArn": Object {
+          "Ref": "WatchbotRole",
+        },
+        "Volumes": Array [
+          Object {
+            "Name": "tmp",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "WatchbotTopic": Object {
+      "Properties": Object {
+        "Subscription": Array [
+          Object {
+            "Endpoint": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotQueue",
+                "Arn",
+              ],
+            },
+            "Protocol": "sqs",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "WatchbotTotalMessagesLambda": Object {
+      "Properties": Object {
+        "Code": Object {
+          "ZipFile": Object {
+            "Fn::Sub": Array [
+              "
+          const AWS = require('aws-sdk');
+          exports.handler = function(event, context, callback) {
+            const sqs = new AWS.SQS({ region: process.env.AWS_DEFAULT_REGION });
+            const cw = new AWS.CloudWatch({ region: process.env.AWS_DEFAULT_REGION });
+
+            return sqs.getQueueAttributes({
+              QueueUrl: '\${QueueUrl}',
+              AttributeNames: ['ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessages']
+            }).promise()
+              .then((attrs) => {
+                return cw.putMetricData({
+                  Namespace: 'Mapbox/ecs-watchbot',
+                  MetricData: [{
+                    MetricName: 'TotalMessages',
+                    Dimensions: [{ Name: 'QueueName', Value: '\${QueueName}' }],
+                    Value: Number(attrs.Attributes.ApproximateNumberOfMessagesNotVisible) +
+                            Number(attrs.Attributes.ApproximateNumberOfMessages)
+                  }]
+                }).promise();
+              })
+              .then((metric) => callback(null, metric))
+              .catch((err) => callback(err));
+          }
+        ",
+              Object {
+                "QueueName": Object {
+                  "Fn::GetAtt": Array [
+                    "WatchbotQueue",
+                    "QueueName",
+                  ],
+                },
+                "QueueUrl": Object {
+                  "Ref": "WatchbotQueue",
+                },
+              },
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotLambdaTotalMessagesRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs6.10",
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "WatchbotTotalMessagesSchedule": Object {
+      "Properties": Object {
+        "Description": "Update TotalMessages metric every minute",
+        "Name": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-total-messages",
+            ],
+          ],
+        },
+        "ScheduleExpression": "cron(0/1 * * * ? *)",
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotTotalMessagesLambda",
+                "Arn",
+              ],
+            },
+            "Id": "WatchbotTotalMessagesLambda",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "WatchbotWorkerDurationMetric": Object {
+      "Properties": Object {
+        "FilterPattern": "{ $.duration = * }",
+        "LogGroupName": Object {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": Array [
+          Object {
+            "MetricName": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "WatchbotWorkerDuration-",
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": "$.duration",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "WatchbotWorkerErrorsAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.12.0/docs/alarms.md#workererrors",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-worker-errors",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "WatchbotWorkerErrors-",
+              Object {
+                "Ref": "AWS::StackName",
+              },
+            ],
+          ],
+        },
+        "Namespace": "Mapbox/ecs-watchbot",
+        "Period": "60",
+        "Statistic": "Sum",
+        "Threshold": 10,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotWorkerErrorsMetric": Object {
+      "Properties": Object {
+        "FilterPattern": "\\"[failure]\\"",
+        "LogGroupName": Object {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": Array [
+          Object {
+            "MetricName": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "WatchbotWorkerErrors-",
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": 1,
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+  },
+}
+`;
+
+exports[`fifo 1`] = `
+Object {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": Object {
+    "NotInChina": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "cn-north-1",
+          ],
+        },
+      ],
+    },
+  },
+  "Mappings": Object {
+    "EcrRegion": Object {
+      "ap-northeast-1": Object {
+        "Region": "us-west-2",
+      },
+      "ap-southeast-1": Object {
+        "Region": "us-west-2",
+      },
+      "ap-southeast-2": Object {
+        "Region": "us-west-2",
+      },
+      "cn-north-1": Object {
+        "Region": "cn-north-1",
+      },
+      "eu-central-1": Object {
+        "Region": "eu-west-1",
+      },
+      "eu-west-1": Object {
+        "Region": "eu-west-1",
+      },
+      "us-east-1": Object {
+        "Region": "us-east-1",
+      },
+      "us-east-2": Object {
+        "Region": "us-east-1",
+      },
+      "us-west-2": Object {
+        "Region": "us-west-2",
+      },
+    },
+  },
+  "Metadata": Object {
+    "EcsWatchbotVersion": "4.12.0",
+  },
+  "Outputs": Object {
+    "ClusterArn": Object {
+      "Description": "Service cluster ARN",
+      "Value": "processing",
+    },
+    "WatchbotDeadLetterQueueUrl": Object {
+      "Description": "The URL for the dead letter queue",
+      "Value": Object {
+        "Ref": "WatchbotDeadLetterQueue",
+      },
+    },
+    "WatchbotLogGroup": Object {
+      "Description": "The ARN of Watchbot's log group",
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "WatchbotLogGroup",
+          "Arn",
+        ],
+      },
+    },
+    "WatchbotQueueUrl": Object {
+      "Description": "The URL for the primary work queue",
+      "Value": Object {
+        "Ref": "WatchbotQueue",
+      },
+    },
+  },
+  "Parameters": Object {},
+  "Resources": Object {
+    "WatchbotAlarmMemoryUtilization": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.12.0/docs/alarms.md#memoryutilization",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "WatchbotMemoryUtilization",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ClusterName",
+            "Value": "processing",
+          },
+          Object {
+            "Name": "ServiceName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotService",
+                "Name",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "MemoryUtilization",
+        "Namespace": "AWS/ECS",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 100,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotCustomScalingResource": Object {
+      "Properties": Object {
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotScalingLambda",
+            "Arn",
+          ],
+        },
+        "maxSize": 1,
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+    },
+    "WatchbotDashboard": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Sub": Array [
+            "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"WatchbotQueue: Visible and NotVisible Messages\\",\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesNotVisible\\",\\"QueueName\\",\\"\${WatchbotQueue}\\",{\\"period\\":60}],[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesVisible\\",\\"QueueName\\",\\"\${WatchbotQueue}\\",{\\"period\\":60}]],\\"stat\\":\\"Sum\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":60,\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":12,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"WatchbotQueue: Deleted messages\\",\\"metrics\\":[[\\"AWS/SQS\\",\\"NumberOfMessagesDeleted\\",\\"QueueName\\",\\"\${WatchbotQueue}\\",{\\"period\\":60}]],\\"stat\\":\\"Sum\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":60,\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":12,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"WatchbotService: RunningCapacity, DesiredCapacity\\",\\"metrics\\":[[\\"Mapbox/ecs-cluster\\",\\"RunningCapacity\\",\\"ClusterName\\",\\"\${Cluster}\\",\\"ServiceName\\",\\"\${WatchbotService}\\",{\\"period\\":60}],[\\".\\",\\"DesiredCapacity\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"period\\":60}]],\\"region\\":\\"\${AWS::Region}\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":12,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"Concurrency vs Throughput\\",\\"metrics\\":[[\\"Mapbox/ecs-cluster\\",\\"RunningCapacity\\",\\"ClusterName\\",\\"\${Cluster}\\",\\"ServiceName\\",\\"\${WatchbotService}\\",{\\"period\\":60,\\"yAxis\\":\\"right\\"}],[\\".\\",\\"DesiredCapacity\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"period\\":60,\\"yAxis\\":\\"right\\"}],[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesVisible\\",\\"QueueName\\",\\"\${WatchbotQueue}\\",{\\"period\\":60,\\"stat\\":\\"Sum\\",\\"yAxis\\":\\"left\\"}]],\\"region\\":\\"\${AWS::Region}\\",\\"period\\":60,\\"yAxis\\":{\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":18,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"WatchbotService: CPUUtilization, MemoryUtilization\\",\\"metrics\\":[[\\"AWS/ECS\\",\\"CPUUtilization\\",\\"ServiceName\\",\\"\${WatchbotService}\\",\\"ClusterName\\",\\"\${Cluster}\\",{\\"period\\":60}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"period\\":60}]],\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":18,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"WatchbotDeadLetterQueue: Visible and NotVisible Messages\\",\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesNotVisible\\",\\"QueueName\\",\\"\${WatchbotDeadLetterQueue}\\",{\\"period\\":60}],[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesVisible\\",\\"QueueName\\",\\"\${WatchbotDeadLetterQueue}\\",{\\"period\\":60}]],\\"stat\\":\\"Sum\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":60,\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}}]}",
+            Object {
+              "Cluster": "processing",
+              "WatchbotDeadLetterQueue": Object {
+                "Fn::GetAtt": Array [
+                  "WatchbotDeadLetterQueue",
+                  "QueueName",
+                ],
+              },
+              "WatchbotQueue": Object {
+                "Fn::GetAtt": Array [
+                  "WatchbotQueue",
+                  "QueueName",
+                ],
+              },
+              "WatchbotService": Object {
+                "Fn::GetAtt": Array [
+                  "WatchbotService",
+                  "Name",
+                ],
+              },
+            },
+          ],
+        },
+        "DashboardName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot",
+              Object {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "WatchbotDeadLetterAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "Provides notification when messages are visible in the dead letter queue",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-dead-letter",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotDeadLetterQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": "60",
+        "Statistic": "Minimum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotDeadLetterQueue": Object {
+      "Description": "List of messages that failed to process 14 times",
+      "Properties": Object {
+        "ContentBasedDeduplication": true,
+        "FifoQueue": true,
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "-",
+              "WatchbotDeadLetterQueue",
+              ".fifo",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "WatchbotLambdaScalingRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:",
+                        Object {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": "CustomcfnScalingLambdaLogs",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "WatchbotLambdaTotalMessagesRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:",
+                        Object {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                Object {
+                  "Action": Array [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::GetAtt": Array [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": "LambdaTotalMessagesMetric",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "WatchbotLogGroup": Object {
+      "Properties": Object {
+        "LogGroupName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "watchbot",
+            ],
+          ],
+        },
+        "RetentionInDays": 14,
+      },
+      "Type": "AWS::Logs::LogGroup",
+    },
+    "WatchbotMessageReceivesMetric": Object {
+      "Properties": Object {
+        "FilterPattern": "{ $.receives = * }",
+        "LogGroupName": Object {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": Array [
+          Object {
+            "MetricName": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "WatchbotMessageReceives-",
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": "$.receives",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "WatchbotMetricSchedulePermission": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotTotalMessagesLambda",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotTotalMessagesSchedule",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "WatchbotNotificationTopic": Object {
+      "Description": "Subscribe to this topic to receive emails when tasks fail or retry",
+      "Properties": Object {
+        "Subscription": Array [
+          Object {
+            "Endpoint": "hello@mapbox.pagerduty.com",
+            "Protocol": "email",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "WatchbotQueue": Object {
+      "Properties": Object {
+        "ContentBasedDeduplication": true,
+        "FifoQueue": true,
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "-",
+              "WatchbotQueue",
+              ".fifo",
+            ],
+          ],
+        },
+        "RedrivePolicy": Object {
+          "deadLetterTargetArn": Object {
+            "Fn::GetAtt": Array [
+              "WatchbotDeadLetterQueue",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 10,
+        },
+        "VisibilityTimeout": 180,
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "WatchbotQueueSizeAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.12.0/docs/alarms.md#queuesize",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-queue-size",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 24,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": "300",
+        "Statistic": "Average",
+        "Threshold": 40,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "ecs-tasks.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
                 Object {
                   "Action": Array [
                     "sqs:ReceiveMessage",
@@ -6130,14 +7315,18 @@ Object {
             "Environment": Array [
               Object {
                 "Name": "WorkTopic",
-                "Value": Object {
-                  "Ref": "WatchbotTopic",
-                },
+                "Value": undefined,
               },
               Object {
                 "Name": "QueueUrl",
                 "Value": Object {
                   "Ref": "WatchbotQueue",
+                },
+              },
+              Object {
+                "Name": "LogGroup",
+                "Value": Object {
+                  "Ref": "WatchbotLogGroup",
                 },
               },
               Object {
@@ -6151,6 +7340,10 @@ Object {
               Object {
                 "Name": "Volumes",
                 "Value": "/tmp",
+              },
+              Object {
+                "Name": "Fifo",
+                "Value": "true",
               },
             ],
             "Image": Object {
@@ -6233,21 +7426,1132 @@ Object {
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
-    "WatchbotTopic": Object {
+    "WatchbotTotalMessagesLambda": Object {
       "Properties": Object {
-        "Subscription": Array [
+        "Code": Object {
+          "ZipFile": Object {
+            "Fn::Sub": Array [
+              "
+          const AWS = require('aws-sdk');
+          exports.handler = function(event, context, callback) {
+            const sqs = new AWS.SQS({ region: process.env.AWS_DEFAULT_REGION });
+            const cw = new AWS.CloudWatch({ region: process.env.AWS_DEFAULT_REGION });
+
+            return sqs.getQueueAttributes({
+              QueueUrl: '\${QueueUrl}',
+              AttributeNames: ['ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessages']
+            }).promise()
+              .then((attrs) => {
+                return cw.putMetricData({
+                  Namespace: 'Mapbox/ecs-watchbot',
+                  MetricData: [{
+                    MetricName: 'TotalMessages',
+                    Dimensions: [{ Name: 'QueueName', Value: '\${QueueName}' }],
+                    Value: Number(attrs.Attributes.ApproximateNumberOfMessagesNotVisible) +
+                            Number(attrs.Attributes.ApproximateNumberOfMessages)
+                  }]
+                }).promise();
+              })
+              .then((metric) => callback(null, metric))
+              .catch((err) => callback(err));
+          }
+        ",
+              Object {
+                "QueueName": Object {
+                  "Fn::GetAtt": Array [
+                    "WatchbotQueue",
+                    "QueueName",
+                  ],
+                },
+                "QueueUrl": Object {
+                  "Ref": "WatchbotQueue",
+                },
+              },
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotLambdaTotalMessagesRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs6.10",
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "WatchbotTotalMessagesSchedule": Object {
+      "Properties": Object {
+        "Description": "Update TotalMessages metric every minute",
+        "Name": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-total-messages",
+            ],
+          ],
+        },
+        "ScheduleExpression": "cron(0/1 * * * ? *)",
+        "Targets": Array [
           Object {
-            "Endpoint": Object {
+            "Arn": Object {
               "Fn::GetAtt": Array [
-                "WatchbotQueue",
+                "WatchbotTotalMessagesLambda",
                 "Arn",
               ],
             },
-            "Protocol": "sqs",
+            "Id": "WatchbotTotalMessagesLambda",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "WatchbotWorkerDurationMetric": Object {
+      "Properties": Object {
+        "FilterPattern": "{ $.duration = * }",
+        "LogGroupName": Object {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": Array [
+          Object {
+            "MetricName": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "WatchbotWorkerDuration-",
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": "$.duration",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "WatchbotWorkerErrorsAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.12.0/docs/alarms.md#workererrors",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-worker-errors",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "WatchbotWorkerErrors-",
+              Object {
+                "Ref": "AWS::StackName",
+              },
+            ],
+          ],
+        },
+        "Namespace": "Mapbox/ecs-watchbot",
+        "Period": "60",
+        "Statistic": "Sum",
+        "Threshold": 10,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotWorkerErrorsMetric": Object {
+      "Properties": Object {
+        "FilterPattern": "\\"[failure]\\"",
+        "LogGroupName": Object {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": Array [
+          Object {
+            "MetricName": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "WatchbotWorkerErrors-",
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": 1,
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+  },
+}
+`;
+
+exports[`fifoMaxSize 1`] = `
+Object {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": Object {
+    "NotInChina": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "cn-north-1",
+          ],
+        },
+      ],
+    },
+  },
+  "Mappings": Object {
+    "EcrRegion": Object {
+      "ap-northeast-1": Object {
+        "Region": "us-west-2",
+      },
+      "ap-southeast-1": Object {
+        "Region": "us-west-2",
+      },
+      "ap-southeast-2": Object {
+        "Region": "us-west-2",
+      },
+      "cn-north-1": Object {
+        "Region": "cn-north-1",
+      },
+      "eu-central-1": Object {
+        "Region": "eu-west-1",
+      },
+      "eu-west-1": Object {
+        "Region": "eu-west-1",
+      },
+      "us-east-1": Object {
+        "Region": "us-east-1",
+      },
+      "us-east-2": Object {
+        "Region": "us-east-1",
+      },
+      "us-west-2": Object {
+        "Region": "us-west-2",
+      },
+    },
+  },
+  "Metadata": Object {
+    "EcsWatchbotVersion": "4.12.0",
+  },
+  "Outputs": Object {
+    "ClusterArn": Object {
+      "Description": "Service cluster ARN",
+      "Value": "processing",
+    },
+    "WatchbotDeadLetterQueueUrl": Object {
+      "Description": "The URL for the dead letter queue",
+      "Value": Object {
+        "Ref": "WatchbotDeadLetterQueue",
+      },
+    },
+    "WatchbotLogGroup": Object {
+      "Description": "The ARN of Watchbot's log group",
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "WatchbotLogGroup",
+          "Arn",
+        ],
+      },
+    },
+    "WatchbotQueueUrl": Object {
+      "Description": "The URL for the primary work queue",
+      "Value": Object {
+        "Ref": "WatchbotQueue",
+      },
+    },
+  },
+  "Parameters": Object {},
+  "Resources": Object {
+    "WatchbotAlarmMemoryUtilization": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.12.0/docs/alarms.md#memoryutilization",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "WatchbotMemoryUtilization",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ClusterName",
+            "Value": "processing",
+          },
+          Object {
+            "Name": "ServiceName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotService",
+                "Name",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "MemoryUtilization",
+        "Namespace": "AWS/ECS",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 100,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotCustomScalingResource": Object {
+      "Properties": Object {
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotScalingLambda",
+            "Arn",
+          ],
+        },
+        "maxSize": 50,
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+    },
+    "WatchbotDashboard": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Sub": Array [
+            "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"WatchbotQueue: Visible and NotVisible Messages\\",\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesNotVisible\\",\\"QueueName\\",\\"\${WatchbotQueue}\\",{\\"period\\":60}],[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesVisible\\",\\"QueueName\\",\\"\${WatchbotQueue}\\",{\\"period\\":60}]],\\"stat\\":\\"Sum\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":60,\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":12,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"WatchbotQueue: Deleted messages\\",\\"metrics\\":[[\\"AWS/SQS\\",\\"NumberOfMessagesDeleted\\",\\"QueueName\\",\\"\${WatchbotQueue}\\",{\\"period\\":60}]],\\"stat\\":\\"Sum\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":60,\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":12,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"WatchbotService: RunningCapacity, DesiredCapacity\\",\\"metrics\\":[[\\"Mapbox/ecs-cluster\\",\\"RunningCapacity\\",\\"ClusterName\\",\\"\${Cluster}\\",\\"ServiceName\\",\\"\${WatchbotService}\\",{\\"period\\":60}],[\\".\\",\\"DesiredCapacity\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"period\\":60}]],\\"region\\":\\"\${AWS::Region}\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":12,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"Concurrency vs Throughput\\",\\"metrics\\":[[\\"Mapbox/ecs-cluster\\",\\"RunningCapacity\\",\\"ClusterName\\",\\"\${Cluster}\\",\\"ServiceName\\",\\"\${WatchbotService}\\",{\\"period\\":60,\\"yAxis\\":\\"right\\"}],[\\".\\",\\"DesiredCapacity\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"period\\":60,\\"yAxis\\":\\"right\\"}],[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesVisible\\",\\"QueueName\\",\\"\${WatchbotQueue}\\",{\\"period\\":60,\\"stat\\":\\"Sum\\",\\"yAxis\\":\\"left\\"}]],\\"region\\":\\"\${AWS::Region}\\",\\"period\\":60,\\"yAxis\\":{\\"right\\":{\\"min\\":0}}}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":18,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"WatchbotService: CPUUtilization, MemoryUtilization\\",\\"metrics\\":[[\\"AWS/ECS\\",\\"CPUUtilization\\",\\"ServiceName\\",\\"\${WatchbotService}\\",\\"ClusterName\\",\\"\${Cluster}\\",{\\"period\\":60}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"period\\":60}]],\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":18,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"title\\":\\"WatchbotDeadLetterQueue: Visible and NotVisible Messages\\",\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesNotVisible\\",\\"QueueName\\",\\"\${WatchbotDeadLetterQueue}\\",{\\"period\\":60}],[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesVisible\\",\\"QueueName\\",\\"\${WatchbotDeadLetterQueue}\\",{\\"period\\":60}]],\\"stat\\":\\"Sum\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":60,\\"yAxis\\":{\\"left\\":{\\"min\\":0}}}}]}",
+            Object {
+              "Cluster": "processing",
+              "WatchbotDeadLetterQueue": Object {
+                "Fn::GetAtt": Array [
+                  "WatchbotDeadLetterQueue",
+                  "QueueName",
+                ],
+              },
+              "WatchbotQueue": Object {
+                "Fn::GetAtt": Array [
+                  "WatchbotQueue",
+                  "QueueName",
+                ],
+              },
+              "WatchbotService": Object {
+                "Fn::GetAtt": Array [
+                  "WatchbotService",
+                  "Name",
+                ],
+              },
+            },
+          ],
+        },
+        "DashboardName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot",
+              Object {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "WatchbotDeadLetterAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "Provides notification when messages are visible in the dead letter queue",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-dead-letter",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotDeadLetterQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": "60",
+        "Statistic": "Minimum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotDeadLetterQueue": Object {
+      "Description": "List of messages that failed to process 14 times",
+      "Properties": Object {
+        "ContentBasedDeduplication": true,
+        "FifoQueue": true,
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "-",
+              "WatchbotDeadLetterQueue",
+              ".fifo",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "WatchbotLambdaScalingRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:",
+                        Object {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": "CustomcfnScalingLambdaLogs",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "WatchbotLambdaTotalMessagesRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:",
+                        Object {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                Object {
+                  "Action": Array [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::GetAtt": Array [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": "LambdaTotalMessagesMetric",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "WatchbotLogGroup": Object {
+      "Properties": Object {
+        "LogGroupName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "watchbot",
+            ],
+          ],
+        },
+        "RetentionInDays": 14,
+      },
+      "Type": "AWS::Logs::LogGroup",
+    },
+    "WatchbotMessageReceivesMetric": Object {
+      "Properties": Object {
+        "FilterPattern": "{ $.receives = * }",
+        "LogGroupName": Object {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": Array [
+          Object {
+            "MetricName": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "WatchbotMessageReceives-",
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": "$.receives",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "WatchbotMetricSchedulePermission": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotTotalMessagesLambda",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotTotalMessagesSchedule",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "WatchbotNotificationTopic": Object {
+      "Description": "Subscribe to this topic to receive emails when tasks fail or retry",
+      "Properties": Object {
+        "Subscription": Array [
+          Object {
+            "Endpoint": "hello@mapbox.pagerduty.com",
+            "Protocol": "email",
           },
         ],
       },
       "Type": "AWS::SNS::Topic",
+    },
+    "WatchbotQueue": Object {
+      "Properties": Object {
+        "ContentBasedDeduplication": true,
+        "FifoQueue": true,
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "-",
+              "WatchbotQueue",
+              ".fifo",
+            ],
+          ],
+        },
+        "RedrivePolicy": Object {
+          "deadLetterTargetArn": Object {
+            "Fn::GetAtt": Array [
+              "WatchbotDeadLetterQueue",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 10,
+        },
+        "VisibilityTimeout": 180,
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "WatchbotQueueSizeAlarm": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.12.0/docs/alarms.md#queuesize",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-queue-size",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 24,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": "300",
+        "Statistic": "Average",
+        "Threshold": 40,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "ecs-tasks.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "sqs:ReceiveMessage",
+                    "sqs:DeleteMessage",
+                    "sqs:ChangeMessageVisibility",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::GetAtt": Array [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "logs:FilterLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::GetAtt": Array [
+                      "WatchbotLogGroup",
+                      "Arn",
+                    ],
+                  },
+                },
+                Object {
+                  "Fn::If": Array [
+                    "NotInChina",
+                    Object {
+                      "Action": "kms:Decrypt",
+                      "Effect": "Allow",
+                      "Resource": Object {
+                        "Fn::ImportValue": "cloudformation-kms-production",
+                      },
+                    },
+                    Object {
+                      "Ref": "AWS::NoValue",
+                    },
+                  ],
+                },
+              ],
+            },
+            "PolicyName": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-default-worker",
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "WatchbotScaleDown": Object {
+      "Properties": Object {
+        "PolicyName": Object {
+          "Fn::Sub": "Watchbot\${AWS::StackName}-scale-down",
+        },
+        "PolicyType": "StepScaling",
+        "ScalingTargetId": Object {
+          "Ref": "WatchbotScalingTarget",
+        },
+        "StepScalingPolicyConfiguration": Object {
+          "AdjustmentType": "PercentChangeInCapacity",
+          "Cooldown": 300,
+          "MetricAggregationType": "Average",
+          "StepAdjustments": Array [
+            Object {
+              "MetricIntervalUpperBound": 0,
+              "ScalingAdjustment": -100,
+            },
+          ],
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
+    "WatchbotScaleDownTrigger": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotScaleDown",
+          },
+        ],
+        "AlarmDescription": "Scale down due to lack of in-flight messages in queue",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-scale-down",
+            ],
+          ],
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "TotalMessages",
+        "Namespace": "Mapbox/ecs-watchbot",
+        "Period": 600,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotScaleUp": Object {
+      "Properties": Object {
+        "PolicyName": Object {
+          "Fn::Sub": "\${AWS::StackName}-scale-up",
+        },
+        "PolicyType": "StepScaling",
+        "ScalingTargetId": Object {
+          "Ref": "WatchbotScalingTarget",
+        },
+        "StepScalingPolicyConfiguration": Object {
+          "AdjustmentType": "ChangeInCapacity",
+          "Cooldown": 300,
+          "MetricAggregationType": "Average",
+          "StepAdjustments": Array [
+            Object {
+              "MetricIntervalLowerBound": 0,
+              "ScalingAdjustment": Object {
+                "Fn::GetAtt": Array [
+                  "WatchbotCustomScalingResource",
+                  "ScalingAdjustment",
+                ],
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
+    "WatchbotScaleUpTrigger": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "WatchbotScaleUp",
+          },
+        ],
+        "AlarmDescription": "Scale up due to visible messages in queue",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-scale-up",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotScalingLambda": Object {
+      "Properties": Object {
+        "Code": Object {
+          "ZipFile": Object {
+            "Fn::Sub": "
+          const response = require('cfn-response');
+          exports.handler = function(event,context){
+            const result = Math.round(Math.max(Math.min(parseInt(event.ResourceProperties.maxSize) / 10, 100), 1));
+            response.send(event, context, response.SUCCESS, { ScalingAdjustment: result });
+          }
+          ",
+          },
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotLambdaScalingRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs6.10",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "WatchbotScalingRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "application-autoscaling.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Path": "/",
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "application-autoscaling:*",
+                    "cloudwatch:DescribeAlarms",
+                    "cloudwatch:PutMetricAlarm",
+                    "ecs:UpdateService",
+                    "ecs:DescribeServices",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+            },
+            "PolicyName": "watchbot-autoscaling",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "WatchbotScalingTarget": Object {
+      "Properties": Object {
+        "MaxCapacity": 50,
+        "MinCapacity": 0,
+        "ResourceId": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "service/",
+              "processing",
+              "/",
+              Object {
+                "Fn::GetAtt": Array [
+                  "WatchbotService",
+                  "Name",
+                ],
+              },
+            ],
+          ],
+        },
+        "RoleARN": Object {
+          "Fn::GetAtt": Array [
+            "WatchbotScalingRole",
+            "Arn",
+          ],
+        },
+        "ScalableDimension": "ecs:service:DesiredCount",
+        "ServiceNamespace": "ecs",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "WatchbotService": Object {
+      "Properties": Object {
+        "Cluster": "processing",
+        "DesiredCount": 0,
+        "TaskDefinition": Object {
+          "Ref": "WatchbotTask",
+        },
+      },
+      "Type": "AWS::ECS::Service",
+    },
+    "WatchbotTask": Object {
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Command": Array [
+              "watchbot",
+              "listen",
+              "echo hello world",
+            ],
+            "Cpu": 128,
+            "Environment": Array [
+              Object {
+                "Name": "WorkTopic",
+                "Value": undefined,
+              },
+              Object {
+                "Name": "QueueUrl",
+                "Value": Object {
+                  "Ref": "WatchbotQueue",
+                },
+              },
+              Object {
+                "Name": "LogGroup",
+                "Value": Object {
+                  "Ref": "WatchbotLogGroup",
+                },
+              },
+              Object {
+                "Name": "writableFilesystem",
+                "Value": false,
+              },
+              Object {
+                "Name": "maxJobDuration",
+                "Value": 0,
+              },
+              Object {
+                "Name": "Volumes",
+                "Value": "/tmp",
+              },
+              Object {
+                "Name": "Fifo",
+                "Value": "true",
+              },
+            ],
+            "Image": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ".dkr.ecr.",
+                  Object {
+                    "Fn::FindInMap": Array [
+                      "EcrRegion",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      "Region",
+                    ],
+                  },
+                  ".",
+                  Object {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/",
+                  "example",
+                  ":",
+                  "1",
+                ],
+              ],
+            },
+            "LogConfiguration": Object {
+              "LogDriver": "awslogs",
+              "Options": Object {
+                "awslogs-group": Object {
+                  "Ref": "WatchbotLogGroup",
+                },
+                "awslogs-region": Object {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "1",
+              },
+            },
+            "MountPoints": Array [
+              Object {
+                "ContainerPath": "/tmp",
+                "SourceVolume": "tmp",
+              },
+            ],
+            "Name": Object {
+              "Fn::Join": Array [
+                "-",
+                Array [
+                  "Watchbot",
+                  Object {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "Privileged": false,
+            "ReadonlyRootFilesystem": true,
+            "Ulimits": Array [
+              Object {
+                "HardLimit": 10240,
+                "Name": "nofile",
+                "SoftLimit": 10240,
+              },
+            ],
+          },
+        ],
+        "Family": "example",
+        "TaskRoleArn": Object {
+          "Ref": "WatchbotRole",
+        },
+        "Volumes": Array [
+          Object {
+            "Name": "tmp",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
     },
     "WatchbotTotalMessagesLambda": Object {
       "Properties": Object {

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -78,6 +78,54 @@ test('[message] constructor', (assert) => {
   assert.end();
 });
 
+test('[message] constructor with SQS FIFO non-JSON message', (assert) => {
+  AWS.stub('SQS', 'receiveMessage');
+
+  const sqsFifoMessage = Object.assign({}, sqsMessage, {
+    Body: 'fake-message-body'
+  });
+  const message = new Message(sqsFifoMessage, { queueUrl });
+
+  assert.deepEqual(
+    message.env,
+    {
+      MessageId: '1',
+      Message: 'fake-message-body',
+      SentTimestamp: '2018-02-07T18:18:53.772Z',
+      ApproximateFirstReceiveTimestamp: '2018-02-07T18:18:53.772Z',
+      ApproximateReceiveCount: '3'
+    },
+    'sets .env'
+  );
+
+  AWS.SQS.restore();
+  assert.end();
+});
+
+test('[message] constructor with SQS FIFO JSON message', (assert) => {
+  AWS.stub('SQS', 'receiveMessage');
+
+  const sqsFifoMessage = Object.assign({}, sqsMessage, {
+    Body: '{ "a": 1, "b": 2 }'
+  });
+  const message = new Message(sqsFifoMessage, { queueUrl });
+
+  assert.deepEqual(
+    message.env,
+    {
+      MessageId: '1',
+      Message: '{ "a": 1, "b": 2 }',
+      SentTimestamp: '2018-02-07T18:18:53.772Z',
+      ApproximateFirstReceiveTimestamp: '2018-02-07T18:18:53.772Z',
+      ApproximateReceiveCount: '3'
+    },
+    'sets .env'
+  );
+
+  AWS.SQS.restore();
+  assert.end();
+});
+
 test('[message] factory', (assert) => {
   const message = Message.create(sqsMessage, { queueUrl });
   assert.ok(message instanceof Message, 'returns Message object');

--- a/test/template.spec.js
+++ b/test/template.spec.js
@@ -159,4 +159,28 @@ test('[template]', () => {
   }));
 
   expect(setsAllLowCPU).toMatchSnapshot('all-properties-low-CPU');
+
+
+  const fifo = cf.merge(template({
+    service: 'example',
+    serviceVersion: '1',
+    command: 'echo hello world',
+    cluster: 'processing',
+    notificationEmail: 'hello@mapbox.pagerduty.com',
+    fifo: true
+  }));
+
+  expect(fifo).toMatchSnapshot('fifo');
+
+  const fifoMaxSize = cf.merge(template({
+    service: 'example',
+    serviceVersion: '1',
+    command: 'echo hello world',
+    cluster: 'processing',
+    notificationEmail: 'hello@mapbox.pagerduty.com',
+    fifo: true,
+    maxSize: 50
+  }));
+
+  expect(fifoMaxSize).toMatchSnapshot('fifoMaxSize');
 });

--- a/test/template.validation.js
+++ b/test/template.validation.js
@@ -75,3 +75,27 @@ test('[template validation] options set', async (assert) => {
 
   assert.end();
 });
+
+test('[template validation] fifo queue', async (assert) => {
+  const fifo = cf.merge(template({
+    service: 'example',
+    serviceVersion: '1',
+    command: 'echo hello world',
+    cluster: 'processing',
+    notificationEmail: 'hello@mapbox.pagerduty.com',
+    fifo: true
+  }));
+
+  const tmp = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
+  fs.writeFileSync(tmp, JSON.stringify(fifo));
+
+  try {
+    await cf.validate(tmp);
+    assert.pass('template is valid');
+  } catch (err) {
+    assert.ifError(err, 'template is not valid');
+  }
+
+  assert.end();
+});
+


### PR DESCRIPTION
This PR explores adding a configuration option that allows you to launch a watchbot stack that operates against a FIFO queue. On the first pass, the biggest adjustments watchbot and its users need to be aware of:

- Usually watchbot makes an SNS topic to feed an SQS queue. When an SQS message is received, it is expected that the message came via SNS, which leads to the `Subject` and `Message` (SNS message attributes) being parsed and exposed to the worker as environment variables. You can't send messages to a FIFO queue via SNS topic -- instead you have to send them directly to the queue. This means the parsing assumptions that watchbot makes may be invalid. The least invasive approach I can think of here would be to adjust message parsing in a backwards compatible way, and expose the `MessageGroupId` to the worker as the `Subject` environment variable, and the `Message` as the SQS message body.

- When feeding a message to a FIFO queue, you must provide a `MessageGroupId`. This acts as a sort of "shard" for the queue -- FIFO behavior is only guaranteed for messages that share an identical `MessageGroupId`. We need some additional documentation in here to explain this.

- Scaling behavior in watchbot is based on the total number of messages in the queue. If there are 50 messages, concurrent processing scales up to 50 (or the configured `MaxSize` if lower). In a FIFO queue, really you would want to scale on the number of `MessageGroupId`s that are being fed to your queue. If there are 50 messages in the queue, but only 2 `MessageGroupId`s, then watchbot would launch 50 containers for processing, but only 2 at a time would be able to process messages.

Currently this PR locks the number of containers to `1` if you specify `fifo: true`, and turns off autoscaling entirely. This is probably not the right approach to take. Given that something like "number of MessageGroupIds" is not a metric that SQS provides in cloudwatch, and given that it is entirely dependent on how the user sends messages to the queue, I don't think we're going to find an ideal scaling behavior here. We should probably re-enable scaling, and document that in a FIFO queue, its important that you consider up-front how many `MessageGroupIds` your queue will have, and set your stack's `MaxSize` to that value or lower.

fixes #278 
cc @davidtheclark 