### PR TITLE
Use dockerhub credential for alpine binary builder

### DIFF
--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -59,6 +59,15 @@ const Resources = {
                   cf.sub('arn:${AWS::Partition}:s3:::watchbot-binaries'),
                   cf.sub('arn:${AWS::Partition}:s3:::watchbot-binaries/*')
                 ]
+              },
+              {
+                Effect: 'Allow',
+                Action: [
+                  'secretsmanager:GetSecretValue'
+                ],
+                Resource: [
+                  cf.arn('secretsmanager', 'secret:general/dockerhub/mapboxmachinereadonly/ecs-watchbot-ci/*')
+                ]
               }
             ]
           }
@@ -109,7 +118,12 @@ const Resources = {
       Environment: {
         Type: 'LINUX_CONTAINER',
         ComputeType: 'BUILD_GENERAL1_SMALL',
-        Image: 'node:12-alpine'
+        Image: 'node:12-alpine',
+        ImagePullCredentialsType: 'SERVICE_ROLE',
+        RegistryCredential: {
+          Credential: 'general/dockerhub/mapboxmachinereadonly/ecs-watchbot-ci/accesstoken',
+          CredentialProvider: 'SECRETS_MANAGER'
+        }
       },
       ServiceRole: cf.getAtt('BundlerRole', 'Arn'),
       Source: {


### PR DESCRIPTION
Make ecs-watchbot-generate-binaries use our dockerhub credential for the AlpineBundler CodeBuild project.  This PR doesn't also add the credential to the standard Bundler project because it uses a `codebuild` curated image, and AWS requires you use CodeBuild credentials for curated images.

Thanks to @rclark for pointing this out!

cc/ @mapbox/data-platform 