### PR TITLE
Remove DesiredCount from Service definition

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -401,7 +401,6 @@ module.exports = (options = {}) => {
     Type: 'AWS::ECS::Service',
     Properties: {
       Cluster: options.cluster,
-      DesiredCount: options.minSize,
       TaskDefinition: cf.ref(prefixed('Task')),
       PropagateTags: 'TASK_DEFINITION',
       NetworkConfiguration: cf.if(

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -1042,7 +1042,6 @@ Object {
           ],
         },
         "Cluster": "processing",
-        "DesiredCount": 0,
         "LaunchType": Object {
           "Fn::If": Array [
             "SoupCapacityIsFargate",
@@ -2560,7 +2559,6 @@ Object {
           ],
         },
         "Cluster": "processing",
-        "DesiredCount": 0,
         "LaunchType": Object {
           "Fn::If": Array [
             "SoupCapacityIsFargate",
@@ -4074,7 +4072,6 @@ Object {
           ],
         },
         "Cluster": "processing",
-        "DesiredCount": 0,
         "LaunchType": Object {
           "Fn::If": Array [
             "SoupCapacityIsFargate",
@@ -5600,7 +5597,6 @@ Object {
           ],
         },
         "Cluster": "processing",
-        "DesiredCount": 0,
         "LaunchType": Object {
           "Fn::If": Array [
             "SoupCapacityIsFargate",
@@ -7030,7 +7026,6 @@ Object {
           ],
         },
         "Cluster": "processing",
-        "DesiredCount": 0,
         "LaunchType": Object {
           "Fn::If": Array [
             "WatchbotCapacityIsFargate",
@@ -8522,7 +8517,6 @@ Object {
           ],
         },
         "Cluster": "processing",
-        "DesiredCount": 0,
         "LaunchType": Object {
           "Fn::If": Array [
             "WatchbotCapacityIsFargate",
@@ -9872,7 +9866,6 @@ Object {
           ],
         },
         "Cluster": "processing",
-        "DesiredCount": 0,
         "LaunchType": Object {
           "Fn::If": Array [
             "WatchbotCapacityIsFargate",


### PR DESCRIPTION
Closes #349
Closes #273

Removes `DesiredCount` so that a running Service will not be scaled down by deploys.