### PR TITLE
SAPI-935 support custom clusters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 10.0.1
+
+-  Add support for providing a custom cluster, enabling usage in default account
+
 ### 10.0.0
 - This library is now distributed as a CDK construct with almost identical functionality. Refer to [UPGRADING_TO_V10](/docs/upgrading-to-watchbot10.md) for migration details.
 

--- a/docs/upgrading-to-watchbot10.md
+++ b/docs/upgrading-to-watchbot10.md
@@ -5,7 +5,7 @@ Starting Watchbot v10, the watchbot CLI can be installed from `ecs-watchbot-bina
 
 Update your Dockerfile with the following:
 ```
-RUN wget https://s3.amazonaws.com/ecs-watchbot-binaries/linux/v10.0.0/watchbot -O /usr/local/bin/watchbot
+RUN wget https://s3.amazonaws.com/ecs-watchbot-binaries/linux/v10.0.1/watchbot -O /usr/local/bin/watchbot
 RUN chmod +x /usr/local/bin/watchbot
 ```
 

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -562,7 +562,7 @@ export class FargateWatchbot extends Resource {
       readonlyRootFilesystem: true,
       maxJobDuration: Duration.seconds(0),
       family: props.serviceName,
-      cluster: Cluster.fromClusterAttributes(this, `${id}Cluster`, {
+      cluster: props.cluster ?? Cluster.fromClusterAttributes(this, `${id}Cluster`, {
         clusterName: `fargate-processing-${props.deploymentEnvironment}`,
         vpc: Vpc.fromLookup(this, `${id}VPC`, {
           vpcId: VPC_IDs[region as SupportedRegion][props.deploymentEnvironment],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.0.1-0",
+  "version": "10.0.1-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.0.1-0",
+      "version": "10.0.1-1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.0.1-1",
+  "version": "10.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.0.1-1",
+      "version": "10.0.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.0.0",
+  "version": "10.0.1-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.0.0",
+      "version": "10.0.1-0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.0.1-1",
+  "version": "10.0.1",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.0.0",
+  "version": "10.0.1-0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",
@@ -81,6 +81,10 @@
   },
   "eslintConfig": {
     "extends": "@mapbox/eslint-config-mapbox",
-    "ignorePatterns": ["/lib/watchbot.js", "/lib/MapboxQueueProcessingFargateService.js", "bin/cdk.js"]
+    "ignorePatterns": [
+      "/lib/watchbot.js",
+      "/lib/MapboxQueueProcessingFargateService.js",
+      "bin/cdk.js"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.0.1-0",
+  "version": "10.0.1-1",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -7,11 +7,11 @@ A library to help run a highly-scalable AWS service that performs data processin
 Add these lines to your Dockerfile, to use the latest watchbot for the linux operating system.
 
 ```
-RUN wget https://s3.amazonaws.com/ecs-watchbot-binaries/linux/v10.0.0/watchbot -O /usr/local/bin/watchbot
+RUN wget https://s3.amazonaws.com/ecs-watchbot-binaries/linux/v10.0.1/watchbot -O /usr/local/bin/watchbot
 RUN chmod +x /usr/local/bin/watchbot
 ```
 * **os**: You can replace `linux` with other operating systems like `alpine`, `macosx` or, `windows`
-* **tag**: You can replace `v10.0.0`  with any [watchbot tag](https://github.com/mapbox/ecs-watchbot/releases) starting from and more recent than v4.0.0
+* **tag**: You can replace `v10.0.1`  with any [watchbot tag](https://github.com/mapbox/ecs-watchbot/releases) starting from and more recent than v4.0.0
   * :rotating_light: For any version <= 9, you need to use `https://s3.amazonaws.com/watchbot-binaries/linux/{VERSION}/watchbot` (note the difference in bucket name)
 
 * If you are an existing user of watchbot, take a look at ["Upgrading to Watchbot 10"](https://github.com/mapbox/ecs-watchbot/blob/master/docs/upgrading-to-watchbot10.md), for a complete set of instructions to upgrade your stacks to Watchbot 10.


### PR DESCRIPTION
This PR enables watchbot users to supply their own cluster configuration. This makes it possible to use the v10 watchbot in the default account. 

Confirmed to be working here: https://github.com/mapbox/search-location-details-etl/blob/83815aadc5e73ec6fa05b1a6fa1306b455913838/cdk/lib/search-location-details-etl-automation-stack.js#L62-L86
<img width="1057" alt="image" src="https://github.com/mapbox/ecs-watchbot/assets/7596199/beadcc0b-82e8-4d20-9d1e-1854d1f4ad08">