### PR TITLE
Switch from Travis to CodeBuild-based CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-- 10
-- 12
-services:
-- docker

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,9 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 10
+  build:
+    commands:
+      - docker build -q -t ecs-watchbot -f test/Dockerfile ./ && docker run -t ecs-watchbot npm run test-container

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,6 +4,9 @@ phases:
   install:
     runtime-versions:
       nodejs: 10
+  pre_build:
+    commands:
+      docker build -q -t ecs-watchbot -f test/Dockerfile ./
   build:
     commands:
-      - docker build -q -t ecs-watchbot -f test/Dockerfile ./ && docker run -t ecs-watchbot npm run test-container
+      - docker run -t ecs-watchbot npm run test-container


### PR DESCRIPTION
This PR introduces a buildspec.yml file to configure a CodeBuild-based CI system and removes the .travis.yml file. The CloudFormation resources for the CodeBuild CI are in a separate private repo. 