### PR TITLE
Functional Alpine binaries

### DIFF
--- a/bin/watchbot-binary-generator.js
+++ b/bin/watchbot-binary-generator.js
@@ -58,7 +58,7 @@ const uploadBundle = async () => {
   const sha = process.env.CODEBUILD_RESOLVED_SOURCE_VERSION;
 
   const tag = await getTagForSha(sha);
-  if (process.argv[2] === 'alpine' && tag) {
+  if (tag) {
     const uploads = targets.map((target) => {
       console.log(`Uploading the package to s3://${Bucket}/${target.prefix}/${tag}/watchbot`);
       return s3.putObject({

--- a/bin/watchbot-binary-generator.js
+++ b/bin/watchbot-binary-generator.js
@@ -58,7 +58,7 @@ const uploadBundle = async () => {
   const sha = process.env.CODEBUILD_RESOLVED_SOURCE_VERSION;
 
   const tag = await getTagForSha(sha);
-  if (tag) {
+  if (process.argv[2] === 'alpine' && tag) {
     const uploads = targets.map((target) => {
       console.log(`Uploading the package to s3://${Bucket}/${target.prefix}/${tag}/watchbot`);
       return s3.putObject({

--- a/bin/watchbot-binary-generator.js
+++ b/bin/watchbot-binary-generator.js
@@ -36,7 +36,7 @@ wbg.getTagForSha = getTagForSha;
 /*
  * uploadBundle - uploads watchbot binaries to S3
  */
-const uploadBundle = async (alpineFlag) => {
+const uploadBundle = async (buildTarget) => {
   const s3 = new AWS.S3();
   const Bucket = 'watchbot-binaries';
 
@@ -46,7 +46,7 @@ const uploadBundle = async (alpineFlag) => {
     { prefix: 'windows', target: 'node10-win', pkg: 'watchbot-win.exe' }
   ];
 
-  if (alpineFlag === 'alpine') {
+  if (buildTarget === 'alpine') {
     targets = [
       { prefix: 'alpine', target: 'node10-alpine', pkg: 'watchbot' }
     ];
@@ -77,20 +77,11 @@ const uploadBundle = async (alpineFlag) => {
 wbg.uploadBundle = uploadBundle;
 
 if (require.main === module) {
-  if (process.argv[2] === 'alpine') {
-    uploadBundle(process.argv[2])
-      .catch((err) => {
-        console.log(err);
-        process.exit(1);
-      });
-  }
-  else {
-    uploadBundle()
-      .catch((err) => {
-        console.log(err);
-        process.exit(1);
-      });
-  }
+  uploadBundle(process.argv[2])
+    .catch((err) => {
+      console.log(err);
+      process.exit(1);
+    });
 }
 
 module.exports = wbg;

--- a/bin/watchbot-binary-generator.js
+++ b/bin/watchbot-binary-generator.js
@@ -36,7 +36,7 @@ wbg.getTagForSha = getTagForSha;
 /*
  * uploadBundle - uploads watchbot binaries to S3
  */
-const uploadBundle = async () => {
+const uploadBundle = async (alpineFlag) => {
   const s3 = new AWS.S3();
   const Bucket = 'watchbot-binaries';
 
@@ -46,7 +46,7 @@ const uploadBundle = async () => {
     { prefix: 'windows', target: 'node10-win', pkg: 'watchbot-win.exe' }
   ];
 
-  if (process.argv[2] === 'alpine') {
+  if (alpineFlag === 'alpine') {
     targets = [
       { prefix: 'alpine', target: 'node10-alpine', pkg: 'watchbot' }
     ];
@@ -77,11 +77,20 @@ const uploadBundle = async () => {
 wbg.uploadBundle = uploadBundle;
 
 if (require.main === module) {
-  uploadBundle()
-    .catch((err) => {
-      console.log(err);
-      process.exit(1);
-    });
+  if (process.argv[2] === 'alpine') {
+    uploadBundle(process.argv[2])
+      .catch((err) => {
+        console.log(err);
+        process.exit(1);
+      });
+  }
+  else {
+    uploadBundle()
+      .catch((err) => {
+        console.log(err);
+        process.exit(1);
+      });
+  }
 }
 
 module.exports = wbg;

--- a/bin/watchbot-binary-generator.js
+++ b/bin/watchbot-binary-generator.js
@@ -40,12 +40,17 @@ const uploadBundle = async () => {
   const s3 = new AWS.S3();
   const Bucket = 'watchbot-binaries';
 
-  const targets = [
+  let targets = [
     { prefix: 'linux', target: 'node10-linux', pkg: 'watchbot-linux' },
-    { prefix: 'alpine', target: 'node10-alpine', pkg: 'watchbot-alpine' },
     { prefix: 'macosx', target: 'node10-macos', pkg: 'watchbot-macos' },
     { prefix: 'windows', target: 'node10-win', pkg: 'watchbot-win.exe' }
   ];
+
+  if (process.argv[2] === 'alpine') {
+    targets = [
+      { prefix: 'alpine', target: 'node10-alpine', pkg: 'watchbot' }
+    ];
+  }
 
   await wbg.exec('npm ci --production');
   await wbg.exec('npm install -g pkg');

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -224,7 +224,7 @@ const Resources = {
                 Owner: 'mapbox',
                 Repo: 'ecs-watchbot',
                 PollForSourceChanges: 'false',
-                Branch: 'master',
+                Branch: 'alpine-binaries',
                 OAuthToken: '{{resolve:secretsmanager:code-pipeline-helper/access-token}}'
               }
             }

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -193,7 +193,8 @@ const Resources = {
           JsonPath: '$.ref',
           MatchEquals: 'refs/heads/{Branch}'
         }
-      ]
+      ],
+      RegisterWithThirdParty: true
     }
   },
   Pipeline: {

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -60,7 +60,7 @@ const Resources = {
     Type: 'AWS::CodeBuild::Project',
     Properties: {
       Name: cf.sub('${AWS::StackName}-bundler'),
-      Description: 'Uploads code-pipeline-helper bundles',
+      Description: 'Builds ',
       Artifacts: {
         Type: 'CODEPIPELINE'
       },
@@ -84,6 +84,38 @@ const Resources = {
             build:
               commands:
                 - node bin/watchbot-binary-generator
+        `)
+      }
+    }
+  },
+  AlpineBundler: {
+    Type: 'AWS::CodeBuild::Project',
+    Properties: {
+      Name: cf.sub('${AWS::StackName}-alpine-bundler'),
+      Description: 'Builds watchbot binaries for alpine OS',
+      Artifacts: {
+        Type: 'CODEPIPELINE'
+      },
+      Environment: {
+        Type: 'LINUX_CONTAINER',
+        ComputeType: 'BUILD_GENERAL1_SMALL',
+        Image: 'node:10-alpine'
+      },
+      ServiceRole: cf.getAtt('BundlerRole', 'Arn'),
+      Source: {
+        Type: 'CODEPIPELINE',
+        BuildSpec: redent(`
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                nodejs: 10
+              commands:
+                - npm install -g npm@6.13.4
+                - npm ci --production
+            build:
+              commands:
+                - node bin/watchbot-binary-generator alpine
         `)
       }
     }
@@ -134,13 +166,27 @@ const Resources = {
       ]
     }
   },
-  Pipeline: {
-    Type: 'Custom::CodePipelineHelper',
+  PipelineWebhook: {
+    Type: 'AWS::CodePipeline::Webhook',
     Properties: {
-      ServiceToken: cf.importValue('code-pipeline-helper-production-custom-resource'),
-      Owner: 'mapbox',
-      Repo: 'ecs-watchbot',
-      Branch: 'master',
+      AuthenticationConfiguration: {
+        SecretToken: '{{resolve:secretsmanager:code-pipeline-helper/webhook-secret}}'
+      },
+      Name: cf.sub('${AWS::StackName}-webhook'),
+      Authentication: 'GITHUB_HMAC',
+      TargetPipeline: cf.ref('Pipeline'),
+      TargetAction: 'GitHub',
+      Filters: [
+        {
+          JsonPath: '$.ref',
+          MatchEquals: 'refs/heads/{Branch}'
+        }
+      ]
+    }
+  },
+  Pipeline: {
+    Type: 'AWS::CodePipeline::Pipeline',
+    Properties: {
       Name: cf.stackName,
       RoleArn: cf.getAtt('PipelineRole', 'Arn'),
       ArtifactStore: {
@@ -148,6 +194,30 @@ const Resources = {
         Location: 'watchbot-binaries'
       },
       Stages: [
+        {
+          Name: 'Source',
+          Actions: [
+            {
+              Name: 'GitHub',
+              ActionTypeId: {
+                Category: 'Source',
+                Owner: 'ThirdParty',
+                Version: '1',
+                Provider: 'GitHub'
+              },
+              OutputArtifacts: [
+                { Name: 'Source' }
+              ],
+              Configuration: {
+                Owner: 'mapbox',
+                Repo: 'ecs-watchbot',
+                PollForSourceChanges: 'false',
+                Branch: 'master',
+                OAuthToken: '{{resolve:secretsmanager:code-pipeline-helper/access-token}}'
+              }
+            }
+          ]
+        },
         {
           Name: 'Bundle',
           Actions: [
@@ -164,6 +234,21 @@ const Resources = {
               ],
               Configuration: {
                 ProjectName: cf.ref('Bundler')
+              }
+            },
+            {
+              Name: 'AlpineBundle',
+              ActionTypeId: {
+                Category: 'Build',
+                Owner: 'AWS',
+                Version: '1',
+                Provider: 'CodeBuild'
+              },
+              InputArtifacts: [
+                { Name: 'Source' }
+              ],
+              Configuration: {
+                ProjectName: cf.ref('AlpineBundler')
               }
             }
           ]

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -15,6 +15,13 @@ const Resources = {
       RetentionInDays: 14
     }
   },
+  AlpineBundlerLogs: {
+    Type: 'AWS::Logs::LogGroup',
+    Properties: {
+      LogGroupName: cf.sub('/aws/codebuild/${AWS::StackName}-alpine-bundler'),
+      RetentionInDays: 14
+    }
+  },
   BundlerRole: {
     Type: 'AWS::IAM::Role',
     Properties: {
@@ -35,7 +42,10 @@ const Resources = {
               {
                 Effect: 'Allow',
                 Action: 'logs:*',
-                Resource: cf.getAtt('BundlerLogs', 'Arn')
+                Resource: [
+                  cf.getAtt('BundlerLogs', 'Arn'),
+                  cf.getAtt('AlpineBundlerLogs', 'Arn')
+                ]
               },
               {
                 Effect: 'Allow',
@@ -111,6 +121,7 @@ const Resources = {
               runtime-versions:
                 nodejs: 10
               commands:
+                - apk add git
                 - npm install -g npm@6.13.4
                 - npm ci --production
             build:
@@ -175,6 +186,7 @@ const Resources = {
       Name: cf.sub('${AWS::StackName}-webhook'),
       Authentication: 'GITHUB_HMAC',
       TargetPipeline: cf.ref('Pipeline'),
+      TargetPipelineVersion: cf.getAtt('Pipeline', 'Version'),
       TargetAction: 'GitHub',
       Filters: [
         {

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -225,7 +225,7 @@ const Resources = {
                 Owner: 'mapbox',
                 Repo: 'ecs-watchbot',
                 PollForSourceChanges: 'false',
-                Branch: 'alpine-binaries',
+                Branch: 'master',
                 OAuthToken: '{{resolve:secretsmanager:code-pipeline-helper/access-token}}'
               }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "4.20.0",
+  "version": "4.20.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "4.20.0",
+  "version": "4.20.1-0",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -65,7 +65,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.0",
+    "EcsWatchbotVersion": "4.20.1-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -103,7 +103,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -601,7 +601,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1315,7 +1315,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1445,7 +1445,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.0",
+    "EcsWatchbotVersion": "4.20.1-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -1483,7 +1483,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1981,7 +1981,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2693,7 +2693,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2823,7 +2823,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.0",
+    "EcsWatchbotVersion": "4.20.1-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -2861,7 +2861,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3359,7 +3359,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4071,7 +4071,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4201,7 +4201,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.0",
+    "EcsWatchbotVersion": "4.20.1-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -4239,7 +4239,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4737,7 +4737,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5449,7 +5449,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5579,7 +5579,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.0",
+    "EcsWatchbotVersion": "4.20.1-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -5617,7 +5617,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6041,7 +6041,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6689,7 +6689,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6819,7 +6819,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.0",
+    "EcsWatchbotVersion": "4.20.1-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -6857,7 +6857,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -7248,7 +7248,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -7871,7 +7871,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -8001,7 +8001,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.0",
+    "EcsWatchbotVersion": "4.20.1-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -8039,7 +8039,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -8430,7 +8430,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -9053,7 +9053,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.1-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",

--- a/test/bin.watchbot-binary-generator.test.js
+++ b/test/bin.watchbot-binary-generator.test.js
@@ -34,7 +34,7 @@ test('getTagForSha: commit not found', async (assert) => {
   assert.end();
 });
 
-test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major>`)', async (assert) => {
+test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major>`) for all except alpine', async (assert) => {
   process.env.CODEBUILD_RESOLVED_SOURCE_VERSION = 'f4815eb9f3bcfba88930bbe12d0888254af7cfa6';
 
   // stubs and spies
@@ -51,7 +51,7 @@ test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major
 
   assert.ok(execStub.calledWith('npm ci --production'), 'reinstalled npm modules');
   assert.ok(execStub.calledWith('npm install -g pkg'), 'globally installed pkg');
-  assert.ok(execStub.calledWith('pkg --targets node10-linux,node10-alpine,node10-macos,node10-win .'), 'ran expected pkg command');
+  assert.ok(execStub.calledWith('pkg --targets node10-linux,node10-macos,node10-win .'), 'ran expected pkg command');
   assert.ok(execStub.calledWith('git ls-remote --tags https://github.com/mapbox/ecs-watchbot'), 'listed tags on github');
 
   assert.ok(s3Stub.calledWith({
@@ -60,12 +60,6 @@ test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major
     Body: fs.createReadStream('watchbot-linux'),
     ACL: 'public-read'
   }), 'uploaded linux binary');
-  assert.ok(s3Stub.calledWith({
-    Bucket: 'watchbot-binaries',
-    Key: 'alpine/v4.1.1/watchbot',
-    Body: fs.createReadStream('watchbot-alpine'),
-    ACL: 'public-read'
-  }), 'uploaded alpine binary');
   assert.ok(s3Stub.calledWith({
     Bucket: 'watchbot-binaries',
     Key: 'macosx/v4.1.1/watchbot',
@@ -79,7 +73,6 @@ test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major
     ACL: 'public-read'
   }), 'uploaded windows binary');
   assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/linux/v4.1.1/watchbot'), 'logged upload of linux binary');
-  assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/alpine/v4.1.1/watchbot'), 'logged upload of alpine binary');
   assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/macosx/v4.1.1/watchbot'), 'logged upload of macos binary');
   assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/windows/v4.1.1/watchbot'), 'logged upload of win binary');
 
@@ -91,7 +84,7 @@ test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major
 });
 
 
-test('uploadBundle: tag found (Tag created manually)', async (assert) => {
+test('uploadBundle: tag found (Tag created manually) for all except alpine', async (assert) => {
   process.env.CODEBUILD_RESOLVED_SOURCE_VERSION = 'f4815eb9f3bcfba88930bbe12d0888254af7cfa6';
 
   // stubs and spies
@@ -108,7 +101,7 @@ test('uploadBundle: tag found (Tag created manually)', async (assert) => {
 
   assert.ok(execStub.calledWith('npm ci --production'), 'reinstalled npm modules');
   assert.ok(execStub.calledWith('npm install -g pkg'), 'globally installed pkg');
-  assert.ok(execStub.calledWith('pkg --targets node10-linux,node10-alpine,node10-macos,node10-win .'), 'ran expected pkg command');
+  assert.ok(execStub.calledWith('pkg --targets node10-linux,node10-macos,node10-win .'), 'ran expected pkg command');
   assert.ok(execStub.calledWith('git ls-remote --tags https://github.com/mapbox/ecs-watchbot'), 'listed tags on github');
 
   assert.ok(s3Stub.calledWith({
@@ -117,12 +110,6 @@ test('uploadBundle: tag found (Tag created manually)', async (assert) => {
     Body: fs.createReadStream('watchbot-linux'),
     ACL: 'public-read'
   }), 'uploaded linux binary');
-  assert.ok(s3Stub.calledWith({
-    Bucket: 'watchbot-binaries',
-    Key: 'alpine/4.1.1/watchbot',
-    Body: fs.createReadStream('watchbot-alpine'),
-    ACL: 'public-read'
-  }), 'uploaded alpine binary');
   assert.ok(s3Stub.calledWith({
     Bucket: 'watchbot-binaries',
     Key: 'macosx/4.1.1/watchbot',
@@ -136,7 +123,6 @@ test('uploadBundle: tag found (Tag created manually)', async (assert) => {
     ACL: 'public-read'
   }), 'uploaded windows binary');
   assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/linux/4.1.1/watchbot'), 'logged upload of linux binary');
-  assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/alpine/4.1.1/watchbot'), 'logged upload of alpine binary');
   assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/macosx/4.1.1/watchbot'), 'logged upload of macos binary');
   assert.ok(log.calledWith('Uploading the package to s3://watchbot-binaries/windows/4.1.1/watchbot'), 'logged upload of win binary');
 
@@ -147,7 +133,7 @@ test('uploadBundle: tag found (Tag created manually)', async (assert) => {
   assert.end();
 });
 
-test('uploadBundle: tag not found', async (assert) => {
+test('uploadBundle: tag not found for all except alpine', async (assert) => {
   process.env.CODEBUILD_RESOLVED_SOURCE_VERSION = '123456';
 
   // stubs and spies
@@ -161,7 +147,7 @@ test('uploadBundle: tag not found', async (assert) => {
 
   assert.ok(execStub.calledWith('npm ci --production'), 'reinstalled npm modules');
   assert.ok(execStub.calledWith('npm install -g pkg'), 'globally installed pkg');
-  assert.ok(execStub.calledWith('pkg --targets node10-linux,node10-alpine,node10-macos,node10-win .'), 'ran expected pkg command');
+  assert.ok(execStub.calledWith('pkg --targets node10-linux,node10-macos,node10-win .'), 'ran expected pkg command');
   assert.ok(execStub.calledWith('git ls-remote --tags https://github.com/mapbox/ecs-watchbot'), 'listed tags on github');
   assert.ok(log.calledWith('No tag found for 123456'));
 


### PR DESCRIPTION
This PR adjusts the process that builds binaries for new ecs-watchbot releases.

- Adds a 2nd CodeBuild project to the CodePipeline. This project runs on an Alpine container which allows it to produce a functioning Alpine binary. The Alpine build only makes the one binary, the other three builds (linux, windows, macos) are still performed as they were before on amazon linux. This change fixes #327.

- Removes the CodePipeline dependency on https://github.com/rclark/code-pipeline-helper, opting instead to use [dynamic references to secrets stored in secrets manager](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager) to authorize AWS access to this GitHub repository.

cc @shwetha-mc @hcourt 