### PR TITLE
Include cwlogs and cli-spinner as dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,8 +1375,7 @@
     "cli-spinner": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.10.tgz",
-      "integrity": "sha512-U0sSQ+JJvSLi1pAYuJykwiA8Dsr15uHEy85iCJ6A+0DjVxivr3d+N2Wjvodeg89uP5K6TswFkKBfAD7B3YSn/Q==",
-      "dev": true
+      "integrity": "sha512-U0sSQ+JJvSLi1pAYuJykwiA8Dsr15uHEy85iCJ6A+0DjVxivr3d+N2Wjvodeg89uP5K6TswFkKBfAD7B3YSn/Q=="
     },
     "cli-width": {
       "version": "2.2.0",
@@ -1574,7 +1573,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cwlogs/-/cwlogs-1.0.3.tgz",
       "integrity": "sha1-Pz/roei6uvyZ1eAfsGKn4rxLJns=",
-      "dev": true,
       "requires": {
         "aws-sdk": "^2.3.17",
         "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
   "devDependencies": {
     "@mapbox/eslint-config-mapbox": "^2.0.1",
     "@mapbox/mock-aws-sdk-js": "^1.0.0",
-    "cli-spinner": "^0.2.10",
-    "cwlogs": "^1.0.3",
     "eslint": "^6.7.2",
     "eslint-plugin-node": "^10.0.0",
     "fake-env": "^1.0.0",
@@ -52,6 +50,8 @@
     "@mapbox/watchbot-progress": "^1.1.6",
     "aws-sdk": "^2.587.0",
     "binary-split": "^1.0.5",
+    "cli-spinner": "^0.2.10",
+    "cwlogs": "^1.0.3",
     "fs-extra": "^8.1.0",
     "inquirer": "^7.0.0",
     "p-queue": "^6.2.1",


### PR DESCRIPTION
For https://github.com/mapbox/ecs-watchbot/issues/335 and https://github.com/mapbox/ecs-watchbot/issues/274.

Adds cwlogs and cli-spinner as full dependencies, since they are used in the CLI.

cc/ @mapbox/developer-tools 