### PR TITLE
Document why the magic number 14 appears in the retry handler.

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -75,6 +75,10 @@ class Message {
 
   async retry() {
     const receives = Number(this.env.ApproximateReceiveCount);
+
+    // Reason for this magic number discussed in detail here:
+    // https://github.com/mapbox/ecs-watchbot/pull/184/files#r167034116
+    // TL;DR - 2^14 seconds is longer than AWS's maximum VisibilityTimeout
     if (receives > 14) return;
 
     const params = {


### PR DESCRIPTION
Adds a comment to describe why the magic number 14 is used in the retry handler.

Thanks to @jakepruitt for pointing out where this magic number was discussed.