### PR TITLE
Apply prefix to ClusterArn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .nyc_output/
 coverage/
 vendor/
+node_modules

--- a/lib/template.js
+++ b/lib/template.js
@@ -949,11 +949,11 @@ module.exports = (options = {}) => {
     }
   };
 
-  const outputs = {
-    ClusterArn: {
-      Description: 'Service cluster ARN',
-      Value: options.cluster
-    }
+  const outputs = {};
+
+  outputs[prefixed('ClusterArn')] = {
+    Description: 'Service cluster ARN',
+    Value: options.cluster
   };
 
   outputs[prefixed('DeadLetterQueueUrl')] = {

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -64,7 +64,7 @@ Object {
     "EcsWatchbotVersion": "4.20.2",
   },
   "Outputs": Object {
-    "ClusterArn": Object {
+    "SoupClusterArn": Object {
       "Description": "Service cluster ARN",
       "Value": "processing",
     },
@@ -1440,7 +1440,7 @@ Object {
     "EcsWatchbotVersion": "4.20.2",
   },
   "Outputs": Object {
-    "ClusterArn": Object {
+    "SoupClusterArn": Object {
       "Description": "Service cluster ARN",
       "Value": "processing",
     },
@@ -2814,7 +2814,7 @@ Object {
     "EcsWatchbotVersion": "4.20.2",
   },
   "Outputs": Object {
-    "ClusterArn": Object {
+    "SoupClusterArn": Object {
       "Description": "Service cluster ARN",
       "Value": "processing",
     },
@@ -4188,7 +4188,7 @@ Object {
     "EcsWatchbotVersion": "4.20.2",
   },
   "Outputs": Object {
-    "ClusterArn": Object {
+    "SoupClusterArn": Object {
       "Description": "Service cluster ARN",
       "Value": "processing",
     },
@@ -5562,7 +5562,7 @@ Object {
     "EcsWatchbotVersion": "4.20.2",
   },
   "Outputs": Object {
-    "ClusterArn": Object {
+    "WatchbotClusterArn": Object {
       "Description": "Service cluster ARN",
       "Value": "processing",
     },
@@ -6798,7 +6798,7 @@ Object {
     "EcsWatchbotVersion": "4.20.2",
   },
   "Outputs": Object {
-    "ClusterArn": Object {
+    "WatchbotClusterArn": Object {
       "Description": "Service cluster ARN",
       "Value": "processing",
     },
@@ -7976,7 +7976,7 @@ Object {
     "EcsWatchbotVersion": "4.20.2",
   },
   "Outputs": Object {
-    "ClusterArn": Object {
+    "WatchbotClusterArn": Object {
       "Description": "Service cluster ARN",
       "Value": "processing",
     },


### PR DESCRIPTION
Use the specified `prefix` parameter when creating the ClusterArn outputs.

This is a breaking change for any consumer using the current ClusterArn output key. The previous behavior always had a `ClusterArn` output key, and the template would fail to build with multiple distinct clusters defined. The new behavior is:
* If no prefix is specified, the default output key is `WatchbotClusterArn`
* If prefixes are specified, an output key is created for each prefix in the pattern `{prefix}ClusterArn`

Also, add node-modules to .gitignore.

Fixes #341 