### PR TITLE
Use username/password formatted credentials for DockerHub

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,7 +6,7 @@ phases:
       nodejs: 12
   pre_build:
     commands:
-      - aws secretsmanager get-secret-value --secret-id ${DOCKER_HUB_TOKEN_KEY} --region us-east-1 --query SecretString --output text | docker login --username mapboxmachinereadonly --password-stdin
+      - docker login --username mapboxmachinereadonly --password ${DOCKER_HUB_TOKEN_KEY}
       - docker build -q -t ecs-watchbot -f test/Dockerfile ./
   build:
     commands:

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -121,7 +121,7 @@ const Resources = {
         Image: 'node:12-alpine',
         ImagePullCredentialsType: 'SERVICE_ROLE',
         RegistryCredential: {
-          Credential: 'general/dockerhub/mapboxmachinereadonly/ecs-watchbot-ci/accesstoken',
+          Credential: 'general/dockerhub/mapboxmachinereadonly/ecs-watchbot-ci/credentials',
           CredentialProvider: 'SECRETS_MANAGER'
         }
       },


### PR DESCRIPTION
The `accesstoken` secret, which is used by both codebuild-helper and the generate-binaries pipeline, is not in the [expected format](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-private-registry.html) used by the generate-binaries pipeline for the `RegistryCredential` attribute.  I created a similar secret that is in the expected format and stored it in `credentials`.

cc/ @mapbox/data-platform 