### PR TITLE
Note that Subject and Message are parsed

### DIFF
--- a/docs/worker-runtime-details.md
+++ b/docs/worker-runtime-details.md
@@ -4,8 +4,8 @@ In addition to any environment variables pre-configured for your worker via `wat
 
 Name | Description
 --- | ---
-Subject | the message's subject
-Message | the message's body
+Subject | the message's subject, parsed by `JSON.parse`
+Message | the message's body, parsed by `JSON.parse`
 MessageId | the message's ID defined by SQS
 SentTimestamp | the time the message was sent
 ApproximateFirstReceiveTimestamp | the time the message was first attempted


### PR DESCRIPTION
The fact that the Subject and Message are already parsed in the worker's `process.env` caught me a bit off guard today, since generally `process.env` values are strings that need to be coerced into other types. It would be nice to indicate in the docs that this is not the case for these values in the worker's env.