### PR TITLE
Handle python's 120 exit code

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 4.20.3
+
+- Treat a rare python exit code of 120 as a special case of exit code 3 (#340).
+
 ### 4.20.2
 
 - Using InChina instead of NotInChina Cloudformation condition: https://github.com/mapbox/ecs-watchbot/pull/329

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -99,6 +99,9 @@ class Worker {
       if (results.code === 0) return await this.success(results);
       if (results.code === 3) return await this.ignore(results);
       if (results.code === 4) return await this.noop(results);
+      // Rarely, python may set an exit code of 120 during its cleanup phase.
+      // We should not retry in this case.
+      if (results.code === 120) return await this.ignore(results);
       return await this.fail(results);
     } catch (err) {
       clearInterval(heartbeatTimeout);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -341,7 +341,7 @@ test('[worker] waitFor, exit 120', async (assert) => {
   logger.log.restore();
   logger.stream.restore();
   const message = sinon.createStubInstance(Message);
-  message.env = { Message: 'forty bananas', SentTimestamp: '2020-11-03T21:57:55.000Z' };
+  message.env = { Message: 'forty bananas', SentTimestamp: '2019-02-09T21:57:55.000Z' };
   const options = { command: 'exit 120', volumes: ['/tmp'] };
   const worker = new Worker(message, options);
 


### PR DESCRIPTION
See https://docs.python.org/3/library/sys.html#sys.exit. 120 is the python interpreter's only special code.

This works around issue #339. There's a deeper problem to be solved, but even so this is a useful patch. We never want to retry in the case that the worker gets a 120 exit code from python.