### PR TITLE
Add PropgateTags to service

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 
 ### 5.0.0
 
--  Sets `PropagateTags` to `TASK_DEFINITION` on the ECS Service. If you are on the old ARN format currently this will move you to the new ARN format by replacing your current service with a new service. This replacement is safe as AWS directs traffic to the new service before taking down the old one. Details on the new ARN format are below.
+-  Sets `PropagateTags` to `TASK_DEFINITION` on the ECS Service. If you are on the old ARN and the AWS account you are in has opted into the new format this version move you to the new ARN format by replacing your current service with a new one.
 
 **ECS Service**
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+
+### 5.0.0
+
+-  Sets `PropagateTags` to `TASK_DEFINITION` on the ECS Service. If you are on the old ARN format currently this will move you to the new ARN format by replacing your current service with a new service. This replacement is safe as AWS directs traffic to the new service before taking down the old one. Details on the new ARN format are below.
+
+**ECS Service**
+
+- Old: arn:aws:ecs:region:account-id:service/service-name
+- New: arn:aws:ecs:region:account-id:service/cluster-name/service-name
+
+**ECS Task**
+
+- Old: arn:aws:ecs:region:account-id:task/task-id
+- New: arn:aws:ecs:region:account-id:task/cluster-name/task-id
+
 ### 4.20.2
 
 - Using InChina instead of NotInChina Cloudformation condition: https://github.com/mapbox/ecs-watchbot/pull/329

--- a/lib/template.js
+++ b/lib/template.js
@@ -491,7 +491,8 @@ module.exports = (options = {}) => {
     Properties: {
       Cluster: options.cluster,
       DesiredCount: options.minSize,
-      TaskDefinition: cf.ref(prefixed('Task'))
+      TaskDefinition: cf.ref(prefixed('Task')),
+      PropagateTags: 'TASK_DEFINITION'
     }
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "4.20.2",
+  "version": "5.0.0-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "5.0.0-beta1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "4.20.2",
+  "version": "5.0.0-beta1",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "5.0.0-beta1",
+  "version": "5.0.0",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -61,7 +61,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.2",
+    "EcsWatchbotVersion": "5.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -99,7 +99,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -597,7 +597,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1312,7 +1312,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1438,7 +1438,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.2",
+    "EcsWatchbotVersion": "5.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -1476,7 +1476,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1974,7 +1974,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2687,7 +2687,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2813,7 +2813,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.2",
+    "EcsWatchbotVersion": "5.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -2851,7 +2851,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3349,7 +3349,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4062,7 +4062,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4188,7 +4188,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.2",
+    "EcsWatchbotVersion": "5.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -4226,7 +4226,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4724,7 +4724,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5437,7 +5437,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5563,7 +5563,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.2",
+    "EcsWatchbotVersion": "5.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -5601,7 +5601,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6025,7 +6025,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6674,7 +6674,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6800,7 +6800,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.2",
+    "EcsWatchbotVersion": "5.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -6838,7 +6838,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -7229,7 +7229,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -7853,7 +7853,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -7979,7 +7979,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "4.20.2",
+    "EcsWatchbotVersion": "5.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -8017,7 +8017,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -8408,7 +8408,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -9032,7 +9032,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v4.20.2/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v5.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -1001,6 +1001,7 @@ Object {
       "Properties": Object {
         "Cluster": "processing",
         "DesiredCount": 0,
+        "PropagateTags": "TASK_DEFINITION",
         "TaskDefinition": Object {
           "Ref": "SoupTask",
         },
@@ -2377,6 +2378,7 @@ Object {
       "Properties": Object {
         "Cluster": "processing",
         "DesiredCount": 0,
+        "PropagateTags": "TASK_DEFINITION",
         "TaskDefinition": Object {
           "Ref": "SoupTask",
         },
@@ -3751,6 +3753,7 @@ Object {
       "Properties": Object {
         "Cluster": "processing",
         "DesiredCount": 0,
+        "PropagateTags": "TASK_DEFINITION",
         "TaskDefinition": Object {
           "Ref": "SoupTask",
         },
@@ -5125,6 +5128,7 @@ Object {
       "Properties": Object {
         "Cluster": "processing",
         "DesiredCount": 0,
+        "PropagateTags": "TASK_DEFINITION",
         "TaskDefinition": Object {
           "Ref": "SoupTask",
         },
@@ -6403,6 +6407,7 @@ Object {
       "Properties": Object {
         "Cluster": "processing",
         "DesiredCount": 0,
+        "PropagateTags": "TASK_DEFINITION",
         "TaskDefinition": Object {
           "Ref": "WatchbotTask",
         },
@@ -7599,6 +7604,7 @@ Object {
       "Properties": Object {
         "Cluster": "processing",
         "DesiredCount": 0,
+        "PropagateTags": "TASK_DEFINITION",
         "TaskDefinition": Object {
           "Ref": "WatchbotTask",
         },
@@ -8777,6 +8783,7 @@ Object {
       "Properties": Object {
         "Cluster": "processing",
         "DesiredCount": 0,
+        "PropagateTags": "TASK_DEFINITION",
         "TaskDefinition": Object {
           "Ref": "WatchbotTask",
         },


### PR DESCRIPTION
This PR adds the PropagateTags property to the ECS Service resource. I have set this to TASK_DEFINITION to give the most flexibility to cost allocation just in case different task definitions in the same service are ever tagged differently.

This PR should be thought of as a breaking change by the user as it will cause their Task and Service to opt into the new ARN format. This will only be a problem if the user has these ARNs hard coded in some way.