### PR TITLE
Expose SQS visibility timeout to Cloudformation template.

### DIFF
--- a/docs/building-a-template.md
+++ b/docs/building-a-template.md
@@ -89,7 +89,9 @@ When creating your watchbot stacks with the `watchbot.template()` method, you no
 **errorThreshold** | Watchbot creates a CloudWatch alarm that will fire if there have been more than this number of failed worker invocations in a 60 second period. This parameter can be provided as either a number or a reference, i.e. `{"Ref": "..."}`. | Number/Ref | No | 10
 **deadletterThreshold** | Use this parameter to control the number of times a message is delivered to the source queue before being moved to the dead-letter queue. This parameter can be provided as either a number or a reference, i.e. `{"Ref": "..."}`. | Number/Ref | No | 10
 **dashboard** | Watchbot creates a Cloudwatch Dashboard called `<cloudformation-stack>-<region>`. If running in cn-north-1, this may need to be disabled | Boolean | No | `true`
-**fifo** | Whether you want Watchbot's SQS queue to be first-in-first-out (FIFO). By default, Watchbot creates a standard SQS queue, in which the order of jobs is not guaranteed to match the order of messages. If your program requires more precise ordering and the limitations of a FIFO queue will be acceptable, set this option to `true`. Learn more in ["Using a FIFO queue"](./using-a-fifo-queue.md) | Boolean | No | `false`
+**fifo** | Whether you want Watchbot's SQS queue to be first-in-first-out (FIFO). By default, Watchbot creates a standard SQS queue, in which the order of jobs is not guaranteed to match the order of messages. If your program requires more precise ordering and the limitations of a FIFO queue will be acceptable, set this option to `true`. Learn more in ["Using a FIFO queue"](./using-a-fifo-queue.md). | Boolean | No | `false`
+**visibilityTimeout** | The message visibility timeout, in seconds, for the SQS queue. Once a queued message is marked received by a consumer, SQS hides it for this time interval. If a message is still in-flight and not deleted from the queue by the worker by this time, the message will be marked visible again and available to other workers. Learn more in ["Worker Retry Cycle"](./worker-retry-cycle.md). | Number/Ref | No | 180
+
 
 ### writableFilesystem mode explained
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -108,7 +108,7 @@ const dashboard = require(path.resolve(__dirname, 'dashboard.js'));
  * in which the order of jobs is not guaranteed to match the order of messages.
  * If your program requires more precise ordering and the limitations of a FIFO queue
  * will be acceptable, set this option to `true`.
- * @param {Number|ref} [options.visbilityTimeout=180] - The message visibility
+ * @param {Number|ref} [options.visibilityTimeout=180] - The message visibility
  * timeout, in seconds, for the SQS queue. Once a queued message is marked
  * received by a consumer, SQS hides it for this time interval. If a message is
  * still in-flight and not deleted from the queue by the worker by this time,

--- a/lib/template.js
+++ b/lib/template.js
@@ -108,6 +108,11 @@ const dashboard = require(path.resolve(__dirname, 'dashboard.js'));
  * in which the order of jobs is not guaranteed to match the order of messages.
  * If your program requires more precise ordering and the limitations of a FIFO queue
  * will be acceptable, set this option to `true`.
+ * @param {Number|ref} [options.visbilityTimeout=180] - The message visibility
+ * timeout, in seconds, for the SQS queue. Once a queued message is marked
+ * received by a consumer, SQS hides it for this time interval. If a message is
+ * still in-flight and not deleted from the queue by the worker by this time,
+ * the message will be marked visible again and available to other workers.
  */
 module.exports = (options = {}) => {
   ['service', 'serviceVersion', 'command', 'cluster'].forEach((required) => {
@@ -122,6 +127,7 @@ module.exports = (options = {}) => {
       env: {},
       maxJobDuration: 0,
       messageRetention: 1209600,
+      visibilityTimeout: 180,
       maxSize: 1,
       minSize: 0,
       mounts: '',
@@ -243,7 +249,7 @@ module.exports = (options = {}) => {
   Resources[prefixed('Queue')] = {
     Type: 'AWS::SQS::Queue',
     Properties: {
-      VisibilityTimeout: 180,
+      VisibilityTimeout: options.visibilityTimeout,
       QueueName: cf.join([cf.stackName, '-', prefixed('Queue')]),
       MessageRetentionPeriod: options.messageRetention,
       RedrivePolicy: {


### PR DESCRIPTION
In the event that a task is externally terminated, a fixed 180 seconds
must pass before the work item is visible again, which may be too long
for some applications. This permits watchbot apps to define their own
visibility timeout for work deadlines.

/cc @rclark @jakepruitt
/fyi @danpat