### PR TITLE
Add support for JSON structured logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .nyc_output/
 coverage/
 vendor/
+node_modules

--- a/bin/watchbot-binary-generator.js
+++ b/bin/watchbot-binary-generator.js
@@ -41,14 +41,14 @@ const uploadBundle = async (buildTarget) => {
   const Bucket = 'watchbot-binaries';
 
   let targets = [
-    { prefix: 'linux', target: 'node12-linux', pkg: 'watchbot-linux' },
-    { prefix: 'macosx', target: 'node12-macos', pkg: 'watchbot-macos' },
-    { prefix: 'windows', target: 'node12-win', pkg: 'watchbot-win.exe' }
+    { prefix: 'linux', target: 'node14-linux', pkg: 'watchbot-linux' },
+    { prefix: 'macosx', target: 'node14-macos', pkg: 'watchbot-macos' },
+    { prefix: 'windows', target: 'node14-win', pkg: 'watchbot-win.exe' }
   ];
 
   if (buildTarget === 'alpine') {
     targets = [
-      { prefix: 'alpine', target: 'node12-alpine', pkg: 'watchbot' }
+      { prefix: 'alpine', target: 'node14-alpine', pkg: 'watchbot' }
     ];
   }
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,12 +1,8 @@
 version: 0.2
 
 phases:
-  install:
-    runtime-versions:
-      nodejs: 12
   pre_build:
     commands:
-      - docker login --username mapboxmachinereadonly --password ${DOCKER_HUB_TOKEN_KEY}
       - docker build -q -t ecs-watchbot -f test/Dockerfile ./
   build:
     commands:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 8.0.0
+
+- Breaking change: use Node 14 for lambdas and binaries going forward
+
 ### 7.0.0
 
 - Breaking change: use Node 12 for lambdas and binaries going forward

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-### 8.0.0-rc.3
+### 8.0.0
 
 - Add support for JSON structured logging via the 'structuredLogging' boolean option (defaults to off)
 - Breaking change: use Node 14 for lambdas and binaries going forward

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
-### 8.0.0
+### 8.0.0-rc.3
 
+- Add support for JSON structured logging via the 'structuredLogging' boolean option (defaults to off)
 - Breaking change: use Node 14 for lambdas and binaries going forward
 
 ### 7.0.0

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -86,7 +86,7 @@ const Resources = {
       Environment: {
         Type: 'LINUX_CONTAINER',
         ComputeType: 'BUILD_GENERAL1_SMALL',
-        Image: 'aws/codebuild/amazonlinux2-x86_64-standard:2.0'
+        Image: 'aws/codebuild/standard:5.0'
       },
       ServiceRole: cf.getAtt('BundlerRole', 'Arn'),
       Source: {
@@ -96,9 +96,8 @@ const Resources = {
           phases:
             install:
               runtime-versions:
-                nodejs: 12
+                nodejs: 14
               commands:
-                - npm install -g npm@6.13.4
                 - npm ci --production
             build:
               commands:
@@ -118,12 +117,8 @@ const Resources = {
       Environment: {
         Type: 'LINUX_CONTAINER',
         ComputeType: 'BUILD_GENERAL1_SMALL',
-        Image: 'node:12-alpine',
-        ImagePullCredentialsType: 'SERVICE_ROLE',
-        RegistryCredential: {
-          Credential: 'general/dockerhub/mapboxmachinereadonly/ecs-watchbot-ci/credentials',
-          CredentialProvider: 'SECRETS_MANAGER'
-        }
+        Image: 'public.ecr.aws/docker/library/node:14-alpine',
+        ImagePullCredentialsType: 'CODEBUILD'
       },
       ServiceRole: cf.getAtt('BundlerRole', 'Arn'),
       Source: {
@@ -133,10 +128,9 @@ const Resources = {
           phases:
             install:
               runtime-versions:
-                nodejs: 12
+                nodejs: 14
               commands:
                 - apk add git
-                - npm install -g npm@6.13.4
                 - npm ci --production
             build:
               commands:

--- a/docs/building-a-template.md
+++ b/docs/building-a-template.md
@@ -98,6 +98,7 @@ When creating your watchbot stacks with the `watchbot.template()` method, you no
 **fifo** | Whether you want Watchbot's SQS queue to be first-in-first-out (FIFO). By default, Watchbot creates a standard SQS queue, in which the order of jobs is not guaranteed to match the order of messages. If your program requires more precise ordering and the limitations of a FIFO queue will be acceptable, set this option to `true`. Learn more in ["Using a FIFO queue"](./using-a-fifo-queue.md) | Boolean | No | `false`
 **placementConstraints** | ECS service [placement constraints](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-placementconstraint.html). This value is ignored for `capacity` values other than `'EC2'`. | Object[]/Ref | No | false
 **placementStrategies** | ECS service [placement strategies](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-placementstrategy.html). This value is ignored for `capacity` values other than `'EC2'`. | Object[]/Ref | No | false
+**structuredLogging** | Whether to emit logs in JSON format or not | Boolean | No | `false`
 
 ### writableFilesystem mode explained
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,17 +3,35 @@
 const stream = require('stream');
 const split = require('binary-split');
 const combiner = require('stream-combiner2');
+const os = require('os');
+
+// https://github.com/trentm/node-bunyan#core-fields
+// const TRACE = 10;
+// const DEBUG = 20;
+const INFO = 30;
+// const WARN = 40;
+const ERROR = 50;
+// const FATAL = 60;
 
 class Logger {
-  constructor(type, message) {
-    if (type !== 'watcher' && type !== 'worker')
-      throw new Error(`Invalid logger type: ${type}`);
+
+  constructor(options, message) {
+    this.structuredLogging = false;
+    if (typeof(options) === 'object') {
+      this.type = options.type;
+      this.structuredLogging = options.structuredLogging || false;
+    } else {
+      this.type = options;
+    }
+    if (this.type !== 'watcher' && this.type !== 'worker')
+      throw new Error(`Invalid logger type: ${this.type}`);
 
     if (message && !(message instanceof require('./message')))
       throw new Error('Invalid message');
 
-    this.type = type;
     this.message = message;
+    this.hostname = os.hostname();
+    this.pid = process.pid;
   }
 
   messageReceived() {
@@ -26,28 +44,65 @@ class Logger {
     );
   }
 
+
   workerSuccess(results) {
-    this.log(JSON.stringify(results));
+    if (this.structuredLogging) {
+      this.log(Object.assign({ level: INFO, worker_event: 'success' }, results));
+    } else {
+      this.log(JSON.stringify(results));
+    }
   }
 
   workerFailure(results) {
-    this.log(`[failure] ${JSON.stringify(results)}`);
+    if (this.structuredLogging) {
+      this.log(Object.assign({ level: INFO, worker_event: 'failure' }, results));
+    } else {
+      this.log(`[failure] ${JSON.stringify(results)}`);
+    }
   }
 
   workerError(err) {
-    this.log(`[error] [worker] ${err.message}`);
+    if (this.structuredLogging) {
+      this.log({ level: ERROR, worker_event: 'error', msg: err.message, err: err });
+    } else {
+      this.log(`[error] [worker] ${err.message}`);
+    }
   }
 
   queueError(err) {
-    this.log(`[error] [sqs] ${err.message}`);
+    if (this.structuredLogging) {
+      this.log({ level: ERROR, sqs_event: 'error', msg: err.message, err: err });
+    } else {
+      this.log(`[error] [sqs] ${err.message}`);
+    }
   }
 
   log(line) {
-    let leader = '';
-    leader += `[${new Date().toGMTString()}] `;
-    leader += `[${this.type}] `;
-    if (this.message) leader += `[${this.message.id}] `;
-    process.stdout.write(`${leader}${line}\n`);
+    if (this.structuredLogging) {
+      const minimum_structured_logline = { v: 0, level: INFO, name: this.type, hostname: this.hostname, pid: process.pid, time: new Date().toISOString() };
+      if (this.message) minimum_structured_logline.watchbot_sqs_message_id = this.message.id;
+      // If the line looks like JSON itself, then try to parse and merge it
+      if (typeof(line) === 'string' && line[0] === '{') {
+        try {
+          process.stdout.write(JSON.stringify(Object.assign(minimum_structured_logline, JSON.parse(line))));
+        } catch (e) {
+          // We failed to parse the read line as JSON, so we'll just treat it as a string
+          process.stdout.write(JSON.stringify(Object.assign(minimum_structured_logline, { msg: line })));
+        }
+      } else if (typeof(line) === 'string') {
+        // We failed to parse the read line as JSON, so we'll just treat it as a string
+        process.stdout.write(JSON.stringify(Object.assign(minimum_structured_logline, { msg: line })));
+      } else { // Assume it's an object, so merge it with the structured line
+        process.stdout.write(JSON.stringify(Object.assign(minimum_structured_logline, line)));
+      }
+    } else {
+      // Original-style logging format
+      let leader = '';
+      leader += `[${new Date().toGMTString()}] `;
+      leader += `[${this.type}] `;
+      if (this.message) leader += `[${this.message.id}] `;
+      process.stdout.write(`${leader}${line}\n`);
+    }
   }
 
   stream() {

--- a/lib/message.js
+++ b/lib/message.js
@@ -70,7 +70,7 @@ class Message {
       params: { QueueUrl: options.queueUrl }
     });
 
-    this.logger = Logger.create('watcher', this);
+    this.logger = Logger.create({ type: 'watcher', structuredLogging: options.structuredLogging }, this);
   }
 
   async retry() {

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -15,7 +15,7 @@ class Messages {
       params: { QueueUrl: options.queueUrl }
     });
 
-    this.logger = Logger.create('watcher');
+    this.logger = Logger.create({ type: 'watcher', structuredLogging: options.structuredLogging });
   }
 
   async waitFor(num = 1) {

--- a/lib/template.js
+++ b/lib/template.js
@@ -37,7 +37,8 @@ module.exports = (options = {}) => {
       deadletterAlarm: true,
       dashboard: true,
       fifo: false,
-      fargatePublicIp: 'DISABLED'
+      fargatePublicIp: 'DISABLED',
+      structuredLogging: false
     },
     options
   );
@@ -70,7 +71,8 @@ module.exports = (options = {}) => {
         { Name: 'writableFilesystem', Value: options.writableFilesystem },
         { Name: 'maxJobDuration', Value: options.maxJobDuration },
         { Name: 'Volumes', Value: mountPoints.map((m) => m.ContainerPath).join(',') },
-        { Name: 'Fifo', Value: options.fifo.toString() }
+        { Name: 'Fifo', Value: options.fifo.toString() },
+        { Name: 'structuredLogging', Value: options.structuredLogging.toString() }
       ]
     );
   };

--- a/lib/template.js
+++ b/lib/template.js
@@ -757,7 +757,7 @@ module.exports = (options = {}) => {
           }
           `)
       },
-      Runtime: 'nodejs12.x'
+      Runtime: 'nodejs14.x'
     }
   };
 
@@ -805,7 +805,7 @@ module.exports = (options = {}) => {
           QueueName: cf.getAtt(prefixed('Queue'), 'QueueName')
         })
       },
-      Runtime: 'nodejs12.x'
+      Runtime: 'nodejs14.x'
     }
   };
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -52,8 +52,8 @@ class Worker {
     this.volumes = options.volumes;
     this.maxJobDuration = options.maxJobDuration;
     this.message = message;
-    this.watcherLogger = Logger.create('watcher', message);
-    this.workerLogger = Logger.create('worker', message);
+    this.watcherLogger = Logger.create({ type: 'watcher', structuredLogging: options.structuredLogging }, message);
+    this.workerLogger = Logger.create({ type: 'worker', structuredLogging: options.structuredLogging }, message);
   }
 
   async success(results) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -30,9 +30,9 @@ const child = async (command, options, logger, maxJobDuration) =>
 
     if (maxJobDuration > 0) {
       maxTimeout = setTimeout(() => {
-        logger.log(`[worker] running killAll. duration has exceeded maxJobDuration. duration: ${Date.now() - start}`);
+        logger.log(`running killAll. duration has exceeded maxJobDuration. duration: ${Date.now() - start}`);
         killAll(child.pid,(err) => {
-          if (err) logger.log(`[worker] killAll Error: ${err}`);
+          if (err) logger.log(`killAll Error: ${err}`);
         });
       }, maxJobDuration * 1000);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "7.0.0-0",
+      "version": "8.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/cloudfriend": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "bin": {
     "watchbot": "bin/watchbot.js",

--- a/readme.md
+++ b/readme.md
@@ -9,11 +9,11 @@ A library to help run a highly-scalable AWS service that performs data processin
 Add these lines to your Dockerfile, to use the latest watchbot for the linux operating system.
 
 ```
-RUN wget https://s3.amazonaws.com/watchbot-binaries/linux/v7.0.0/watchbot -O /usr/local/bin/watchbot
+RUN wget https://s3.amazonaws.com/watchbot-binaries/linux/v8.0.0/watchbot -O /usr/local/bin/watchbot
 RUN chmod +x /usr/local/bin/watchbot
 ```
 * **os**: You can replace `linux` with other operating systems like `alpine`, `macosx` or, `windows`
-* **tag**: You can replace `v7.0.0`  with any [watchbot tag](https://github.com/mapbox/ecs-watchbot/releases) starting from and more recent than v4.0.0
+* **tag**: You can replace `v8.0.0`  with any [watchbot tag](https://github.com/mapbox/ecs-watchbot/releases) starting from and more recent than v4.0.0
 
 * If you are an existing user of watchbot, take a look at ["Upgrading to Watchbot 4"](https://github.com/mapbox/ecs-watchbot/blob/master/docs/upgrading-to-watchbot4.md), for a complete set of instructions to upgrade your stacks to Watchbot 4.
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:12
+# We use the AWS ECR version of this package to avoid any problems hitting rate
+# limits fetching from DockerHub with the `node:14` image
+FROM public.ecr.aws/docker/library/node:14
 
 COPY ./package.json ./package.json
 COPY ./package-lock.json ./package-lock.json
 
-RUN npm install -g npm
-RUN npm install
+RUN npm ci
 
 COPY ./lib ./lib
 COPY ./test ./test

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -1129,6 +1129,10 @@ Object {
                 "Value": "false",
               },
               Object {
+                "Name": "structuredLogging",
+                "Value": "false",
+              },
+              Object {
                 "Name": "MyKey",
                 "Value": "MyValue",
               },
@@ -2641,6 +2645,10 @@ Object {
               },
               Object {
                 "Name": "Fifo",
+                "Value": "false",
+              },
+              Object {
+                "Name": "structuredLogging",
                 "Value": "false",
               },
               Object {
@@ -4160,6 +4168,10 @@ Object {
               },
               Object {
                 "Name": "Fifo",
+                "Value": "false",
+              },
+              Object {
+                "Name": "structuredLogging",
                 "Value": "false",
               },
               Object {
@@ -5688,6 +5700,10 @@ Object {
                 "Value": "false",
               },
               Object {
+                "Name": "structuredLogging",
+                "Value": "false",
+              },
+              Object {
                 "Name": "MyKey",
                 "Value": "MyValue",
               },
@@ -7114,6 +7130,10 @@ Object {
               },
               Object {
                 "Name": "Fifo",
+                "Value": "false",
+              },
+              Object {
+                "Name": "structuredLogging",
                 "Value": "false",
               },
             ],
@@ -8605,6 +8625,10 @@ Object {
                 "Name": "Fifo",
                 "Value": "true",
               },
+              Object {
+                "Name": "structuredLogging",
+                "Value": "false",
+              },
             ],
             "Image": Object {
               "Fn::Join": Array [
@@ -9953,6 +9977,10 @@ Object {
               Object {
                 "Name": "Fifo",
                 "Value": "true",
+              },
+              Object {
+                "Name": "structuredLogging",
+                "Value": "false",
               },
             ],
             "Image": Object {

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -89,7 +89,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "7.0.0",
+    "EcsWatchbotVersion": "8.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -127,7 +127,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -625,7 +625,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -949,7 +949,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -1385,7 +1385,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -1452,7 +1452,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -1606,7 +1606,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "7.0.0",
+    "EcsWatchbotVersion": "8.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -1644,7 +1644,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2142,7 +2142,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -2466,7 +2466,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -2898,7 +2898,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -2965,7 +2965,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3119,7 +3119,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "7.0.0",
+    "EcsWatchbotVersion": "8.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -3157,7 +3157,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3655,7 +3655,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -3979,7 +3979,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -4423,7 +4423,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -4490,7 +4490,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -4644,7 +4644,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "7.0.0",
+    "EcsWatchbotVersion": "8.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -4682,7 +4682,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5180,7 +5180,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -5504,7 +5504,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -5948,7 +5948,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -6015,7 +6015,7 @@ Object {
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6169,7 +6169,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "7.0.0",
+    "EcsWatchbotVersion": "8.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -6207,7 +6207,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6631,7 +6631,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -6933,7 +6933,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -7355,7 +7355,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -7422,7 +7422,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -7700,7 +7700,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "7.0.0",
+    "EcsWatchbotVersion": "8.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -7738,7 +7738,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -8129,7 +8129,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -8424,7 +8424,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -8828,7 +8828,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -8895,7 +8895,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -9049,7 +9049,7 @@ Object {
     },
   },
   "Metadata": Object {
-    "EcsWatchbotVersion": "7.0.0",
+    "EcsWatchbotVersion": "8.0.0",
   },
   "Outputs": Object {
     "ClusterArn": Object {
@@ -9087,7 +9087,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#memoryutilization",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -9478,7 +9478,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#queuesize",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",
@@ -9773,7 +9773,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -10177,7 +10177,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -10244,7 +10244,7 @@ Object {
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v7.0.0/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v8.0.0/docs/alarms.md#workererrors",
         "AlarmName": Object {
           "Fn::Join": Array [
             "-",

--- a/test/bin.watchbot-binary-generator.test.js
+++ b/test/bin.watchbot-binary-generator.test.js
@@ -51,7 +51,7 @@ test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major
 
   assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
   assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
-  assert.equals(execStub.args[2][0], 'pkg --targets node12-linux,node12-macos,node12-win .', 'ran expected pkg command');
+  assert.equals(execStub.args[2][0], 'pkg --targets node14-linux,node14-macos,node14-win .', 'ran expected pkg command');
   assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
 
   assert.ok(s3Stub.calledWith({
@@ -100,7 +100,7 @@ test('uploadBundle: tag found (Tag created using `npm version <patch|minor|major
 
   assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
   assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
-  assert.equals(execStub.args[2][0], 'pkg --targets node12-alpine .', 'ran expected pkg command');
+  assert.equals(execStub.args[2][0], 'pkg --targets node14-alpine .', 'ran expected pkg command');
   assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
 
   assert.ok(s3Stub.calledWith({
@@ -135,7 +135,7 @@ test('uploadBundle: tag found (Tag created manually) for all except alpine', asy
 
   assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
   assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
-  assert.equals(execStub.args[2][0], 'pkg --targets node12-linux,node12-macos,node12-win .', 'ran expected pkg command');
+  assert.equals(execStub.args[2][0], 'pkg --targets node14-linux,node14-macos,node14-win .', 'ran expected pkg command');
   assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
 
   assert.ok(s3Stub.calledWith({
@@ -183,7 +183,7 @@ test('uploadBundle: tag found (Tag created manually) for alpine', async (assert)
 
   assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
   assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
-  assert.equals(execStub.args[2][0], 'pkg --targets node12-alpine .', 'ran expected pkg command');
+  assert.equals(execStub.args[2][0], 'pkg --targets node14-alpine .', 'ran expected pkg command');
   assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
 
   assert.ok(s3Stub.calledWith({
@@ -214,7 +214,7 @@ test('uploadBundle: tag not found for all except alpine', async (assert) => {
 
   assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
   assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
-  assert.equals(execStub.args[2][0], 'pkg --targets node12-linux,node12-macos,node12-win .', 'ran expected pkg command');
+  assert.equals(execStub.args[2][0], 'pkg --targets node14-linux,node14-macos,node14-win .', 'ran expected pkg command');
   assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
   assert.ok(log.calledWith('No tag found for 123456'));
 
@@ -237,7 +237,7 @@ test('uploadBundle: tag not found for alpine', async (assert) => {
 
   assert.equals(execStub.args[0][0], 'npm ci --production', 'reinstalled npm modules');
   assert.equals(execStub.args[1][0], 'npm install -g pkg', 'globally installed pkg');
-  assert.equals(execStub.args[2][0], 'pkg --targets node12-alpine .', 'ran expected pkg command');
+  assert.equals(execStub.args[2][0], 'pkg --targets node14-alpine .', 'ran expected pkg command');
   assert.equals(execStub.args[3][0], 'git ls-remote --tags https://github.com/mapbox/ecs-watchbot', 'listed tags on github');
   assert.ok(log.calledWith('No tag found for 123456'));
 

--- a/test/bin.watchbot.test.js
+++ b/test/bin.watchbot.test.js
@@ -24,6 +24,7 @@ test('[bin.watchbot] success', async (assert) => {
   process.env.QueueUrl = 'https://faker';
   process.env.Volumes = '/tmp,/mnt';
   process.env.maxJobDuration = 180;
+  process.env.structuredLogging = 'true';
 
   try {
     await watchbot();
@@ -35,6 +36,7 @@ test('[bin.watchbot] success', async (assert) => {
     Watcher.create.calledWith({
       queueUrl: 'https://faker',
       writableFilesystem: false,
+      structuredLogging: true,
       workerOptions: {
         command: 'echo hello world',
         volumes: ['/tmp', '/mnt'],
@@ -48,6 +50,7 @@ test('[bin.watchbot] success', async (assert) => {
 
   delete process.env.QueueUrl;
   delete process.env.Volumes;
+  delete process.env.structuredLogging;
   mockArgs.restore();
   watcher.teardown();
   assert.end();

--- a/test/logger-structured.test.js
+++ b/test/logger-structured.test.js
@@ -1,0 +1,272 @@
+'use strict';
+
+const test = require('tape');
+const sinon = require('sinon');
+const Logger = require('../lib/logger');
+const Message = require('../lib/message');
+const os = require('os');
+
+const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789012/fake';
+const sqsMessage = {
+  MessageId: '895ab607-3767-4bbb-bd45-2a3b341cbc46',
+  ReceiptHandle: 'a',
+  Body: JSON.stringify({ Subject: 'one', Message: '1' }),
+  Attributes: {
+    SentTimestamp: '1518027533772',
+    ApproximateFirstReceiveTimestamp: '1518027533772',
+    ApproximateReceiveCount: 3
+  }
+};
+const message = new Message(sqsMessage, { queueUrl });
+
+test('[logger] constructor', (assert) => {
+  assert.throws(
+    () => new Logger({ type: 'pie', structuredLogging: true }),
+    /Invalid logger type/,
+    'throws error on invalid type'
+  );
+
+  assert.throws(
+    () => new Logger({ type: 'watcher', structuredLogging: true }, {}),
+    /Invalid message/,
+    'throws error on invalid message'
+  );
+
+  assert.doesNotThrow(() => new Logger({ type: 'watcher', structuredLogging: true }), 'message is not required');
+
+  const logger = new Logger({ type: 'worker', structuredLogging: true }, message);
+
+  assert.equal(logger.type, 'worker', 'sets .type');
+  assert.equal(logger.message, message, 'sets .message');
+
+  assert.end();
+});
+
+test('[logger] factory', (assert) => {
+  const message = sinon.createStubInstance(Message);
+  const logger = Logger.create({ type: 'watcher', structuredLogging: true }, message);
+  assert.ok(logger instanceof Logger, 'returns a Logger object');
+  assert.equal(logger.message, message, 'sets .message');
+  assert.end();
+});
+
+test('[logger] messageReceived', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toISOString')
+    .returns('2021-11-09T06:43:12.123Z');
+  sinon
+    .stub(os, 'hostname')
+    .returns('my-hostname');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger({ type: 'watcher', structuredLogging: true }, message);
+  logger.messageReceived();
+
+  const data = JSON.parse(process.stdout.write.args[0][0]);
+  delete data.pid;
+  assert.same(
+    data,
+    { v: 0, level: 30, name: 'watcher', hostname: 'my-hostname', time: '2021-11-09T06:43:12.123Z',
+      watchbot_sqs_message_id: '895ab607-3767-4bbb-bd45-2a3b341cbc46', subject: 'one', message: '1',
+      receives: '3' },
+    'expected message'
+  );
+
+  Date.prototype.toISOString.restore();
+  process.stdout.write.restore();
+  os.hostname.restore();
+  assert.end();
+});
+
+test('[logger] workerSuccess', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toISOString')
+    .returns('2021-11-09T06:43:12.123Z');
+  sinon
+    .stub(os, 'hostname')
+    .returns('my-hostname');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger({ type: 'watcher', structuredLogging: true }, message);
+  logger.workerSuccess({ code: 0, duration: 12345, response_duration: 12345 });
+
+  const data = JSON.parse(process.stdout.write.args[0][0]);
+  delete data.pid;
+  assert.same(
+    data,
+    { v: 0, level: 30, name: 'watcher', hostname: 'my-hostname', time: '2021-11-09T06:43:12.123Z',
+      watchbot_sqs_message_id: '895ab607-3767-4bbb-bd45-2a3b341cbc46', worker_event: 'success',
+      code: 0, duration: 12345, response_duration: 12345 },
+    'expected message'
+  );
+
+  Date.prototype.toISOString.restore();
+  process.stdout.write.restore();
+  os.hostname.restore();
+  assert.end();
+});
+
+test('[logger] workerFailure', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toISOString')
+    .returns('2021-11-09T06:43:12.123Z');
+  sinon
+    .stub(os, 'hostname')
+    .returns('my-hostname');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger({ type: 'watcher', structuredLogging: true }, message);
+  logger.workerFailure({ code: 124, signal: 'SIGTERM', duration: 12345, response_duration: 12345 });
+
+  const data = JSON.parse(process.stdout.write.args[0][0]);
+  delete data.pid;
+  assert.same(
+    data,
+    { v: 0, level: 30, name: 'watcher', hostname: 'my-hostname', time: '2021-11-09T06:43:12.123Z',
+      watchbot_sqs_message_id: '895ab607-3767-4bbb-bd45-2a3b341cbc46', worker_event: 'failure', code: 124,
+      signal: 'SIGTERM', duration: 12345, response_duration: 12345 },
+    'expected message'
+  );
+
+  Date.prototype.toISOString.restore();
+  process.stdout.write.restore();
+  os.hostname.restore();
+  assert.end();
+});
+
+test('[logger] workerError', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toISOString')
+    .returns('2021-11-09T06:43:12.123Z');
+  sinon
+    .stub(os, 'hostname')
+    .returns('my-hostname');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger({ type: 'watcher', structuredLogging: true }, message);
+  logger.workerError(new Error('foo'));
+
+  const data = JSON.parse(process.stdout.write.args[0][0]);
+  delete data.pid;
+  assert.same(
+    data,
+    { v: 0, level: 50, name: 'watcher', hostname: 'my-hostname', time: '2021-11-09T06:43:12.123Z',
+      watchbot_sqs_message_id: '895ab607-3767-4bbb-bd45-2a3b341cbc46', worker_event: 'error',
+      msg: 'foo', err: {} },
+    'expected message'
+  );
+
+  Date.prototype.toISOString.restore();
+  process.stdout.write.restore();
+  os.hostname.restore();
+  assert.end();
+});
+
+test('[logger] queueError', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toISOString')
+    .returns('2021-11-09T06:43:12.123Z');
+  sinon
+    .stub(os, 'hostname')
+    .returns('my-hostname');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger({ type: 'watcher', structuredLogging: true });
+  logger.queueError(new Error('foo'));
+
+  const data = JSON.parse(process.stdout.write.args[0][0]);
+  delete data.pid;
+  assert.same(
+    data,
+    { v: 0, level: 50, name: 'watcher', hostname: 'my-hostname', time: '2021-11-09T06:43:12.123Z',
+      sqs_event: 'error', msg: 'foo', err: {} },
+    'expected message'
+  );
+
+  Date.prototype.toISOString.restore();
+  os.hostname.restore();
+  process.stdout.write.restore();
+  assert.end();
+});
+
+test('[logger] log', (assert) => {
+  sinon
+    .stub(Date.prototype, 'toISOString')
+    .returns('2021-11-09T06:43:12.123Z');
+  sinon
+    .stub(os, 'hostname')
+    .returns('my-hostname');
+  sinon.spy(process.stdout, 'write');
+
+  let logger = new Logger({ type: 'worker', structuredLogging: true }, message);
+  logger.log('hello there');
+
+  let data = JSON.parse(process.stdout.write.args[0][0]);
+  delete data.pid;
+  process.stdout.write.restore();
+  assert.same(
+    data,
+    { v: 0, level: 30, name: 'worker', hostname: 'my-hostname', time: '2021-11-09T06:43:12.123Z',
+      watchbot_sqs_message_id: '895ab607-3767-4bbb-bd45-2a3b341cbc46', msg: 'hello there' },
+    'prefixed with timestamp, type, and message id'
+  );
+
+  sinon.spy(process.stdout, 'write');
+  logger = new Logger({ type: 'watcher', structuredLogging: true });
+  logger.log('ok then');
+
+  data = JSON.parse(process.stdout.write.args[0][0]);
+  delete data.pid;
+  assert.same(
+    data,
+    { v:0, 'level':30, name: 'watcher',  hostname: 'my-hostname', time: '2021-11-09T06:43:12.123Z',
+      msg: 'ok then' },
+    'prefixed with timestamp, and type'
+  );
+
+  Date.prototype.toISOString.restore();
+  os.hostname.restore();
+  process.stdout.write.restore();
+  assert.end();
+});
+
+test('[logger] stream', async (assert) => {
+  sinon
+    .stub(Date.prototype, 'toISOString')
+    .returns('2021-11-09T06:43:12.123Z');
+  sinon
+    .stub(os, 'hostname')
+    .returns('my-hostname');
+  sinon.spy(process.stdout, 'write');
+
+  const logger = new Logger({ type: 'worker', structuredLogging: true }, message);
+  const writable = logger.stream();
+
+  writable.write('hello there\nhow are you');
+  writable
+    .on('finish', () => {
+      const first = JSON.parse(process.stdout.write.args[0][0]);
+      const second = JSON.parse(process.stdout.write.args[1][0]);
+      delete first.pid;
+      delete second.pid;
+      process.stdout.write.restore();
+      assert.same(
+        first,
+        { v: 0, level: 30, name: 'worker', hostname: 'my-hostname', time: '2021-11-09T06:43:12.123Z',
+          watchbot_sqs_message_id: '895ab607-3767-4bbb-bd45-2a3b341cbc46', msg: 'hello there' },
+        'prefixed first line with timestamp, type, and message id'
+      );
+
+      assert.same(
+        second,
+        { v: 0, level: 30, name: 'worker', hostname: 'my-hostname', time: '2021-11-09T06:43:12.123Z',
+          watchbot_sqs_message_id: '895ab607-3767-4bbb-bd45-2a3b341cbc46', msg: 'how are you' },
+        'splits on newline, prefixed second line with timestamp, type, and message id'
+      );
+
+      Date.prototype.toISOString.restore();
+      os.hostname.restore();
+      assert.end();
+    })
+    .end();
+});


### PR DESCRIPTION
This PR includes 2 changes:

  1. Updates the build/publish to a Node 14 environment - the Node 12 builds no longer function due to old Python versions in the Node 12 base images.  This is a breaking change and a major version bump.
  2. Adds support for JSON structured logging to `ecs-watchbot`, to more nicely integrate with CloudWatch logging.

## Structured logging

This PR adds a new option to the template generator:

  `structuredLogging: true|false (default)`

This changes the way the watchbot worker logs.  Instead of logging:

```
[Fri, 09 Feb 2018 21:57:55 GMT] [watcher] [895ab607-3767-4bbb-bd45-2a3b341cbc46] {"subject":"one","message":"1","receives":"3"}
```

it will log:

```
{ "v": 0, "level": 30, "name": "watcher", "hostname": "my-hostname", "time": "2021-11-09T06:43:12.123Z", "watchbot_sqs_message_id": "895ab607-3767-4bbb-bd45-2a3b341cbc46", "subject": "one", "message": 1, "receives": 3 }
```

All log messages emitted by the `watchbot` code will be in JSON form.  It also attempts to neatly integrate log output from called code in the following way:

  1. If structured logging is enabled, and the client log line starts with `{`, it will attempt to parse the client log line as JSON and merge the result into the JSON output.  If the client log line does not parse, it's added verbatim as a string property called `msg`
  2. If structured logging is enabled and the client log line doesn't start with `{`, then it's added verbatim as a string property called `msg`.
  3. If structured logging is not enabled, then log output remains the same as earlier watchbot versions (with the `[xxx]` prefixes).

JSON formatted log messages are harder to read by humans, but easier to read by computers.  In particular, CloudWatch Log Insights has native support for JSON-formatted log messages, and makes it easy and fast to query by particular fields in the JSON log lines.

This new feature is opt-in.  Existing users of `ecs-watchbot` should not be affected, and log output will remain the same as before.

## How to test

This PR includes updated tests that verify that the `structuredLogging` property works as expected and emits JSON-formatted log-lines.