### PR TITLE
Fix fetching of recent dead-letter message logs; Small refactor of dead-letter command choices logic

### DIFF
--- a/bin/dead-letter.js
+++ b/bin/dead-letter.js
@@ -351,7 +351,7 @@ async function getLogs(sqs, queue, message) {
     fetchLogs(queue.logs, message.id, (err, data) => {
       if (err) return reject(err);
 
-      const re = new RegExp(`\\[watchbot\\] \\[(.*?)\\] {"subject":".*?","message":"${message.message}"`);
+      const re = new RegExp(`\\[worker\\] \\[(.*?)\\] {"subject":".*?","message":"${message.message}"`);
       const line = data.split('\n').find((line) => re.test(line));
       if (!line) return resolve('Could not find any matching logs\n');
 

--- a/bin/dead-letter.js
+++ b/bin/dead-letter.js
@@ -348,7 +348,7 @@ async function getLogs(sqs, queue, message) {
   spinner.start();
 
   return new Promise((resolve, reject) => {
-    fetchLogs(queue.logs, message.message, (err, data) => {
+    fetchLogs(queue.logs, message.id, (err, data) => {
       if (err) return reject(err);
 
       const re = new RegExp(`\\[watchbot\\] \\[(.*?)\\] {"subject":".*?","message":"${message.message}"`);

--- a/bin/dead-letter.js
+++ b/bin/dead-letter.js
@@ -349,17 +349,8 @@ async function getLogs(sqs, queue, message) {
 
   return new Promise((resolve, reject) => {
     fetchLogs(queue.logs, message.id, (err, data) => {
-      if (err) return reject(err);
-
-      const re = new RegExp(`\\[worker\\] \\[(.*?)\\] {"subject":".*?","message":"${message.message}"`);
-      const line = data.split('\n').find((line) => re.test(line));
-      if (!line) return resolve('Could not find any matching logs\n');
-
-      const id = line.match(re)[1];
-      fetchLogs(queue.logs, id, (err, data) => {
-        if (err) return reject(err);
-        resolve(data);
-      });
+      if (err) { return reject(err); }
+      resolve(data);
     });
   }).then(async (data) => {
     spinner.stop(true);

--- a/bin/dead-letter.js
+++ b/bin/dead-letter.js
@@ -102,21 +102,15 @@ async function triageSelection(queue) {
     name: 'action',
     message: 'Would you like to:',
     choices: [
-      'Triage dead messages individually?',
-      'Print out all dead messages?',
-      'Return all dead messages to the work queue?',
-      'Purge the dead letter queue?'
+      { name: 'Triage dead messages individually?', value: 'triage' },
+      { name: 'Print out all dead messages?', value: 'writeOut' },
+      { name: 'Return all dead messages to the work queue?', value: 'replay' },
+      { name: 'Purge the dead letter queue?', value: 'purge' }
     ]
   });
 
-  const mapping = {
-    'Purge the dead letter queue?': 'purge',
-    'Return all dead messages to the work queue?': 'replay',
-    'Triage dead messages individually?': 'triage',
-    'Print out all dead messages?': 'writeOut'
-  };
 
-  return { queue, action: mapping[answers.action] };
+  return { queue, action: answers.action };
 }
 
 async function purge(sqs, queue) {
@@ -133,7 +127,7 @@ async function purge(sqs, queue) {
 }
 
 async function writeOut(sqs, queue) {
-  const reciever = receiveAll(sqs, queue.deadLetter);
+  const receiver = receiveAll(sqs, queue.deadLetter);
 
   const stringifier = new stream.Transform({
     objectMode: true,
@@ -156,7 +150,7 @@ async function writeOut(sqs, queue) {
       }
     };
 
-    reciever
+    receiver
       .pipe(stringifier)
       .on('end', done)
       .pipe(process.stdout);
@@ -176,7 +170,7 @@ async function replay(sqs, queue) {
   spinner.setSpinnerString('⠄⠆⠇⠋⠙⠸⠰⠠⠰⠸⠙⠋⠇⠆');
   spinner.start();
 
-  const reciever = receiveAll(sqs, queue.deadLetter);
+  const receiver = receiveAll(sqs, queue.deadLetter);
 
   const replayer = new stream.Writable({
     objectMode: true,
@@ -192,7 +186,7 @@ async function replay(sqs, queue) {
   });
 
   await new Promise((resolve, reject) => {
-    reciever
+    receiver
       .on('error', reject)
       .pipe(replayer)
       .on('error', reject)
@@ -217,22 +211,15 @@ async function triagePrompts(sqs, queue, message) {
     name: 'action',
     message: 'Would you like to:',
     choices: [
-      'Return this message to the work queue?',
-      'Return this message to the dead letter queue?',
-      'Delete this message entirely?',
-      'View this message\'s recent logs?',
-      'Stop individual triage?'
+      { name: 'Return this message to the work queue?', value: 'replayOne' },
+      { name: 'Return this message to the dead letter queue?', value: 'returnOne' },
+      { name: 'Delete this message entirely?', value: 'deleteOne' },
+      { name: 'View this message\'s recent logs?', value: 'logs' },
+      { name: 'Stop individual triage?', value: 'stop' }
     ]
   });
-  const mapping = {
-    'Return this message to the work queue?': 'replayOne',
-    'Return this message to the dead letter queue?': 'returnOne',
-    'View this message\'s recent logs?': 'logs',
-    'Delete this message entirely?': 'deleteOne',
-    'Stop individual triage?': 'stop'
-  };
 
-  const choice = mapping[answers.action];
+  const choice = answers.action;
   const queueUrl = choice === 'replayOne' ? queue.work : queue.deadLetter;
 
   if (choice === 'logs') {

--- a/test/bin.dead-letter.test.js
+++ b/test/bin.dead-letter.test.js
@@ -79,8 +79,7 @@ test('[dead-letter] individual message triage', async (assert) => {
     read: function() {
       if (count === 0) {
         this.push([
-          '[Sun, 12 Feb 2017 00:24:41 GMT] [worker] [a406f47b-a0f2-49a6-a159-b0f8578104bf] {"subject":"bozo","message":"message-4","receives":"1"}',
-          '[Sun, 12 Feb 2017 00:24:42 GMT] [worker] [436d13dc-a666-44fd-a2df-70f1f4b3f107] {"subject":"bozo","message":"message-5","receives":"1"}'
+          '[Sun, 12 Feb 2017 00:24:41 GMT] [watcher] [id-4] {"subject":"bozo","message":"message-4","receives":"1"}'
         ].join('\n'));
         count++;
       }
@@ -119,9 +118,8 @@ test('[dead-letter] individual message triage', async (assert) => {
       VisibilityTimeout: 0
     }), 'returns the fourth message to the dead letter queue');
 
-    assert.equal(fetch.callCount, 2, 'two calls to fetch recent logs');
-    assert.equals(fetch.args[0][0].pattern, 'id-4', 'one fetch call based on message itself');
-    assert.equals(fetch.args[1][0].pattern, 'a406f47b-a0f2-49a6-a159-b0f8578104bf', 'one fetch call based on message itself');
+    assert.equal(fetch.callCount, 1, 'one calls to fetch recent logs');
+    assert.equals(fetch.args[0][0].pattern, 'id-4', 'one fetch call based on message id');
 
   } catch (err) {
     assert.ifError(err);

--- a/test/bin.dead-letter.test.js
+++ b/test/bin.dead-letter.test.js
@@ -120,7 +120,7 @@ test('[dead-letter] individual message triage', async (assert) => {
     }), 'returns the fourth message to the dead letter queue');
 
     assert.equal(fetch.callCount, 2, 'two calls to fetch recent logs');
-    assert.equals(fetch.args[0][0].pattern, 'message-4', 'one fetch call based on message itself');
+    assert.equals(fetch.args[0][0].pattern, 'id-4', 'one fetch call based on message itself');
     assert.equals(fetch.args[1][0].pattern, 'a406f47b-a0f2-49a6-a159-b0f8578104bf', 'one fetch call based on message itself');
 
   } catch (err) {

--- a/test/bin.dead-letter.test.js
+++ b/test/bin.dead-letter.test.js
@@ -79,8 +79,8 @@ test('[dead-letter] individual message triage', async (assert) => {
     read: function() {
       if (count === 0) {
         this.push([
-          '[Sun, 12 Feb 2017 00:24:41 GMT] [watchbot] [a406f47b-a0f2-49a6-a159-b0f8578104bf] {"subject":"bozo","message":"message-4","receives":"1"}',
-          '[Sun, 12 Feb 2017 00:24:42 GMT] [watchbot] [436d13dc-a666-44fd-a2df-70f1f4b3f107] {"subject":"bozo","message":"message-5","receives":"1"}'
+          '[Sun, 12 Feb 2017 00:24:41 GMT] [worker] [a406f47b-a0f2-49a6-a159-b0f8578104bf] {"subject":"bozo","message":"message-4","receives":"1"}',
+          '[Sun, 12 Feb 2017 00:24:42 GMT] [worker] [436d13dc-a666-44fd-a2df-70f1f4b3f107] {"subject":"bozo","message":"message-5","receives":"1"}'
         ].join('\n'));
         count++;
       }


### PR DESCRIPTION
- Fixes #350 by sending `message.id` instead of `message.body` to inner `fetchLogs` helper. The helper's parameter names indicated that this was the intent - https://github.com/mapbox/ecs-watchbot/pull/354/commits/fa89915b3444ee75b3b8b6bc11566bc9a831337f has the fix
- Reduces duplication of long question strings for matching an inquirer question choice to its "action" by using inquirer's `[{ name, value}]` format for its `choices` parameter. Also fixes some small typos.

