### PR TITLE
Node 12 support

### DIFF
--- a/bin/watchbot-binary-generator.js
+++ b/bin/watchbot-binary-generator.js
@@ -41,14 +41,14 @@ const uploadBundle = async (buildTarget) => {
   const Bucket = 'watchbot-binaries';
 
   let targets = [
-    { prefix: 'linux', target: 'node10-linux', pkg: 'watchbot-linux' },
-    { prefix: 'macosx', target: 'node10-macos', pkg: 'watchbot-macos' },
-    { prefix: 'windows', target: 'node10-win', pkg: 'watchbot-win.exe' }
+    { prefix: 'linux', target: 'node12-linux', pkg: 'watchbot-linux' },
+    { prefix: 'macosx', target: 'node12-macos', pkg: 'watchbot-macos' },
+    { prefix: 'windows', target: 'node12-win', pkg: 'watchbot-win.exe' }
   ];
 
   if (buildTarget === 'alpine') {
     targets = [
-      { prefix: 'alpine', target: 'node10-alpine', pkg: 'watchbot' }
+      { prefix: 'alpine', target: 'node12-alpine', pkg: 'watchbot' }
     ];
   }
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 10
+      nodejs: 12
   pre_build:
     commands:
       - aws secretsmanager get-secret-value --secret-id ${DOCKER_HUB_TOKEN_KEY} --region us-east-1 --query SecretString --output text | docker login --username mapboxmachinereadonly --password-stdin

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -87,7 +87,7 @@ const Resources = {
           phases:
             install:
               runtime-versions:
-                nodejs: 10
+                nodejs: 12
               commands:
                 - npm install -g npm@6.13.4
                 - npm ci --production
@@ -109,7 +109,7 @@ const Resources = {
       Environment: {
         Type: 'LINUX_CONTAINER',
         ComputeType: 'BUILD_GENERAL1_SMALL',
-        Image: 'node:10-alpine'
+        Image: 'node:12-alpine'
       },
       ServiceRole: cf.getAtt('BundlerRole', 'Arn'),
       Source: {
@@ -119,7 +119,7 @@ const Resources = {
           phases:
             install:
               runtime-versions:
-                nodejs: 10
+                nodejs: 12
               commands:
                 - apk add git
                 - npm install -g npm@6.13.4

--- a/lib/template.js
+++ b/lib/template.js
@@ -757,7 +757,7 @@ module.exports = (options = {}) => {
           }
           `)
       },
-      Runtime: 'nodejs10.x'
+      Runtime: 'nodejs12.x'
     }
   };
 
@@ -805,7 +805,7 @@ module.exports = (options = {}) => {
           QueueName: cf.getAtt(prefixed('Queue'), 'QueueName')
         })
       },
-      Runtime: 'nodejs10.x'
+      Runtime: 'nodejs12.x'
     }
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "6.1.1",
+  "version": "7.0.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "6.1.0",
+      "version": "7.0.0-0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/cloudfriend": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "6.1.1",
+  "version": "7.0.0-0",
   "description": "",
   "main": "index.js",
   "engines": {
     "node": ">=12"
   },
   "bin": {
-    "watchbot": "./bin/watchbot.js",
+    "watchbot": "bin/watchbot.js",
     "watchbot-progress": "bin/watchbot-progress.sh",
-    "watchbot-dead-letter": "./bin/dead-letter.js"
+    "watchbot-dead-letter": "bin/dead-letter.js"
   },
   "scripts": {
     "pretest": "npm run lint && npm run validate-templates",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "bin": {
     "watchbot": "./bin/watchbot.js",

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:12
 
 COPY ./package.json ./package.json
 COPY ./package-lock.json ./package-lock.json

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -89,7 +89,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.1",
+    "EcsWatchbotVersion": "7.0.0-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -127,7 +127,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -625,7 +625,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1452,7 +1452,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1606,7 +1606,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.1",
+    "EcsWatchbotVersion": "7.0.0-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -1644,7 +1644,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2142,7 +2142,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2965,7 +2965,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3119,7 +3119,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.1",
+    "EcsWatchbotVersion": "7.0.0-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -3157,7 +3157,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3655,7 +3655,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4490,7 +4490,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4644,7 +4644,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.1",
+    "EcsWatchbotVersion": "7.0.0-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -4682,7 +4682,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5180,7 +5180,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6015,7 +6015,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6169,7 +6169,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.1",
+    "EcsWatchbotVersion": "7.0.0-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -6207,7 +6207,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6631,7 +6631,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -7422,7 +7422,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -7700,7 +7700,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.1",
+    "EcsWatchbotVersion": "7.0.0-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -7738,7 +7738,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -8129,7 +8129,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -8895,7 +8895,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -9049,7 +9049,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.1",
+    "EcsWatchbotVersion": "7.0.0-0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -9087,7 +9087,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -9478,7 +9478,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -10244,7 +10244,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0-0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -89,7 +89,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.0",
+    "EcsWatchbotVersion": "6.1.1",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -127,7 +127,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -625,7 +625,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -949,7 +949,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -1385,7 +1385,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -1452,7 +1452,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1606,7 +1606,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.0",
+    "EcsWatchbotVersion": "6.1.1",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -1644,7 +1644,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2142,7 +2142,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2466,7 +2466,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -2898,7 +2898,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -2965,7 +2965,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3119,7 +3119,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.0",
+    "EcsWatchbotVersion": "6.1.1",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -3157,7 +3157,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3655,7 +3655,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3979,7 +3979,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -4423,7 +4423,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -4490,7 +4490,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4644,7 +4644,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.0",
+    "EcsWatchbotVersion": "6.1.1",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -4682,7 +4682,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5180,7 +5180,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5504,7 +5504,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -5948,7 +5948,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -6015,7 +6015,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6169,7 +6169,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.0",
+    "EcsWatchbotVersion": "6.1.1",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -6207,7 +6207,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6631,7 +6631,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6933,7 +6933,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -7355,7 +7355,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -7422,7 +7422,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -7700,7 +7700,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.0",
+    "EcsWatchbotVersion": "6.1.1",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -7738,7 +7738,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -8129,7 +8129,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -8424,7 +8424,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -8828,7 +8828,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -8895,7 +8895,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -9049,7 +9049,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "6.1.0",
+    "EcsWatchbotVersion": "6.1.1",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -9087,7 +9087,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -9478,7 +9478,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -9773,7 +9773,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -10177,7 +10177,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs12.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -10244,7 +10244,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v6.1.1/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",

--- a/test/bin.watchbot-binary-generator.test.js
+++ b/test/bin.watchbot-binary-generator.test.js
@@ -49,10 +49,10 @@ test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major
 
   await wbg.uploadBundle();
 
-  assert.ok(execStub.calledWith('npm ci --production'), 'reinstalled npm modules');
-  assert.ok(execStub.calledWith('npm install -g pkg'), 'globally installed pkg');
-  assert.ok(execStub.calledWith('pkg --targets node10-linux,node10-macos,node10-win .'), 'ran expected pkg command');
-  assert.ok(execStub.calledWith('git ls-remote --tags https://github.com/mapbox/ecs-watchbot'), 'listed tags on github');
+  assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
+  assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
+  assert.equals(execStub.args[2][0], 'pkg --targets node12-linux,node12-macos,node12-win .', 'ran expected pkg command');
+  assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
 
   assert.ok(s3Stub.calledWith({
     Bucket: 'watchbot-binaries',
@@ -98,10 +98,10 @@ test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major
 
   await wbg.uploadBundle('alpine');
 
-  assert.ok(execStub.calledWith('npm ci --production'), 'reinstalled npm modules');
-  assert.ok(execStub.calledWith('npm install -g pkg'), 'globally installed pkg');
-  assert.ok(execStub.calledWith('pkg --targets node10-alpine .'), 'ran expected pkg command');
-  assert.ok(execStub.calledWith('git ls-remote --tags https://github.com/mapbox/ecs-watchbot'), 'listed tags on github');
+  assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
+  assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
+  assert.equals(execStub.args[2][0], 'pkg --targets node12-alpine .', 'ran expected pkg command');
+  assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
 
   assert.ok(s3Stub.calledWith({
     Bucket: 'watchbot-binaries',
@@ -133,10 +133,10 @@ test('uploadBundle: tag found (Tag created manually) for all except alpine', asy
 
   await wbg.uploadBundle();
 
-  assert.ok(execStub.calledWith('npm ci --production'), 'reinstalled npm modules');
-  assert.ok(execStub.calledWith('npm install -g pkg'), 'globally installed pkg');
-  assert.ok(execStub.calledWith('pkg --targets node10-linux,node10-macos,node10-win .'), 'ran expected pkg command');
-  assert.ok(execStub.calledWith('git ls-remote --tags https://github.com/mapbox/ecs-watchbot'), 'listed tags on github');
+  assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
+  assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
+  assert.equals(execStub.args[2][0], 'pkg --targets node12-linux,node12-macos,node12-win .', 'ran expected pkg command');
+  assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
 
   assert.ok(s3Stub.calledWith({
     Bucket: 'watchbot-binaries',
@@ -181,10 +181,10 @@ test('uploadBundle: tag found (Tag created manually) for alpine', async (assert)
 
   await wbg.uploadBundle('alpine');
 
-  assert.ok(execStub.calledWith('npm ci --production'), 'reinstalled npm modules');
-  assert.ok(execStub.calledWith('npm install -g pkg'), 'globally installed pkg');
-  assert.ok(execStub.calledWith('pkg --targets node10-alpine .'), 'ran expected pkg command');
-  assert.ok(execStub.calledWith('git ls-remote --tags https://github.com/mapbox/ecs-watchbot'), 'listed tags on github');
+  assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
+  assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
+  assert.equals(execStub.args[2][0], 'pkg --targets node12-alpine .', 'ran expected pkg command');
+  assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
 
   assert.ok(s3Stub.calledWith({
     Bucket: 'watchbot-binaries',
@@ -212,10 +212,10 @@ test('uploadBundle: tag not found for all except alpine', async (assert) => {
 
   await wbg.uploadBundle();
 
-  assert.ok(execStub.calledWith('npm ci --production'), 'reinstalled npm modules');
-  assert.ok(execStub.calledWith('npm install -g pkg'), 'globally installed pkg');
-  assert.ok(execStub.calledWith('pkg --targets node10-linux,node10-macos,node10-win .'), 'ran expected pkg command');
-  assert.ok(execStub.calledWith('git ls-remote --tags https://github.com/mapbox/ecs-watchbot'), 'listed tags on github');
+  assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
+  assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
+  assert.equals(execStub.args[2][0], 'pkg --targets node12-linux,node12-macos,node12-win .', 'ran expected pkg command');
+  assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
   assert.ok(log.calledWith('No tag found for 123456'));
 
   log.restore();
@@ -235,10 +235,10 @@ test('uploadBundle: tag not found for alpine', async (assert) => {
 
   await wbg.uploadBundle('alpine');
 
-  assert.ok(execStub.calledWith('npm ci --production'), 'reinstalled npm modules');
-  assert.ok(execStub.calledWith('npm install -g pkg'), 'globally installed pkg');
-  assert.ok(execStub.calledWith('pkg --targets node10-alpine .'), 'ran expected pkg command');
-  assert.ok(execStub.calledWith('git ls-remote --tags https://github.com/mapbox/ecs-watchbot'), 'listed tags on github');
+  assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
+  assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
+  assert.equals(execStub.args[2][0], 'pkg --targets node12-alpine .', 'ran expected pkg command');
+  assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
   assert.ok(log.calledWith('No tag found for 123456'));
 
   log.restore();


### PR DESCRIPTION
Stacks created by ecs-watchbot are using Node 10, which is EOL April 30th.

This PR will upgrade ecs-watchbot Lambdas to use Node 12, and stop generation of Node 10 binaries in favor of Node 12.

cc/ @mapbox/data-platform for review, please