### PR TITLE
9.1.0 - IAM role management

### DIFF
--- a/bin/dead-letter.js
+++ b/bin/dead-letter.js
@@ -3,7 +3,7 @@
 
 /* eslint-disable no-console */
 
-const { CloudFormation } = require('@aws-sdk/client-cloudformation')
+const { CloudFormation } = require('@aws-sdk/client-cloudformation');
 const { SQS } = require('@aws-sdk/client-sqs');
 const inquirer = require('inquirer');
 const stream = require('stream');

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,26 @@
+### 9.1.0
+
+- Merge ScalingLambdaRole and LambdaTotalMessagesRole into the primary WatchbotRole resource to reduce number of distinct IAM roles
+- Add option `autoScalingRole` for using a predefined auto scaling role instead of creating one for the stack. This role should have the following permissions, with the resouce scope being as strict as desired: 
+
+```JSON
+{
+  "Statement": [
+    {
+      "Action": [
+        "application-autoscaling:*",
+        "cloudwatch:DescribeAlarms",
+        "cloudwatch:PutMetricAlarm",
+        "ecs:UpdateService",
+        "ecs:DescribeServices"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+```
+
 ### 9.0.1
 
 -  Bug fix: TotalMessagesLambda now working as expected; watchbot stacks now scaling down when no tasks in queue

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -247,7 +247,7 @@ const Resources = {
               ActionTypeId: {
                 Category: 'Build',
                 Owner: 'AWS',
-                Version: '2',
+                Version: '1',
                 Provider: 'CodeBuild'
               },
               InputArtifacts: [

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -223,7 +223,7 @@ const Resources = {
               ActionTypeId: {
                 Category: 'Source',
                 Owner: 'ThirdParty',
-                Version: '1',
+                Version: '2',
                 Provider: 'GitHub'
               },
               OutputArtifacts: [
@@ -262,7 +262,7 @@ const Resources = {
               ActionTypeId: {
                 Category: 'Build',
                 Owner: 'AWS',
-                Version: '2',
+                Version: '1',
                 Provider: 'CodeBuild'
               },
               InputArtifacts: [

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -233,7 +233,7 @@ const Resources = {
                 Owner: 'mapbox',
                 Repo: 'ecs-watchbot',
                 PollForSourceChanges: 'false',
-                Branch: 'mapsam/iam-role-options',
+                Branch: '9.x',
                 OAuthToken: '{{resolve:secretsmanager:code-pipeline-helper/access-token}}'
               }
             }

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -223,7 +223,7 @@ const Resources = {
               ActionTypeId: {
                 Category: 'Source',
                 Owner: 'ThirdParty',
-                Version: '2',
+                Version: '1',
                 Provider: 'GitHub'
               },
               OutputArtifacts: [
@@ -233,7 +233,7 @@ const Resources = {
                 Owner: 'mapbox',
                 Repo: 'ecs-watchbot',
                 PollForSourceChanges: 'false',
-                Branch: 'master',
+                Branch: 'mapsam/iam-role-options',
                 OAuthToken: '{{resolve:secretsmanager:code-pipeline-helper/access-token}}'
               }
             }

--- a/cloudformation/ecs-watchbot-generate-binaries.template.js
+++ b/cloudformation/ecs-watchbot-generate-binaries.template.js
@@ -247,7 +247,7 @@ const Resources = {
               ActionTypeId: {
                 Category: 'Build',
                 Owner: 'AWS',
-                Version: '1',
+                Version: '2',
                 Provider: 'CodeBuild'
               },
               InputArtifacts: [
@@ -262,7 +262,7 @@ const Resources = {
               ActionTypeId: {
                 Category: 'Build',
                 Owner: 'AWS',
-                Version: '1',
+                Version: '2',
                 Provider: 'CodeBuild'
               },
               InputArtifacts: [

--- a/docs/building-a-template.md
+++ b/docs/building-a-template.md
@@ -99,6 +99,7 @@ When creating your watchbot stacks with the `watchbot.template()` method, you no
 **placementConstraints** | ECS service [placement constraints](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-placementconstraint.html). This value is ignored for `capacity` values other than `'EC2'`. | Object[]/Ref | No | false
 **placementStrategies** | ECS service [placement strategies](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-placementstrategy.html). This value is ignored for `capacity` values other than `'EC2'`. | Object[]/Ref | No | false
 **structuredLogging** | Whether to emit logs in JSON format or not | Boolean | No | `false`
+**autoscalingRoleArn** | A custom autoscaling role to use instead of building a distinct role for the stack | String/Ref | No | If not provided, an autoscaling role will be built with the permissions described in [Custom Autoscaling Role](#custom-autoscaling-role)
 
 ### writableFilesystem mode explained
 
@@ -136,4 +137,26 @@ var outputs = {
 };
 
 cloudfriend.merge(myTemplate, watcher, outputs);
+```
+
+### Custom Autoscaling Role
+
+You can provide a custom autoscaling role for your service. If you do not provide a custom role, a role with the following permissions will be created, which can only be assumed by the `application-autoscaling.amazonaws.com` principal.
+
+```JSON
+{
+  "Statement": [
+    {
+      "Action": [
+        "application-autoscaling:*",
+        "cloudwatch:DescribeAlarms",
+        "cloudwatch:PutMetricAlarm",
+        "ecs:UpdateService",
+        "ecs:DescribeServices"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
 ```

--- a/lib/template.js
+++ b/lib/template.js
@@ -518,7 +518,7 @@ module.exports = (options = {}) => {
       ]),
       MinCapacity: options.minSize,
       MaxCapacity: options.maxSize,
-      RoleARN: options.autoscalingRole || cf.getAtt(prefixed('ScalingRole'), 'Arn')
+      RoleARN: options.autoscalingRoleArn || cf.getAtt(prefixed('ScalingRole'), 'Arn')
     }
   };
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -39,7 +39,7 @@ module.exports = (options = {}) => {
       fifo: false,
       fargatePublicIp: 'DISABLED',
       structuredLogging: false,
-      autoscalingRole: false,
+      autoscalingRole: false
     },
     options
   );
@@ -247,7 +247,7 @@ module.exports = (options = {}) => {
         Statement: [
           {
             Effect: 'Allow',
-            Principal: { Service: ['ecs-tasks.amazonaws.com'] },
+            Principal: { Service: ['ecs-tasks.amazonaws.com', 'lambda.amazonaws.com'] },
             Action: ['sts:AssumeRole']
           }
         ]
@@ -284,6 +284,39 @@ module.exports = (options = {}) => {
                   Resource: cf.importValue('cloudformation-kms-production')
                 }
               )
+            ]
+          }
+        },
+        // roles for log-based lambda scaling utility
+        {
+          PolicyName: cf.join([cf.stackName, '-lambda-scaling']),
+          PolicyDocument: {
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: [
+                  'logs:*'
+                ],
+                Resource: cf.join([
+                  'arn:',
+                  cf.partition,
+                  ':logs:*:*:*'
+                ])
+              },
+              {
+                Effect: 'Allow',
+                Action: [
+                  'cloudwatch:PutMetricData'
+                ],
+                Resource: '*'
+              },
+              {
+                Effect: 'Allow',
+                Action: [
+                  'sqs:GetQueueAttributes'
+                ],
+                Resource: cf.getAtt(prefixed('Queue'), 'Arn')
+              }
             ]
           }
         }
@@ -715,44 +748,11 @@ module.exports = (options = {}) => {
     }
   };
 
-  Resources[prefixed('LambdaScalingRole')] = {
-    Type: 'AWS::IAM::Role',
-    Properties: {
-      AssumeRolePolicyDocument: {
-        Statement: [
-          {
-            Effect: 'Allow',
-            Principal: { Service: ['lambda.amazonaws.com'] },
-            Action: ['sts:AssumeRole']
-          }
-        ]
-      },
-      Policies: [{
-        PolicyName: 'CustomcfnScalingLambdaLogs',
-        PolicyDocument: {
-          Statement: [
-            {
-              Effect: 'Allow',
-              Action: [
-                'logs:*'
-              ],
-              Resource: cf.join([
-                'arn:',
-                cf.partition,
-                ':logs:*:*:*'
-              ])
-            }
-          ]
-        }
-      }]
-    }
-  };
-
   Resources[prefixed('ScalingLambda')] = {
     Type: 'AWS::Lambda::Function',
     Properties: {
       Handler: 'index.handler',
-      Role: cf.getAtt(prefixed('LambdaScalingRole'), 'Arn'),
+      Role: cf.getAtt(prefixed('Role'), 'Arn'),
       Code: {
         ZipFile: cf.sub(`
           const response = require('./cfn-response');
@@ -778,7 +778,7 @@ module.exports = (options = {}) => {
     Type: 'AWS::Lambda::Function',
     Properties: {
       Handler: 'index.handler',
-      Role: cf.getAtt(prefixed('LambdaTotalMessagesRole'), 'Arn'),
+      Role: cf.getAtt(prefixed('Role'), 'Arn'),
       Timeout: 60,
       Code: {
         ZipFile: cf.sub(`
@@ -812,53 +812,6 @@ module.exports = (options = {}) => {
         })
       },
       Runtime: 'nodejs18.x'
-    }
-  };
-
-  Resources[prefixed('LambdaTotalMessagesRole')] = {
-    Type: 'AWS::IAM::Role',
-    Properties: {
-      AssumeRolePolicyDocument: {
-        Statement: [
-          {
-            Effect: 'Allow',
-            Principal: { Service: ['lambda.amazonaws.com'] },
-            Action: ['sts:AssumeRole']
-          }
-        ]
-      },
-      Policies: [{
-        PolicyName: 'LambdaTotalMessagesMetric',
-        PolicyDocument: {
-          Statement: [
-            {
-              Effect: 'Allow',
-              Action: [
-                'logs:*'
-              ],
-              Resource: cf.join([
-                'arn:',
-                cf.partition,
-                ':logs:*:*:*'
-              ])
-            },
-            {
-              Effect: 'Allow',
-              Action: [
-                'cloudwatch:PutMetricData'
-              ],
-              Resource: '*'
-            },
-            {
-              Effect: 'Allow',
-              Action: [
-                'sqs:GetQueueAttributes'
-              ],
-              Resource: cf.getAtt(prefixed('Queue'), 'Arn')
-            }
-          ]
-        }
-      }]
     }
   };
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -38,7 +38,8 @@ module.exports = (options = {}) => {
       dashboard: true,
       fifo: false,
       fargatePublicIp: 'DISABLED',
-      structuredLogging: false
+      structuredLogging: false,
+      autoscalingRole: false,
     },
     options
   );
@@ -433,41 +434,43 @@ module.exports = (options = {}) => {
     Resources[prefixed('Service')].Properties.PlacementStrategies =
       options.placementStrategies;
 
-  Resources[prefixed('ScalingRole')] = {
-    Type: 'AWS::IAM::Role',
-    Properties: {
-      AssumeRolePolicyDocument: {
-        Statement: [
+  if (!options.autoscalingRole) {
+    Resources[prefixed('ScalingRole')] = {
+      Type: 'AWS::IAM::Role',
+      Properties: {
+        AssumeRolePolicyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Principal: { Service: ['application-autoscaling.amazonaws.com'] },
+              Action: ['sts:AssumeRole']
+            }
+          ]
+        },
+        Path: '/',
+        Policies: [
           {
-            Effect: 'Allow',
-            Principal: { Service: ['application-autoscaling.amazonaws.com'] },
-            Action: ['sts:AssumeRole']
+            PolicyName: 'watchbot-autoscaling',
+            PolicyDocument: {
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  Action: [
+                    'application-autoscaling:*',
+                    'cloudwatch:DescribeAlarms',
+                    'cloudwatch:PutMetricAlarm',
+                    'ecs:UpdateService',
+                    'ecs:DescribeServices'
+                  ],
+                  Resource: '*'
+                }
+              ]
+            }
           }
         ]
-      },
-      Path: '/',
-      Policies: [
-        {
-          PolicyName: 'watchbot-autoscaling',
-          PolicyDocument: {
-            Statement: [
-              {
-                Effect: 'Allow',
-                Action: [
-                  'application-autoscaling:*',
-                  'cloudwatch:DescribeAlarms',
-                  'cloudwatch:PutMetricAlarm',
-                  'ecs:UpdateService',
-                  'ecs:DescribeServices'
-                ],
-                Resource: '*'
-              }
-            ]
-          }
-        }
-      ]
-    }
-  };
+      }
+    };
+  }
 
   Resources[prefixed('ScalingTarget')] = {
     Type: 'AWS::ApplicationAutoScaling::ScalableTarget',
@@ -482,7 +485,7 @@ module.exports = (options = {}) => {
       ]),
       MinCapacity: options.minSize,
       MaxCapacity: options.maxSize,
-      RoleARN: cf.getAtt(prefixed('ScalingRole'), 'Arn')
+      RoleARN: options.autoscalingRole || cf.getAtt(prefixed('ScalingRole'), 'Arn')
     }
   };
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -39,7 +39,7 @@ module.exports = (options = {}) => {
       fifo: false,
       fargatePublicIp: 'DISABLED',
       structuredLogging: false,
-      autoscalingRole: false
+      autoscalingRoleArn: false
     },
     options
   );
@@ -467,7 +467,7 @@ module.exports = (options = {}) => {
     Resources[prefixed('Service')].Properties.PlacementStrategies =
       options.placementStrategies;
 
-  if (!options.autoscalingRole) {
+  if (!options.autoscalingRoleArn) {
     Resources[prefixed('ScalingRole')] = {
       Type: 'AWS::IAM::Role',
       Properties: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "9.0.1",
+  "version": "9.1.0-dev.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "9.0.1",
+      "version": "9.1.0-dev.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "9.1.0-dev.2",
+  "version": "9.1.0-dev.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "9.1.0-dev.2",
+      "version": "9.1.0-dev.3",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "9.1.0-dev.3",
+  "version": "9.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "9.1.0-dev.3",
+      "version": "9.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "9.1.0-dev.1",
+  "version": "9.1.0-dev.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "9.1.0-dev.1",
+      "version": "9.1.0-dev.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "9.0.1",
+  "version": "9.1.0-dev.1",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "9.1.0-dev.2",
+  "version": "9.1.0-dev.3",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "9.1.0-dev.3",
+  "version": "9.1.0",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "9.1.0-dev.1",
+  "version": "9.1.0-dev.2",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -5876,6 +5876,2628 @@ exports[`[template]: all-properties-no-CPU 1`] = `
 }
 `;
 
+exports[`[template]: autoscalingRoleArn 1`] = `
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "InChina": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "0",
+            {
+              "Fn::Split": [
+                "-",
+                {
+                  "Ref": "AWS::Region",
+                },
+              ],
+            },
+          ],
+        },
+        "cn",
+      ],
+    },
+    "WatchbotCapacityIsEC2": {
+      "Fn::Equals": [
+        "FARGATE",
+        "EC2",
+      ],
+    },
+    "WatchbotCapacityIsFargate": {
+      "Fn::Equals": [
+        "FARGATE",
+        "FARGATE",
+      ],
+    },
+    "WatchbotCapacityIsFargateSpot": {
+      "Fn::Equals": [
+        "FARGATE",
+        "FARGATE_SPOT",
+      ],
+    },
+    "WatchbotCapacityIsNotEC2": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            "FARGATE",
+            "EC2",
+          ],
+        },
+      ],
+    },
+  },
+  "Mappings": {
+    "EcrRegion": {
+      "ap-northeast-1": {
+        "Region": "us-west-2",
+      },
+      "ap-southeast-1": {
+        "Region": "us-west-2",
+      },
+      "ap-southeast-2": {
+        "Region": "us-west-2",
+      },
+      "cn-north-1": {
+        "Region": "cn-north-1",
+      },
+      "cn-northwest-1": {
+        "Region": "cn-northwest-1",
+      },
+      "eu-central-1": {
+        "Region": "eu-west-1",
+      },
+      "eu-west-1": {
+        "Region": "eu-west-1",
+      },
+      "us-east-1": {
+        "Region": "us-east-1",
+      },
+      "us-east-2": {
+        "Region": "us-east-1",
+      },
+      "us-west-1": {
+        "Region": "us-west-2",
+      },
+      "us-west-2": {
+        "Region": "us-west-2",
+      },
+    },
+  },
+  "Metadata": {
+    "EcsWatchbotVersion": "9.1.0",
+  },
+  "Outputs": {
+    "ClusterArn": {
+      "Description": "Service cluster ARN",
+      "Value": "processing",
+    },
+    "WatchbotDeadLetterQueueUrl": {
+      "Description": "The URL for the dead letter queue",
+      "Value": {
+        "Ref": "WatchbotDeadLetterQueue",
+      },
+    },
+    "WatchbotLogGroup": {
+      "Description": "The ARN of Watchbot's log group",
+      "Value": {
+        "Fn::GetAtt": [
+          "WatchbotLogGroup",
+          "Arn",
+        ],
+      },
+    },
+    "WatchbotQueueUrl": {
+      "Description": "The URL for the primary work queue",
+      "Value": {
+        "Ref": "WatchbotQueue",
+      },
+    },
+  },
+  "Parameters": {},
+  "Resources": {
+    "WatchbotAlarmMemoryUtilization": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#memoryutilization",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "WatchbotMemoryUtilization",
+              {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "ClusterName",
+            "Value": "processing",
+          },
+          {
+            "Name": "ServiceName",
+            "Value": {
+              "Fn::GetAtt": [
+                "WatchbotService",
+                "Name",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "MemoryUtilization",
+        "Namespace": "AWS/ECS",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 100,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotCustomScalingResource": {
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "WatchbotScalingLambda",
+            "Arn",
+          ],
+        },
+        "maxSize": 1,
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+    },
+    "WatchbotDashboard": {
+      "Properties": {
+        "DashboardBody": {
+          "Fn::Sub": [
+            "{"widgets":[{"type":"metric","x":0,"y":0,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotQueue: Visible and NotVisible Messages","metrics":[["AWS/SQS","ApproximateNumberOfMessagesNotVisible","QueueName","\${WatchbotQueue}",{"period":60}],["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","\${WatchbotQueue}",{"period":60}]],"stat":"Sum","region":"\${AWS::Region}","period":60,"yAxis":{"left":{"min":0}}}},{"type":"metric","x":0,"y":12,"width":12,"height":6,"properties":{"metrics":[["AWS/SQS","ApproximateAgeOfOldestMessage","QueueName","\${WatchbotQueue}",{"stat":"Maximum"}],["...",{"stat":"p99"}],["..."],["...",{"stat":"p50"}]],"view":"timeSeries","stacked":false,"title":"WatchbotQueue: Age of Oldest Message (sec)","stat":"Average","region":"\${AWS::Region}","period":60,"yAxis":{"left":{"min":0}}}},{"type":"metric","x":0,"y":12,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotQueue: Worker Duration (msec)","metrics":[["Mapbox/ecs-watchbot","\${Prefix}WorkerDuration-\${AWS::StackName}",{"stat":"Maximum"}],["...",{"stat":"p99"}],["..."],["...",{"stat":"p50"}]],"region":"\${AWS::Region}","stat":"Average","period":60,"yAxis":{"left":{"min":0}}}},{"type":"metric","x":0,"y":12,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotQueue: Response Duration (msec)","metrics":[["Mapbox/ecs-watchbot","\${Prefix}ResponseDuration-\${AWS::StackName}",{"stat":"Maximum"}],["...",{"stat":"p99"}],["..."],["...",{"stat":"p50"}]],"region":"\${AWS::Region}","stat":"Average","period":60,"yAxis":{"left":{"min":0}}}},{"type":"metric","x":0,"y":12,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotQueue: Deleted messages","metrics":[["AWS/SQS","NumberOfMessagesDeleted","QueueName","\${WatchbotQueue}",{"period":60}]],"stat":"Sum","region":"\${AWS::Region}","period":60,"yAxis":{"left":{"min":0}}}},{"type":"metric","x":12,"y":12,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotService: Task Counts","metrics":[["ECS/ContainerInsights","RunningTaskCount","ClusterName","\${Cluster}","ServiceName","\${WatchbotService}",{"period":60}],[".","DesiredTaskCount",".",".",".",".",{"period":60}],[".","PendingTaskCount",".",".",".",".",{"period":60}]],"region":"\${AWS::Region}","period":60}},{"type":"metric","x":12,"y":12,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"Concurrency vs Throughput","metrics":[["ECS/ContainerInsights","RunningTaskCount","ClusterName","\${Cluster}","ServiceName","\${WatchbotService}",{"period":60,"yAxis":"right"}],[".","DesiredTaskCount",".",".",".",".",{"period":60,"yAxis":"right"}],["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","\${WatchbotQueue}",{"period":60,"stat":"Sum","yAxis":"left"}]],"region":"\${AWS::Region}","period":60,"yAxis":{"right":{"min":0}}}},{"type":"metric","x":0,"y":18,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotService: CPUUtilization, MemoryUtilization","metrics":[["AWS/ECS","CPUUtilization","ServiceName","\${WatchbotService}","ClusterName","\${Cluster}",{"period":60}],[".","MemoryUtilization",".",".",".",".",{"period":60}]],"region":"\${AWS::Region}","period":300}},{"type":"metric","x":12,"y":18,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotDeadLetterQueue: Visible and NotVisible Messages","metrics":[["AWS/SQS","ApproximateNumberOfMessagesNotVisible","QueueName","\${WatchbotDeadLetterQueue}",{"period":60}],["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","\${WatchbotDeadLetterQueue}",{"period":60}]],"stat":"Sum","region":"\${AWS::Region}","period":60,"yAxis":{"left":{"min":0}}}}]}",
+            {
+              "Cluster": "processing",
+              "Prefix": "Watchbot",
+              "WatchbotDeadLetterQueue": {
+                "Fn::GetAtt": [
+                  "WatchbotDeadLetterQueue",
+                  "QueueName",
+                ],
+              },
+              "WatchbotQueue": {
+                "Fn::GetAtt": [
+                  "WatchbotQueue",
+                  "QueueName",
+                ],
+              },
+              "WatchbotService": {
+                "Fn::GetAtt": [
+                  "WatchbotService",
+                  "Name",
+                ],
+              },
+            },
+          ],
+        },
+        "DashboardName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot",
+              {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "WatchbotDeadLetterAlarm": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "Provides notification when messages are visible in the dead letter queue",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-dead-letter",
+              {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "WatchbotDeadLetterQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": "60",
+        "Statistic": "Minimum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotDeadLetterQueue": {
+      "Description": "List of messages that failed to process 14 times",
+      "Properties": {
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "-",
+              "WatchbotDeadLetterQueue",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "WatchbotLogGroup": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              {
+                "Ref": "AWS::Region",
+              },
+              "watchbot",
+            ],
+          ],
+        },
+        "RetentionInDays": 14,
+      },
+      "Type": "AWS::Logs::LogGroup",
+    },
+    "WatchbotMessageReceivesMetric": {
+      "Properties": {
+        "FilterPattern": "{ $.receives = * }",
+        "LogGroupName": {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": {
+              "Fn::Join": [
+                "",
+                [
+                  "WatchbotMessageReceives-",
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": "$.receives",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "WatchbotMetricSchedulePermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "WatchbotTotalMessagesLambda",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "WatchbotTotalMessagesSchedule",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "WatchbotNotificationTopic": {
+      "Description": "Subscribe to this topic to receive emails when tasks fail or retry",
+      "Properties": {
+        "Subscription": [
+          {
+            "Endpoint": "hello@mapbox.pagerduty.com",
+            "Protocol": "email",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "WatchbotQueue": {
+      "Properties": {
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "-",
+              "WatchbotQueue",
+            ],
+          ],
+        },
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "WatchbotDeadLetterQueue",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 10,
+        },
+        "VisibilityTimeout": 180,
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "WatchbotQueuePolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Id": "WatchbotWatchbotQueue",
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+              ],
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "WatchbotTopic",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "WatchbotQueue",
+                  "Arn",
+                ],
+              },
+              "Sid": "SendSomeMessages",
+            },
+          ],
+          "Version": "2008-10-17",
+        },
+        "Queues": [
+          {
+            "Ref": "WatchbotQueue",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::QueuePolicy",
+    },
+    "WatchbotQueueSizeAlarm": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#queuesize",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-queue-size",
+              {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 24,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": "300",
+        "Statistic": "Average",
+        "Threshold": 40,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotResponseDurationMetric": {
+      "Properties": {
+        "FilterPattern": "{ $.response_duration = * }",
+        "LogGroupName": {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": {
+              "Fn::Join": [
+                "",
+                [
+                  "WatchbotResponseDuration-",
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": "$.response_duration",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "WatchbotRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ecs-tasks.amazonaws.com",
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:ReceiveMessage",
+                    "sqs:DeleteMessage",
+                    "sqs:ChangeMessageVisibility",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "logs:FilterLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "WatchbotLogGroup",
+                      "Arn",
+                    ],
+                  },
+                },
+                {
+                  "Fn::If": [
+                    "InChina",
+                    {
+                      "Ref": "AWS::NoValue",
+                    },
+                    {
+                      "Action": "kms:Decrypt",
+                      "Effect": "Allow",
+                      "Resource": {
+                        "Fn::ImportValue": "cloudformation-kms-production",
+                      },
+                    },
+                  ],
+                },
+                {
+                  "Action": "sns:Publish",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "WatchbotTopic",
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-default-worker",
+                ],
+              ],
+            },
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-lambda-scaling",
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "WatchbotScaleDown": {
+      "Properties": {
+        "PolicyName": {
+          "Fn::Sub": "Watchbot\${AWS::StackName}-scale-down",
+        },
+        "PolicyType": "StepScaling",
+        "ScalingTargetId": {
+          "Ref": "WatchbotScalingTarget",
+        },
+        "StepScalingPolicyConfiguration": {
+          "AdjustmentType": "PercentChangeInCapacity",
+          "Cooldown": 300,
+          "MetricAggregationType": "Average",
+          "StepAdjustments": [
+            {
+              "MetricIntervalUpperBound": 0,
+              "ScalingAdjustment": -100,
+            },
+          ],
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
+    "WatchbotScaleDownTrigger": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotScaleDown",
+          },
+        ],
+        "AlarmDescription": "Scale down due to lack of in-flight messages in queue",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-scale-down",
+            ],
+          ],
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "TotalMessages",
+        "Namespace": "Mapbox/ecs-watchbot",
+        "Period": 600,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotScaleUp": {
+      "Properties": {
+        "PolicyName": {
+          "Fn::Sub": "\${AWS::StackName}-scale-up",
+        },
+        "PolicyType": "StepScaling",
+        "ScalingTargetId": {
+          "Ref": "WatchbotScalingTarget",
+        },
+        "StepScalingPolicyConfiguration": {
+          "AdjustmentType": "ChangeInCapacity",
+          "Cooldown": 300,
+          "MetricAggregationType": "Average",
+          "StepAdjustments": [
+            {
+              "MetricIntervalLowerBound": 0,
+              "ScalingAdjustment": {
+                "Fn::GetAtt": [
+                  "WatchbotCustomScalingResource",
+                  "ScalingAdjustment",
+                ],
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
+    "WatchbotScaleUpTrigger": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotScaleUp",
+          },
+        ],
+        "AlarmDescription": "Scale up due to visible messages in queue",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-scale-up",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotScalingLambda": {
+      "Properties": {
+        "Code": {
+          "ZipFile": {
+            "Fn::Sub": "
+          const response = require('./cfn-response');
+          exports.handler = function(event,context){
+            const result = Math.round(Math.max(Math.min(parseInt(event.ResourceProperties.maxSize) / 10, 100), 1));
+            response.send(event, context, response.SUCCESS, { ScalingAdjustment: result });
+          }
+          ",
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "WatchbotRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "WatchbotScalingTarget": {
+      "Properties": {
+        "MaxCapacity": 1,
+        "MinCapacity": 0,
+        "ResourceId": {
+          "Fn::Join": [
+            "",
+            [
+              "service/",
+              "processing",
+              "/",
+              {
+                "Fn::GetAtt": [
+                  "WatchbotService",
+                  "Name",
+                ],
+              },
+            ],
+          ],
+        },
+        "RoleARN": "arn:autoscaling:role/abcd",
+        "ScalableDimension": "ecs:service:DesiredCount",
+        "ServiceNamespace": "ecs",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "WatchbotService": {
+      "Properties": {
+        "CapacityProviderStrategy": {
+          "Fn::If": [
+            "WatchbotCapacityIsFargateSpot",
+            [
+              {
+                "CapacityProvider": "FARGATE_SPOT",
+                "Weight": 1,
+              },
+            ],
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "Cluster": "processing",
+        "LaunchType": {
+          "Fn::If": [
+            "WatchbotCapacityIsFargate",
+            "FARGATE",
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "NetworkConfiguration": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            {
+              "AwsvpcConfiguration": {
+                "AssignPublicIp": "DISABLED",
+                "SecurityGroups": undefined,
+                "Subnets": undefined,
+              },
+            },
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "PropagateTags": "TASK_DEFINITION",
+        "TaskDefinition": {
+          "Ref": "WatchbotTask",
+        },
+      },
+      "Type": "AWS::ECS::Service",
+    },
+    "WatchbotTask": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "watchbot",
+              "listen",
+              "echo hello world",
+            ],
+            "Cpu": {
+              "Fn::If": [
+                "WatchbotCapacityIsEC2",
+                {
+                  "Fn::If": [
+                    "WatchbotCapacityIsNotEC2",
+                    256,
+                    128,
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+            "Environment": [
+              {
+                "Name": "WorkTopic",
+                "Value": {
+                  "Ref": "WatchbotTopic",
+                },
+              },
+              {
+                "Name": "QueueUrl",
+                "Value": {
+                  "Ref": "WatchbotQueue",
+                },
+              },
+              {
+                "Name": "LogGroup",
+                "Value": {
+                  "Ref": "WatchbotLogGroup",
+                },
+              },
+              {
+                "Name": "writableFilesystem",
+                "Value": false,
+              },
+              {
+                "Name": "maxJobDuration",
+                "Value": 0,
+              },
+              {
+                "Name": "Volumes",
+                "Value": "/tmp",
+              },
+              {
+                "Name": "Fifo",
+                "Value": "false",
+              },
+              {
+                "Name": "structuredLogging",
+                "Value": "false",
+              },
+            ],
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ".dkr.ecr.",
+                  {
+                    "Fn::FindInMap": [
+                      "EcrRegion",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      "Region",
+                    ],
+                  },
+                  ".",
+                  {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/",
+                  "example",
+                  ":",
+                  "1",
+                ],
+              ],
+            },
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "WatchbotLogGroup",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "1",
+              },
+            },
+            "Memory": {
+              "Fn::If": [
+                "WatchbotCapacityIsEC2",
+                {
+                  "Fn::If": [
+                    "WatchbotCapacityIsNotEC2",
+                    512,
+                    {
+                      "Ref": "AWS::NoValue",
+                    },
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+            "MemoryReservation": {
+              "Ref": "AWS::NoValue",
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/tmp",
+                "SourceVolume": "tmp",
+              },
+            ],
+            "Name": {
+              "Fn::Join": [
+                "-",
+                [
+                  "Watchbot",
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "Privileged": false,
+            "ReadonlyRootFilesystem": {
+              "Fn::If": [
+                "WatchbotCapacityIsEC2",
+                true,
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+            "Ulimits": [
+              {
+                "HardLimit": 10240,
+                "Name": "nofile",
+                "SoftLimit": 10240,
+              },
+            ],
+          },
+        ],
+        "Cpu": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            {
+              "Fn::If": [
+                "WatchbotCapacityIsNotEC2",
+                256,
+                128,
+              ],
+            },
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "ExecutionRoleArn": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            {
+              "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/ecsTaskExecutionRole",
+            },
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "Family": "example",
+        "Memory": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            {
+              "Fn::If": [
+                "WatchbotCapacityIsNotEC2",
+                512,
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "NetworkMode": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            "awsvpc",
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "RequiresCompatibilities": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            [
+              "FARGATE",
+            ],
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "TaskRoleArn": {
+          "Ref": "WatchbotRole",
+        },
+        "Volumes": [
+          {
+            "Name": "tmp",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "WatchbotTopic": {
+      "Properties": {
+        "Subscription": [
+          {
+            "Endpoint": {
+              "Fn::GetAtt": [
+                "WatchbotQueue",
+                "Arn",
+              ],
+            },
+            "Protocol": "sqs",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "WatchbotTotalMessagesLambda": {
+      "Properties": {
+        "Code": {
+          "ZipFile": {
+            "Fn::Sub": [
+              "
+          const { SQS } = require('@aws-sdk/client-sqs');
+          const { CloudWatch } = require('@aws-sdk/client-cloudwatch');
+          exports.handler = function(event, context, callback) {
+            const sqs = new SQS({ region: process.env.AWS_DEFAULT_REGION });
+            const cw = new CloudWatch({ region: process.env.AWS_DEFAULT_REGION });
+
+            return sqs.getQueueAttributes({
+              QueueUrl: '\${QueueUrl}',
+              AttributeNames: ['ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessages']
+            })
+              .then((attrs) => {
+                return cw.putMetricData({
+                  Namespace: 'Mapbox/ecs-watchbot',
+                  MetricData: [{
+                    MetricName: 'TotalMessages',
+                    Dimensions: [{ Name: 'QueueName', Value: '\${QueueName}' }],
+                    Value: Number(attrs.Attributes.ApproximateNumberOfMessagesNotVisible) +
+                            Number(attrs.Attributes.ApproximateNumberOfMessages)
+                  }]
+                })
+              })
+              .then((metric) => callback(null, metric))
+              .catch((err) => callback(err));
+          }
+        ",
+              {
+                "QueueName": {
+                  "Fn::GetAtt": [
+                    "WatchbotQueue",
+                    "QueueName",
+                  ],
+                },
+                "QueueUrl": {
+                  "Ref": "WatchbotQueue",
+                },
+              },
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "WatchbotRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "WatchbotTotalMessagesSchedule": {
+      "Properties": {
+        "Description": "Update TotalMessages metric every minute",
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-total-messages",
+            ],
+          ],
+        },
+        "ScheduleExpression": "cron(0/1 * * * ? *)",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "WatchbotTotalMessagesLambda",
+                "Arn",
+              ],
+            },
+            "Id": "WatchbotTotalMessagesLambda",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "WatchbotWorkerDurationMetric": {
+      "Properties": {
+        "FilterPattern": "{ $.duration = * }",
+        "LogGroupName": {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": {
+              "Fn::Join": [
+                "",
+                [
+                  "WatchbotWorkerDuration-",
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": "$.duration",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "WatchbotWorkerErrorsAlarm": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#workererrors",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-worker-errors",
+              {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": {
+          "Fn::Join": [
+            "",
+            [
+              "WatchbotWorkerErrors-",
+              {
+                "Ref": "AWS::StackName",
+              },
+            ],
+          ],
+        },
+        "Namespace": "Mapbox/ecs-watchbot",
+        "Period": "60",
+        "Statistic": "Sum",
+        "Threshold": 10,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotWorkerErrorsMetric": {
+      "Properties": {
+        "FilterPattern": ""[failure]"",
+        "LogGroupName": {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": {
+              "Fn::Join": [
+                "",
+                [
+                  "WatchbotWorkerErrors-",
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": 1,
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+  },
+  "Rules": {},
+  "Transform": undefined,
+}
+`;
+
+exports[`[template]: autoscalingRoleArnImport 1`] = `
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "InChina": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "0",
+            {
+              "Fn::Split": [
+                "-",
+                {
+                  "Ref": "AWS::Region",
+                },
+              ],
+            },
+          ],
+        },
+        "cn",
+      ],
+    },
+    "WatchbotCapacityIsEC2": {
+      "Fn::Equals": [
+        "FARGATE",
+        "EC2",
+      ],
+    },
+    "WatchbotCapacityIsFargate": {
+      "Fn::Equals": [
+        "FARGATE",
+        "FARGATE",
+      ],
+    },
+    "WatchbotCapacityIsFargateSpot": {
+      "Fn::Equals": [
+        "FARGATE",
+        "FARGATE_SPOT",
+      ],
+    },
+    "WatchbotCapacityIsNotEC2": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            "FARGATE",
+            "EC2",
+          ],
+        },
+      ],
+    },
+  },
+  "Mappings": {
+    "EcrRegion": {
+      "ap-northeast-1": {
+        "Region": "us-west-2",
+      },
+      "ap-southeast-1": {
+        "Region": "us-west-2",
+      },
+      "ap-southeast-2": {
+        "Region": "us-west-2",
+      },
+      "cn-north-1": {
+        "Region": "cn-north-1",
+      },
+      "cn-northwest-1": {
+        "Region": "cn-northwest-1",
+      },
+      "eu-central-1": {
+        "Region": "eu-west-1",
+      },
+      "eu-west-1": {
+        "Region": "eu-west-1",
+      },
+      "us-east-1": {
+        "Region": "us-east-1",
+      },
+      "us-east-2": {
+        "Region": "us-east-1",
+      },
+      "us-west-1": {
+        "Region": "us-west-2",
+      },
+      "us-west-2": {
+        "Region": "us-west-2",
+      },
+    },
+  },
+  "Metadata": {
+    "EcsWatchbotVersion": "9.1.0",
+  },
+  "Outputs": {
+    "ClusterArn": {
+      "Description": "Service cluster ARN",
+      "Value": "processing",
+    },
+    "WatchbotDeadLetterQueueUrl": {
+      "Description": "The URL for the dead letter queue",
+      "Value": {
+        "Ref": "WatchbotDeadLetterQueue",
+      },
+    },
+    "WatchbotLogGroup": {
+      "Description": "The ARN of Watchbot's log group",
+      "Value": {
+        "Fn::GetAtt": [
+          "WatchbotLogGroup",
+          "Arn",
+        ],
+      },
+    },
+    "WatchbotQueueUrl": {
+      "Description": "The URL for the primary work queue",
+      "Value": {
+        "Ref": "WatchbotQueue",
+      },
+    },
+  },
+  "Parameters": {},
+  "Resources": {
+    "WatchbotAlarmMemoryUtilization": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#memoryutilization",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "WatchbotMemoryUtilization",
+              {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "ClusterName",
+            "Value": "processing",
+          },
+          {
+            "Name": "ServiceName",
+            "Value": {
+              "Fn::GetAtt": [
+                "WatchbotService",
+                "Name",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "MemoryUtilization",
+        "Namespace": "AWS/ECS",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 100,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotCustomScalingResource": {
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "WatchbotScalingLambda",
+            "Arn",
+          ],
+        },
+        "maxSize": 1,
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+    },
+    "WatchbotDashboard": {
+      "Properties": {
+        "DashboardBody": {
+          "Fn::Sub": [
+            "{"widgets":[{"type":"metric","x":0,"y":0,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotQueue: Visible and NotVisible Messages","metrics":[["AWS/SQS","ApproximateNumberOfMessagesNotVisible","QueueName","\${WatchbotQueue}",{"period":60}],["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","\${WatchbotQueue}",{"period":60}]],"stat":"Sum","region":"\${AWS::Region}","period":60,"yAxis":{"left":{"min":0}}}},{"type":"metric","x":0,"y":12,"width":12,"height":6,"properties":{"metrics":[["AWS/SQS","ApproximateAgeOfOldestMessage","QueueName","\${WatchbotQueue}",{"stat":"Maximum"}],["...",{"stat":"p99"}],["..."],["...",{"stat":"p50"}]],"view":"timeSeries","stacked":false,"title":"WatchbotQueue: Age of Oldest Message (sec)","stat":"Average","region":"\${AWS::Region}","period":60,"yAxis":{"left":{"min":0}}}},{"type":"metric","x":0,"y":12,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotQueue: Worker Duration (msec)","metrics":[["Mapbox/ecs-watchbot","\${Prefix}WorkerDuration-\${AWS::StackName}",{"stat":"Maximum"}],["...",{"stat":"p99"}],["..."],["...",{"stat":"p50"}]],"region":"\${AWS::Region}","stat":"Average","period":60,"yAxis":{"left":{"min":0}}}},{"type":"metric","x":0,"y":12,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotQueue: Response Duration (msec)","metrics":[["Mapbox/ecs-watchbot","\${Prefix}ResponseDuration-\${AWS::StackName}",{"stat":"Maximum"}],["...",{"stat":"p99"}],["..."],["...",{"stat":"p50"}]],"region":"\${AWS::Region}","stat":"Average","period":60,"yAxis":{"left":{"min":0}}}},{"type":"metric","x":0,"y":12,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotQueue: Deleted messages","metrics":[["AWS/SQS","NumberOfMessagesDeleted","QueueName","\${WatchbotQueue}",{"period":60}]],"stat":"Sum","region":"\${AWS::Region}","period":60,"yAxis":{"left":{"min":0}}}},{"type":"metric","x":12,"y":12,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotService: Task Counts","metrics":[["ECS/ContainerInsights","RunningTaskCount","ClusterName","\${Cluster}","ServiceName","\${WatchbotService}",{"period":60}],[".","DesiredTaskCount",".",".",".",".",{"period":60}],[".","PendingTaskCount",".",".",".",".",{"period":60}]],"region":"\${AWS::Region}","period":60}},{"type":"metric","x":12,"y":12,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"Concurrency vs Throughput","metrics":[["ECS/ContainerInsights","RunningTaskCount","ClusterName","\${Cluster}","ServiceName","\${WatchbotService}",{"period":60,"yAxis":"right"}],[".","DesiredTaskCount",".",".",".",".",{"period":60,"yAxis":"right"}],["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","\${WatchbotQueue}",{"period":60,"stat":"Sum","yAxis":"left"}]],"region":"\${AWS::Region}","period":60,"yAxis":{"right":{"min":0}}}},{"type":"metric","x":0,"y":18,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotService: CPUUtilization, MemoryUtilization","metrics":[["AWS/ECS","CPUUtilization","ServiceName","\${WatchbotService}","ClusterName","\${Cluster}",{"period":60}],[".","MemoryUtilization",".",".",".",".",{"period":60}]],"region":"\${AWS::Region}","period":300}},{"type":"metric","x":12,"y":18,"width":12,"height":6,"properties":{"view":"timeSeries","stacked":false,"title":"WatchbotDeadLetterQueue: Visible and NotVisible Messages","metrics":[["AWS/SQS","ApproximateNumberOfMessagesNotVisible","QueueName","\${WatchbotDeadLetterQueue}",{"period":60}],["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","\${WatchbotDeadLetterQueue}",{"period":60}]],"stat":"Sum","region":"\${AWS::Region}","period":60,"yAxis":{"left":{"min":0}}}}]}",
+            {
+              "Cluster": "processing",
+              "Prefix": "Watchbot",
+              "WatchbotDeadLetterQueue": {
+                "Fn::GetAtt": [
+                  "WatchbotDeadLetterQueue",
+                  "QueueName",
+                ],
+              },
+              "WatchbotQueue": {
+                "Fn::GetAtt": [
+                  "WatchbotQueue",
+                  "QueueName",
+                ],
+              },
+              "WatchbotService": {
+                "Fn::GetAtt": [
+                  "WatchbotService",
+                  "Name",
+                ],
+              },
+            },
+          ],
+        },
+        "DashboardName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot",
+              {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "WatchbotDeadLetterAlarm": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "Provides notification when messages are visible in the dead letter queue",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-dead-letter",
+              {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "WatchbotDeadLetterQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": "60",
+        "Statistic": "Minimum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotDeadLetterQueue": {
+      "Description": "List of messages that failed to process 14 times",
+      "Properties": {
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "-",
+              "WatchbotDeadLetterQueue",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "WatchbotLogGroup": {
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              {
+                "Ref": "AWS::Region",
+              },
+              "watchbot",
+            ],
+          ],
+        },
+        "RetentionInDays": 14,
+      },
+      "Type": "AWS::Logs::LogGroup",
+    },
+    "WatchbotMessageReceivesMetric": {
+      "Properties": {
+        "FilterPattern": "{ $.receives = * }",
+        "LogGroupName": {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": {
+              "Fn::Join": [
+                "",
+                [
+                  "WatchbotMessageReceives-",
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": "$.receives",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "WatchbotMetricSchedulePermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "WatchbotTotalMessagesLambda",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "WatchbotTotalMessagesSchedule",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "WatchbotNotificationTopic": {
+      "Description": "Subscribe to this topic to receive emails when tasks fail or retry",
+      "Properties": {
+        "Subscription": [
+          {
+            "Endpoint": "hello@mapbox.pagerduty.com",
+            "Protocol": "email",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "WatchbotQueue": {
+      "Properties": {
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "-",
+              "WatchbotQueue",
+            ],
+          ],
+        },
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "WatchbotDeadLetterQueue",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 10,
+        },
+        "VisibilityTimeout": 180,
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "WatchbotQueuePolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Id": "WatchbotWatchbotQueue",
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage",
+              ],
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "WatchbotTopic",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "WatchbotQueue",
+                  "Arn",
+                ],
+              },
+              "Sid": "SendSomeMessages",
+            },
+          ],
+          "Version": "2008-10-17",
+        },
+        "Queues": [
+          {
+            "Ref": "WatchbotQueue",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::QueuePolicy",
+    },
+    "WatchbotQueueSizeAlarm": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#queuesize",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-queue-size",
+              {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 24,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": "300",
+        "Statistic": "Average",
+        "Threshold": 40,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotResponseDurationMetric": {
+      "Properties": {
+        "FilterPattern": "{ $.response_duration = * }",
+        "LogGroupName": {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": {
+              "Fn::Join": [
+                "",
+                [
+                  "WatchbotResponseDuration-",
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": "$.response_duration",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "WatchbotRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ecs-tasks.amazonaws.com",
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:ReceiveMessage",
+                    "sqs:DeleteMessage",
+                    "sqs:ChangeMessageVisibility",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "logs:FilterLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "WatchbotLogGroup",
+                      "Arn",
+                    ],
+                  },
+                },
+                {
+                  "Fn::If": [
+                    "InChina",
+                    {
+                      "Ref": "AWS::NoValue",
+                    },
+                    {
+                      "Action": "kms:Decrypt",
+                      "Effect": "Allow",
+                      "Resource": {
+                        "Fn::ImportValue": "cloudformation-kms-production",
+                      },
+                    },
+                  ],
+                },
+                {
+                  "Action": "sns:Publish",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "WatchbotTopic",
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-default-worker",
+                ],
+              ],
+            },
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-lambda-scaling",
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "WatchbotScaleDown": {
+      "Properties": {
+        "PolicyName": {
+          "Fn::Sub": "Watchbot\${AWS::StackName}-scale-down",
+        },
+        "PolicyType": "StepScaling",
+        "ScalingTargetId": {
+          "Ref": "WatchbotScalingTarget",
+        },
+        "StepScalingPolicyConfiguration": {
+          "AdjustmentType": "PercentChangeInCapacity",
+          "Cooldown": 300,
+          "MetricAggregationType": "Average",
+          "StepAdjustments": [
+            {
+              "MetricIntervalUpperBound": 0,
+              "ScalingAdjustment": -100,
+            },
+          ],
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
+    "WatchbotScaleDownTrigger": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotScaleDown",
+          },
+        ],
+        "AlarmDescription": "Scale down due to lack of in-flight messages in queue",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-scale-down",
+            ],
+          ],
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "TotalMessages",
+        "Namespace": "Mapbox/ecs-watchbot",
+        "Period": 600,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotScaleUp": {
+      "Properties": {
+        "PolicyName": {
+          "Fn::Sub": "\${AWS::StackName}-scale-up",
+        },
+        "PolicyType": "StepScaling",
+        "ScalingTargetId": {
+          "Ref": "WatchbotScalingTarget",
+        },
+        "StepScalingPolicyConfiguration": {
+          "AdjustmentType": "ChangeInCapacity",
+          "Cooldown": 300,
+          "MetricAggregationType": "Average",
+          "StepAdjustments": [
+            {
+              "MetricIntervalLowerBound": 0,
+              "ScalingAdjustment": {
+                "Fn::GetAtt": [
+                  "WatchbotCustomScalingResource",
+                  "ScalingAdjustment",
+                ],
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
+    "WatchbotScaleUpTrigger": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotScaleUp",
+          },
+        ],
+        "AlarmDescription": "Scale up due to visible messages in queue",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-scale-up",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "WatchbotQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotScalingLambda": {
+      "Properties": {
+        "Code": {
+          "ZipFile": {
+            "Fn::Sub": "
+          const response = require('./cfn-response');
+          exports.handler = function(event,context){
+            const result = Math.round(Math.max(Math.min(parseInt(event.ResourceProperties.maxSize) / 10, 100), 1));
+            response.send(event, context, response.SUCCESS, { ScalingAdjustment: result });
+          }
+          ",
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "WatchbotRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "WatchbotScalingTarget": {
+      "Properties": {
+        "MaxCapacity": 1,
+        "MinCapacity": 0,
+        "ResourceId": {
+          "Fn::Join": [
+            "",
+            [
+              "service/",
+              "processing",
+              "/",
+              {
+                "Fn::GetAtt": [
+                  "WatchbotService",
+                  "Name",
+                ],
+              },
+            ],
+          ],
+        },
+        "RoleARN": {
+          "Fn::ImportValue": "my-role-arn",
+        },
+        "ScalableDimension": "ecs:service:DesiredCount",
+        "ServiceNamespace": "ecs",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "WatchbotService": {
+      "Properties": {
+        "CapacityProviderStrategy": {
+          "Fn::If": [
+            "WatchbotCapacityIsFargateSpot",
+            [
+              {
+                "CapacityProvider": "FARGATE_SPOT",
+                "Weight": 1,
+              },
+            ],
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "Cluster": "processing",
+        "LaunchType": {
+          "Fn::If": [
+            "WatchbotCapacityIsFargate",
+            "FARGATE",
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "NetworkConfiguration": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            {
+              "AwsvpcConfiguration": {
+                "AssignPublicIp": "DISABLED",
+                "SecurityGroups": undefined,
+                "Subnets": undefined,
+              },
+            },
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "PropagateTags": "TASK_DEFINITION",
+        "TaskDefinition": {
+          "Ref": "WatchbotTask",
+        },
+      },
+      "Type": "AWS::ECS::Service",
+    },
+    "WatchbotTask": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "watchbot",
+              "listen",
+              "echo hello world",
+            ],
+            "Cpu": {
+              "Fn::If": [
+                "WatchbotCapacityIsEC2",
+                {
+                  "Fn::If": [
+                    "WatchbotCapacityIsNotEC2",
+                    256,
+                    128,
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+            "Environment": [
+              {
+                "Name": "WorkTopic",
+                "Value": {
+                  "Ref": "WatchbotTopic",
+                },
+              },
+              {
+                "Name": "QueueUrl",
+                "Value": {
+                  "Ref": "WatchbotQueue",
+                },
+              },
+              {
+                "Name": "LogGroup",
+                "Value": {
+                  "Ref": "WatchbotLogGroup",
+                },
+              },
+              {
+                "Name": "writableFilesystem",
+                "Value": false,
+              },
+              {
+                "Name": "maxJobDuration",
+                "Value": 0,
+              },
+              {
+                "Name": "Volumes",
+                "Value": "/tmp",
+              },
+              {
+                "Name": "Fifo",
+                "Value": "false",
+              },
+              {
+                "Name": "structuredLogging",
+                "Value": "false",
+              },
+            ],
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ".dkr.ecr.",
+                  {
+                    "Fn::FindInMap": [
+                      "EcrRegion",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      "Region",
+                    ],
+                  },
+                  ".",
+                  {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/",
+                  "example",
+                  ":",
+                  "1",
+                ],
+              ],
+            },
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "WatchbotLogGroup",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "1",
+              },
+            },
+            "Memory": {
+              "Fn::If": [
+                "WatchbotCapacityIsEC2",
+                {
+                  "Fn::If": [
+                    "WatchbotCapacityIsNotEC2",
+                    512,
+                    {
+                      "Ref": "AWS::NoValue",
+                    },
+                  ],
+                },
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+            "MemoryReservation": {
+              "Ref": "AWS::NoValue",
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/tmp",
+                "SourceVolume": "tmp",
+              },
+            ],
+            "Name": {
+              "Fn::Join": [
+                "-",
+                [
+                  "Watchbot",
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "Privileged": false,
+            "ReadonlyRootFilesystem": {
+              "Fn::If": [
+                "WatchbotCapacityIsEC2",
+                true,
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+            "Ulimits": [
+              {
+                "HardLimit": 10240,
+                "Name": "nofile",
+                "SoftLimit": 10240,
+              },
+            ],
+          },
+        ],
+        "Cpu": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            {
+              "Fn::If": [
+                "WatchbotCapacityIsNotEC2",
+                256,
+                128,
+              ],
+            },
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "ExecutionRoleArn": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            {
+              "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/ecsTaskExecutionRole",
+            },
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "Family": "example",
+        "Memory": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            {
+              "Fn::If": [
+                "WatchbotCapacityIsNotEC2",
+                512,
+                {
+                  "Ref": "AWS::NoValue",
+                },
+              ],
+            },
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "NetworkMode": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            "awsvpc",
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "RequiresCompatibilities": {
+          "Fn::If": [
+            "WatchbotCapacityIsNotEC2",
+            [
+              "FARGATE",
+            ],
+            {
+              "Ref": "AWS::NoValue",
+            },
+          ],
+        },
+        "TaskRoleArn": {
+          "Ref": "WatchbotRole",
+        },
+        "Volumes": [
+          {
+            "Name": "tmp",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "WatchbotTopic": {
+      "Properties": {
+        "Subscription": [
+          {
+            "Endpoint": {
+              "Fn::GetAtt": [
+                "WatchbotQueue",
+                "Arn",
+              ],
+            },
+            "Protocol": "sqs",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "WatchbotTotalMessagesLambda": {
+      "Properties": {
+        "Code": {
+          "ZipFile": {
+            "Fn::Sub": [
+              "
+          const { SQS } = require('@aws-sdk/client-sqs');
+          const { CloudWatch } = require('@aws-sdk/client-cloudwatch');
+          exports.handler = function(event, context, callback) {
+            const sqs = new SQS({ region: process.env.AWS_DEFAULT_REGION });
+            const cw = new CloudWatch({ region: process.env.AWS_DEFAULT_REGION });
+
+            return sqs.getQueueAttributes({
+              QueueUrl: '\${QueueUrl}',
+              AttributeNames: ['ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessages']
+            })
+              .then((attrs) => {
+                return cw.putMetricData({
+                  Namespace: 'Mapbox/ecs-watchbot',
+                  MetricData: [{
+                    MetricName: 'TotalMessages',
+                    Dimensions: [{ Name: 'QueueName', Value: '\${QueueName}' }],
+                    Value: Number(attrs.Attributes.ApproximateNumberOfMessagesNotVisible) +
+                            Number(attrs.Attributes.ApproximateNumberOfMessages)
+                  }]
+                })
+              })
+              .then((metric) => callback(null, metric))
+              .catch((err) => callback(err));
+          }
+        ",
+              {
+                "QueueName": {
+                  "Fn::GetAtt": [
+                    "WatchbotQueue",
+                    "QueueName",
+                  ],
+                },
+                "QueueUrl": {
+                  "Ref": "WatchbotQueue",
+                },
+              },
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "WatchbotRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "WatchbotTotalMessagesSchedule": {
+      "Properties": {
+        "Description": "Update TotalMessages metric every minute",
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-total-messages",
+            ],
+          ],
+        },
+        "ScheduleExpression": "cron(0/1 * * * ? *)",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "WatchbotTotalMessagesLambda",
+                "Arn",
+              ],
+            },
+            "Id": "WatchbotTotalMessagesLambda",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "WatchbotWorkerDurationMetric": {
+      "Properties": {
+        "FilterPattern": "{ $.duration = * }",
+        "LogGroupName": {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": {
+              "Fn::Join": [
+                "",
+                [
+                  "WatchbotWorkerDuration-",
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": "$.duration",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+    "WatchbotWorkerErrorsAlarm": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "WatchbotNotificationTopic",
+          },
+        ],
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#workererrors",
+        "AlarmName": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Ref": "AWS::StackName",
+              },
+              "Watchbot-worker-errors",
+              {
+                "Ref": "AWS::Region",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": {
+          "Fn::Join": [
+            "",
+            [
+              "WatchbotWorkerErrors-",
+              {
+                "Ref": "AWS::StackName",
+              },
+            ],
+          ],
+        },
+        "Namespace": "Mapbox/ecs-watchbot",
+        "Period": "60",
+        "Statistic": "Sum",
+        "Threshold": 10,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "WatchbotWorkerErrorsMetric": {
+      "Properties": {
+        "FilterPattern": ""[failure]"",
+        "LogGroupName": {
+          "Ref": "WatchbotLogGroup",
+        },
+        "MetricTransformations": [
+          {
+            "MetricName": {
+              "Fn::Join": [
+                "",
+                [
+                  "WatchbotWorkerErrors-",
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                ],
+              ],
+            },
+            "MetricNamespace": "Mapbox/ecs-watchbot",
+            "MetricValue": 1,
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
+  },
+  "Rules": {},
+  "Transform": undefined,
+}
+`;
+
 exports[`[template]: defaults 1`] = `
 {
   "AWSTemplateFormatVersion": "2010-09-09",

--- a/test/__snapshots__/template.spec.js.snap
+++ b/test/__snapshots__/template.spec.js.snap
@@ -89,7 +89,7 @@ exports[`[template]: all-properties 1`] = `
     },
   },
   "Metadata": {
-    "EcsWatchbotVersion": "9.0.1",
+    "EcsWatchbotVersion": "9.1.0",
   },
   "Outputs": {
     "ClusterArn": {
@@ -127,7 +127,7 @@ exports[`[template]: all-properties 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#memoryutilization",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -286,119 +286,6 @@ exports[`[template]: all-properties 1`] = `
         },
       },
       "Type": "AWS::SQS::Queue",
-    },
-    "SoupLambdaScalingRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "CustomcfnScalingLambdaLogs",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "SoupLambdaTotalMessagesRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-                {
-                  "Action": [
-                    "cloudwatch:PutMetricData",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": "*",
-                },
-                {
-                  "Action": [
-                    "sqs:GetQueueAttributes",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::GetAtt": [
-                      "SoupQueue",
-                      "Arn",
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "LambdaTotalMessagesMetric",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
     },
     "SoupLogGroup": {
       "Properties": {
@@ -625,7 +512,7 @@ exports[`[template]: all-properties 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#queuesize",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -699,6 +586,7 @@ exports[`[template]: all-properties 1`] = `
               "Principal": {
                 "Service": [
                   "ecs-tasks.amazonaws.com",
+                  "lambda.amazonaws.com",
                 ],
               },
             },
@@ -768,6 +656,60 @@ exports[`[template]: all-properties 1`] = `
                     "Ref": "AWS::StackName",
                   },
                   "-default-worker",
+                ],
+              ],
+            },
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "SoupQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-lambda-scaling",
                 ],
               ],
             },
@@ -945,7 +887,7 @@ exports[`[template]: all-properties 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "SoupLambdaScalingRole",
+            "SoupRole",
             "Arn",
           ],
         },
@@ -1386,7 +1328,7 @@ exports[`[template]: all-properties 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "SoupLambdaTotalMessagesRole",
+            "SoupRole",
             "Arn",
           ],
         },
@@ -1457,7 +1399,7 @@ exports[`[template]: all-properties 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#workererrors",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -1613,7 +1555,7 @@ exports[`[template]: all-properties-CPU 1`] = `
     },
   },
   "Metadata": {
-    "EcsWatchbotVersion": "9.0.1",
+    "EcsWatchbotVersion": "9.1.0",
   },
   "Outputs": {
     "ClusterArn": {
@@ -1651,7 +1593,7 @@ exports[`[template]: all-properties-CPU 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#memoryutilization",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -1810,119 +1752,6 @@ exports[`[template]: all-properties-CPU 1`] = `
         },
       },
       "Type": "AWS::SQS::Queue",
-    },
-    "SoupLambdaScalingRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "CustomcfnScalingLambdaLogs",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "SoupLambdaTotalMessagesRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-                {
-                  "Action": [
-                    "cloudwatch:PutMetricData",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": "*",
-                },
-                {
-                  "Action": [
-                    "sqs:GetQueueAttributes",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::GetAtt": [
-                      "SoupQueue",
-                      "Arn",
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "LambdaTotalMessagesMetric",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
     },
     "SoupLogGroup": {
       "Properties": {
@@ -2149,7 +1978,7 @@ exports[`[template]: all-properties-CPU 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#queuesize",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -2223,6 +2052,7 @@ exports[`[template]: all-properties-CPU 1`] = `
               "Principal": {
                 "Service": [
                   "ecs-tasks.amazonaws.com",
+                  "lambda.amazonaws.com",
                 ],
               },
             },
@@ -2292,6 +2122,60 @@ exports[`[template]: all-properties-CPU 1`] = `
                     "Ref": "AWS::StackName",
                   },
                   "-default-worker",
+                ],
+              ],
+            },
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "SoupQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-lambda-scaling",
                 ],
               ],
             },
@@ -2469,7 +2353,7 @@ exports[`[template]: all-properties-CPU 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "SoupLambdaScalingRole",
+            "SoupRole",
             "Arn",
           ],
         },
@@ -2906,7 +2790,7 @@ exports[`[template]: all-properties-CPU 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "SoupLambdaTotalMessagesRole",
+            "SoupRole",
             "Arn",
           ],
         },
@@ -2977,7 +2861,7 @@ exports[`[template]: all-properties-CPU 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#workererrors",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -3133,7 +3017,7 @@ exports[`[template]: all-properties-low-CPU 1`] = `
     },
   },
   "Metadata": {
-    "EcsWatchbotVersion": "9.0.1",
+    "EcsWatchbotVersion": "9.1.0",
   },
   "Outputs": {
     "ClusterArn": {
@@ -3171,7 +3055,7 @@ exports[`[template]: all-properties-low-CPU 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#memoryutilization",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -3330,119 +3214,6 @@ exports[`[template]: all-properties-low-CPU 1`] = `
         },
       },
       "Type": "AWS::SQS::Queue",
-    },
-    "SoupLambdaScalingRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "CustomcfnScalingLambdaLogs",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "SoupLambdaTotalMessagesRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-                {
-                  "Action": [
-                    "cloudwatch:PutMetricData",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": "*",
-                },
-                {
-                  "Action": [
-                    "sqs:GetQueueAttributes",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::GetAtt": [
-                      "SoupQueue",
-                      "Arn",
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "LambdaTotalMessagesMetric",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
     },
     "SoupLogGroup": {
       "Properties": {
@@ -3669,7 +3440,7 @@ exports[`[template]: all-properties-low-CPU 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#queuesize",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -3743,6 +3514,7 @@ exports[`[template]: all-properties-low-CPU 1`] = `
               "Principal": {
                 "Service": [
                   "ecs-tasks.amazonaws.com",
+                  "lambda.amazonaws.com",
                 ],
               },
             },
@@ -3812,6 +3584,60 @@ exports[`[template]: all-properties-low-CPU 1`] = `
                     "Ref": "AWS::StackName",
                   },
                   "-default-worker",
+                ],
+              ],
+            },
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "SoupQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-lambda-scaling",
                 ],
               ],
             },
@@ -3989,7 +3815,7 @@ exports[`[template]: all-properties-low-CPU 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "SoupLambdaScalingRole",
+            "SoupRole",
             "Arn",
           ],
         },
@@ -4438,7 +4264,7 @@ exports[`[template]: all-properties-low-CPU 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "SoupLambdaTotalMessagesRole",
+            "SoupRole",
             "Arn",
           ],
         },
@@ -4509,7 +4335,7 @@ exports[`[template]: all-properties-low-CPU 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#workererrors",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -4665,7 +4491,7 @@ exports[`[template]: all-properties-no-CPU 1`] = `
     },
   },
   "Metadata": {
-    "EcsWatchbotVersion": "9.0.1",
+    "EcsWatchbotVersion": "9.1.0",
   },
   "Outputs": {
     "ClusterArn": {
@@ -4703,7 +4529,7 @@ exports[`[template]: all-properties-no-CPU 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#memoryutilization",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -4862,119 +4688,6 @@ exports[`[template]: all-properties-no-CPU 1`] = `
         },
       },
       "Type": "AWS::SQS::Queue",
-    },
-    "SoupLambdaScalingRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "CustomcfnScalingLambdaLogs",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "SoupLambdaTotalMessagesRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-                {
-                  "Action": [
-                    "cloudwatch:PutMetricData",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": "*",
-                },
-                {
-                  "Action": [
-                    "sqs:GetQueueAttributes",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::GetAtt": [
-                      "SoupQueue",
-                      "Arn",
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "LambdaTotalMessagesMetric",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
     },
     "SoupLogGroup": {
       "Properties": {
@@ -5201,7 +4914,7 @@ exports[`[template]: all-properties-no-CPU 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#queuesize",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -5275,6 +4988,7 @@ exports[`[template]: all-properties-no-CPU 1`] = `
               "Principal": {
                 "Service": [
                   "ecs-tasks.amazonaws.com",
+                  "lambda.amazonaws.com",
                 ],
               },
             },
@@ -5344,6 +5058,60 @@ exports[`[template]: all-properties-no-CPU 1`] = `
                     "Ref": "AWS::StackName",
                   },
                   "-default-worker",
+                ],
+              ],
+            },
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "SoupQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-lambda-scaling",
                 ],
               ],
             },
@@ -5521,7 +5289,7 @@ exports[`[template]: all-properties-no-CPU 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "SoupLambdaScalingRole",
+            "SoupRole",
             "Arn",
           ],
         },
@@ -5970,7 +5738,7 @@ exports[`[template]: all-properties-no-CPU 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "SoupLambdaTotalMessagesRole",
+            "SoupRole",
             "Arn",
           ],
         },
@@ -6041,7 +5809,7 @@ exports[`[template]: all-properties-no-CPU 1`] = `
             "Ref": "SoupNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#workererrors",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -6197,7 +5965,7 @@ exports[`[template]: defaults 1`] = `
     },
   },
   "Metadata": {
-    "EcsWatchbotVersion": "9.0.1",
+    "EcsWatchbotVersion": "9.1.0",
   },
   "Outputs": {
     "ClusterArn": {
@@ -6235,7 +6003,7 @@ exports[`[template]: defaults 1`] = `
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#memoryutilization",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -6395,119 +6163,6 @@ exports[`[template]: defaults 1`] = `
       },
       "Type": "AWS::SQS::Queue",
     },
-    "WatchbotLambdaScalingRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "CustomcfnScalingLambdaLogs",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "WatchbotLambdaTotalMessagesRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-                {
-                  "Action": [
-                    "cloudwatch:PutMetricData",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": "*",
-                },
-                {
-                  "Action": [
-                    "sqs:GetQueueAttributes",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::GetAtt": [
-                      "WatchbotQueue",
-                      "Arn",
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "LambdaTotalMessagesMetric",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
     "WatchbotLogGroup": {
       "Properties": {
         "LogGroupName": {
@@ -6659,7 +6314,7 @@ exports[`[template]: defaults 1`] = `
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#queuesize",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -6733,6 +6388,7 @@ exports[`[template]: defaults 1`] = `
               "Principal": {
                 "Service": [
                   "ecs-tasks.amazonaws.com",
+                  "lambda.amazonaws.com",
                 ],
               },
             },
@@ -6802,6 +6458,60 @@ exports[`[template]: defaults 1`] = `
                     "Ref": "AWS::StackName",
                   },
                   "-default-worker",
+                ],
+              ],
+            },
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-lambda-scaling",
                 ],
               ],
             },
@@ -6957,7 +6667,7 @@ exports[`[template]: defaults 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "WatchbotLambdaScalingRole",
+            "WatchbotRole",
             "Arn",
           ],
         },
@@ -7384,7 +7094,7 @@ exports[`[template]: defaults 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "WatchbotLambdaTotalMessagesRole",
+            "WatchbotRole",
             "Arn",
           ],
         },
@@ -7455,7 +7165,7 @@ exports[`[template]: defaults 1`] = `
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#workererrors",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -7735,7 +7445,7 @@ exports[`[template]: fifo 1`] = `
     },
   },
   "Metadata": {
-    "EcsWatchbotVersion": "9.0.1",
+    "EcsWatchbotVersion": "9.1.0",
   },
   "Outputs": {
     "ClusterArn": {
@@ -7773,7 +7483,7 @@ exports[`[template]: fifo 1`] = `
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#memoryutilization",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -7936,119 +7646,6 @@ exports[`[template]: fifo 1`] = `
       },
       "Type": "AWS::SQS::Queue",
     },
-    "WatchbotLambdaScalingRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "CustomcfnScalingLambdaLogs",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "WatchbotLambdaTotalMessagesRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-                {
-                  "Action": [
-                    "cloudwatch:PutMetricData",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": "*",
-                },
-                {
-                  "Action": [
-                    "sqs:GetQueueAttributes",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::GetAtt": [
-                      "WatchbotQueue",
-                      "Arn",
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "LambdaTotalMessagesMetric",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
     "WatchbotLogGroup": {
       "Properties": {
         "LogGroupName": {
@@ -8164,7 +7761,7 @@ exports[`[template]: fifo 1`] = `
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#queuesize",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -8238,6 +7835,7 @@ exports[`[template]: fifo 1`] = `
               "Principal": {
                 "Service": [
                   "ecs-tasks.amazonaws.com",
+                  "lambda.amazonaws.com",
                 ],
               },
             },
@@ -8300,6 +7898,60 @@ exports[`[template]: fifo 1`] = `
                     "Ref": "AWS::StackName",
                   },
                   "-default-worker",
+                ],
+              ],
+            },
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-lambda-scaling",
                 ],
               ],
             },
@@ -8455,7 +8107,7 @@ exports[`[template]: fifo 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "WatchbotLambdaScalingRole",
+            "WatchbotRole",
             "Arn",
           ],
         },
@@ -8864,7 +8516,7 @@ exports[`[template]: fifo 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "WatchbotLambdaTotalMessagesRole",
+            "WatchbotRole",
             "Arn",
           ],
         },
@@ -8935,7 +8587,7 @@ exports[`[template]: fifo 1`] = `
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#workererrors",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -9091,7 +8743,7 @@ exports[`[template]: fifoMaxSize 1`] = `
     },
   },
   "Metadata": {
-    "EcsWatchbotVersion": "9.0.1",
+    "EcsWatchbotVersion": "9.1.0",
   },
   "Outputs": {
     "ClusterArn": {
@@ -9129,7 +8781,7 @@ exports[`[template]: fifoMaxSize 1`] = `
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#memoryutilization",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#memoryutilization",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -9292,119 +8944,6 @@ exports[`[template]: fifoMaxSize 1`] = `
       },
       "Type": "AWS::SQS::Queue",
     },
-    "WatchbotLambdaScalingRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "CustomcfnScalingLambdaLogs",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "WatchbotLambdaTotalMessagesRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com",
-                ],
-              },
-            },
-          ],
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:*",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:",
-                        {
-                          "Ref": "AWS::Partition",
-                        },
-                        ":logs:*:*:*",
-                      ],
-                    ],
-                  },
-                },
-                {
-                  "Action": [
-                    "cloudwatch:PutMetricData",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": "*",
-                },
-                {
-                  "Action": [
-                    "sqs:GetQueueAttributes",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": {
-                    "Fn::GetAtt": [
-                      "WatchbotQueue",
-                      "Arn",
-                    ],
-                  },
-                },
-              ],
-            },
-            "PolicyName": "LambdaTotalMessagesMetric",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
     "WatchbotLogGroup": {
       "Properties": {
         "LogGroupName": {
@@ -9520,7 +9059,7 @@ exports[`[template]: fifoMaxSize 1`] = `
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#queuesize",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#queuesize",
         "AlarmName": {
           "Fn::Join": [
             "-",
@@ -9594,6 +9133,7 @@ exports[`[template]: fifoMaxSize 1`] = `
               "Principal": {
                 "Service": [
                   "ecs-tasks.amazonaws.com",
+                  "lambda.amazonaws.com",
                 ],
               },
             },
@@ -9656,6 +9196,60 @@ exports[`[template]: fifoMaxSize 1`] = `
                     "Ref": "AWS::StackName",
                   },
                   "-default-worker",
+                ],
+              ],
+            },
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:*",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":logs:*:*:*",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "sqs:GetQueueAttributes",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "WatchbotQueue",
+                      "Arn",
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::StackName",
+                  },
+                  "-lambda-scaling",
                 ],
               ],
             },
@@ -9811,7 +9405,7 @@ exports[`[template]: fifoMaxSize 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "WatchbotLambdaScalingRole",
+            "WatchbotRole",
             "Arn",
           ],
         },
@@ -10220,7 +9814,7 @@ exports[`[template]: fifoMaxSize 1`] = `
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
-            "WatchbotLambdaTotalMessagesRole",
+            "WatchbotRole",
             "Arn",
           ],
         },
@@ -10291,7 +9885,7 @@ exports[`[template]: fifoMaxSize 1`] = `
             "Ref": "WatchbotNotificationTopic",
           },
         ],
-        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.0.1/docs/alarms.md#workererrors",
+        "AlarmDescription": "https://github.com/mapbox/ecs-watchbot/blob/v9.1.0/docs/alarms.md#workererrors",
         "AlarmName": {
           "Fn::Join": [
             "-",

--- a/test/template.spec.js
+++ b/test/template.spec.js
@@ -214,4 +214,28 @@ test('[template]', () => {
   }));
 
   expect(fifoMaxSize).toMatchSnapshot('fifoMaxSize');
+
+  const builtWithAutoscalingRole = cf.merge(template({
+    service: 'example',
+    serviceVersion: '1',
+    command: 'echo hello world',
+    cluster: 'processing',
+    notificationEmail: 'hello@mapbox.pagerduty.com',
+    capacity: 'FARGATE',
+    autoscalingRoleArn: 'arn:autoscaling:role/abcd'
+  }));
+
+  expect(builtWithAutoscalingRole).toMatchSnapshot('autoscalingRoleArn');
+
+  const builtWithAutoscalingRoleImport = cf.merge(template({
+    service: 'example',
+    serviceVersion: '1',
+    command: 'echo hello world',
+    cluster: 'processing',
+    notificationEmail: 'hello@mapbox.pagerduty.com',
+    capacity: 'FARGATE',
+    autoscalingRoleArn: cf.importValue('my-role-arn')
+  }));
+
+  expect(builtWithAutoscalingRoleImport).toMatchSnapshot('autoscalingRoleArnImport');
 });


### PR DESCRIPTION
### What changed?

This is a change to the 9.x branch of ecs-watchbot that merges some of the IAM roles to reduce the number of roles created per stack. It allows the user to pass a pre-defined autoscaling role with the `options.autoscalingRoleArn` parameter, which enables a user to re-use a role throughout multiple stacks if they desire.

Role | Retain | Description
---|---|---
WatchbotRole | ✅ | this is the primary role and is still created for each stack. It now has multiple policies that encompass the permissions from the two additional lambda roles  
WatchBotLambdaScalingRole | ❌ | this role has been removed and is now a policy in WatchbotRole 
WatchBotLambdaTotalMessagesRole | ❌ | this role has been removed and is now a policy in WatchbotRole 
WatchbotScalingRole | ❌* | this role is now conditionally created if the user does not provide a string or ref with `options.autoscalingRoleArn` when building the template

Docs are included in the README to provide guidance on what permissions the auto-scaling role requires in order to work properly.

### 10.x vs. 9.x

Given ecs-watchbot has been migrated to a CDK stack in 10.x, this release focuses exclusively on a 9.x backport to support the most users. 10.x roles will be updated as well but in a separate release. The watchbot binaries are still being built by this branch and maintained by Mapbox.

Test binaries can be found at the following location:

```
https://s3.amazonaws.com/watchbot-binaries/linux/v9.1.0-dev.3/watchbot
```

### Deploy test

I was able to create a new stack called `ecs-watchbot-iam-test-staging` successfully with the following configuration (some options are obfuscated):

```js
const bot = watchbot.template({
  cluster: cf.ref('Cluster'),
  service: 'ecs-watchbot-iam-test',
  serviceVersion: cf.ref('GitSha'),
  command: 'node index.js',
  env: { 
    AWS_STACK_NAME: cf.stackName 
  },
  maxSize: 5,
  reservation: { memory: 512 },
  notificationTopic: cf.importValue('val'),
  fargatePublicIp: 'ENABLED',
  fargateSecurityGroups: [cf.importValue('val')],
  fargateSubnets: cf.split(',',  cf.importValue('val')),
  capacity: 'FARGATE_SPOT',
  autoscalingRoleArn: 'arn:aws:iam::ACCOUNT:role/ecs-watchbot-role',
});
```

I verified the following: 

* Only 1 IAM role is created ✅ 
* Stack custom metrics are created ✅ 
* Stack scales out when messages are > 0 for more than 5 minutes ✅ 
* Stack scales in when messages are < 1 for more than 10 minutes ✅ 
* ECS service scaleout works as expected ✅ 
* Utility lambdas succeed ✅ 

![Screen Shot 2024-05-21 at 11 24 15 AM](https://github.com/mapbox/ecs-watchbot/assets/1943001/18755030-dc27-406e-9179-c44e8405a616)

![Screen Shot 2024-05-21 at 11 22 02 AM](https://github.com/mapbox/ecs-watchbot/assets/1943001/dc3e1fbf-ce55-4d9c-8c99-5503dd22922f)

![Screen Shot 2024-05-21 at 11 39 27 AM](https://github.com/mapbox/ecs-watchbot/assets/1943001/02315965-0869-48e3-a691-8d0733ccf1da)

![Screen Shot 2024-05-21 at 11 12 46 AM](https://github.com/mapbox/ecs-watchbot/assets/1943001/64e0b3a5-3390-4be2-bab9-924d05cb7b4c)

![Screen Shot 2024-05-21 at 11 05 48 AM](https://github.com/mapbox/ecs-watchbot/assets/1943001/b1baf4d6-7672-40da-b373-609b2221aba3)

Looking at metrics is a nice way to visually see the service scale out when messages are >0 and scale in when messages are <1. I sent 100 messages in bulk to the test service, then purged the queue after scale out was confirmed. Subsequently, the service scaled in.

![Screen Shot 2024-05-21 at 11 39 05 AM](https://github.com/mapbox/ecs-watchbot/assets/1943001/ed55ddb8-0b21-4ed0-a19b-cfe93da21c9d)


### Checklist
Complete the steps below before merge where applicable:

- [ ] I included JIRA ticket code in the PR header
- [ ] I read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) doc.
- [ ] I used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title.
- [ ] I used proper typescript comments to document the changes made
- [ ] I made changes to relevant tests or added new tests if applicable
- [ ] I updated the [package.json](package.json), [package-lock.json](package-lock.json) and [readme.md](readme.md) to reflect the new correct Watchbot version
  - DO NOT MERGE WITHOUT MAKING THESE CHANGES
- [ ] I updated the [changelog.md](changelog.md)
