### PR TITLE
optionally remove deadletter alarm

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -613,7 +613,6 @@ module.exports = (options = {}) => {
     }
   };
 
-  console.log('options.deadletterAlarm', options.deadletterAlarm);
   if (options.deadletterAlarm) {
     Resources[prefixed('DeadLetterAlarm')] = {
       Type: 'AWS::CloudWatch::Alarm',

--- a/lib/template.js
+++ b/lib/template.js
@@ -101,6 +101,8 @@ const dashboard = require(path.resolve(__dirname, 'dashboard.js'));
  * control the number of times a message is delivered to the source queue before
  * being moved to the dead-letter queue. This parameter can be provided as either
  * a number or a reference, i.e. `{"Ref": "..."}`.
+ * @param {boolean} [options.deadletterAlarm=true] - Use this parameter to disable
+ * creating an alarm for the dead letter queue threshold going from 0-1 messages.
  */
 module.exports = (options = {}) => {
   ['service', 'serviceVersion', 'command', 'cluster'].forEach((required) => {
@@ -128,6 +130,7 @@ module.exports = (options = {}) => {
       alarmPeriods: 24,
       failedPlacementAlarmPeriods: 1,
       deadletterThreshold: 10,
+      deadletterAlarm: true,
       dashboard: true
     },
     options
@@ -610,25 +613,28 @@ module.exports = (options = {}) => {
     }
   };
 
-  Resources[prefixed('DeadLetterAlarm')] = {
-    Type: 'AWS::CloudWatch::Alarm',
-    Properties: {
-      AlarmName: cf.join('-', [cf.ref('AWS::StackName'), prefixed('-dead-letter')]),
-      AlarmDescription:
-        'Provides notification when messages are visible in the dead letter queue',
-      EvaluationPeriods: 1,
-      Statistic: 'Minimum',
-      Threshold: 1,
-      Period: '60',
-      ComparisonOperator: 'GreaterThanOrEqualToThreshold',
-      Namespace: 'AWS/SQS',
-      Dimensions: [
-        { Name: 'QueueName', Value: cf.getAtt(prefixed('DeadLetterQueue'), 'QueueName') }
-      ],
-      MetricName: 'ApproximateNumberOfMessagesVisible',
-      AlarmActions: [notify]
-    }
-  };
+  console.log('options.deadletterAlarm', options.deadletterAlarm);
+  if (options.deadletterAlarm) {
+    Resources[prefixed('DeadLetterAlarm')] = {
+      Type: 'AWS::CloudWatch::Alarm',
+      Properties: {
+        AlarmName: cf.join('-', [cf.ref('AWS::StackName'), prefixed('-dead-letter')]),
+        AlarmDescription:
+          'Provides notification when messages are visible in the dead letter queue',
+        EvaluationPeriods: 1,
+        Statistic: 'Minimum',
+        Threshold: 1,
+        Period: '60',
+        ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+        Namespace: 'AWS/SQS',
+        Dimensions: [
+          { Name: 'QueueName', Value: cf.getAtt(prefixed('DeadLetterQueue'), 'QueueName') }
+        ],
+        MetricName: 'ApproximateNumberOfMessagesVisible',
+        AlarmActions: [notify]
+      }
+    };
+  }
 
   Resources[prefixed('WorkerErrorsMetric')] = {
     Type: 'AWS::Logs::MetricFilter',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "4.11.2",
+  "version": "4.12.0-1",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "4.12.0-1",
+  "version": "4.11.2",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -49,7 +49,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.11.1",
+    "EcsWatchbotVersion": "4.11.2",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -87,7 +87,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -578,7 +578,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1253,7 +1253,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1364,7 +1364,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.11.1",
+    "EcsWatchbotVersion": "4.11.2",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -1402,7 +1402,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1893,7 +1893,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2566,7 +2566,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2677,7 +2677,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.11.1",
+    "EcsWatchbotVersion": "4.11.2",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -2715,7 +2715,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3206,7 +3206,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3879,7 +3879,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3990,7 +3990,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.11.1",
+    "EcsWatchbotVersion": "4.11.2",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -4028,7 +4028,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4519,7 +4519,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5192,7 +5192,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5303,7 +5303,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.11.1",
+    "EcsWatchbotVersion": "4.11.2",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -5341,7 +5341,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5758,7 +5758,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6367,7 +6367,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.11.2/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",

--- a/test/template.spec.js
+++ b/test/template.spec.js
@@ -53,6 +53,7 @@ test('[template]', () => {
     messageTimeout: 300,
     messageRetention: 1096,
     deadletterThreshold: 50,
+    deadletterAlarm: true,
     notificationEmail: 'hello@mapbox.pagerduty.com'
   }));
 

--- a/test/template.validation.js
+++ b/test/template.validation.js
@@ -59,6 +59,7 @@ test('[template validation] options set', async (assert) => {
     messageTimeout: 300,
     messageRetention: 1096,
     deadletterThreshold: 50,
+    deadletterAlarm: true,
     notificationEmail: 'hello@mapbox.pagerduty.com'
   }));
 


### PR DESCRIPTION
This adds a `deadletterAlarm` option to provide a way to bypass creating the deadletter queue alarm resource. Resolves #287 

Tests: wasn't sure how to properly test since there's only a single template snapshot. Is it worth creating a second snapshot without the alarm resource? 

cc @mapbox/platform 