### PR TITLE
feat: add ephemeral storage, change scaling and add tests - CLOUDPLAT-921

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: checkout reop and npm install
         uses: actions/checkout@v4
+
+      - name: npm install
         run: npm install
 
       - name: run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: ecs-watchbot test
 on:
   push:
     branches:
-      - master
+      - "*"
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: ecs-watchbot test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      docker:
+        image: docker:19.03.12
+        options: --privileged
+
+    steps:
+      - uses: actions/checkout@v4
+      - id: action-node-setup
+        uses: mapbox/gha@action-node-setup-v1
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,10 @@ jobs:
         options: --privileged
 
     steps:
-      - name: npm install
+      - name: checkout reop and npm install
+        uses: actions/checkout@v4
         run: npm install
 
       - name: run tests
         run: npm run test
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: ecs-watchbot test
 on:
   push:
     branches:
-      - "*"
+      - "master"
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,8 @@ jobs:
         options: --privileged
 
     steps:
-      - uses: actions/checkout@v4
-      - id: action-node-setup
-        uses: mapbox/gha@action-node-setup-v1
+      - name: npm install
+        run: npm install
 
+      - name: run tests
+        run: npm run test

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ### 10.1.0
-- Expose `LinuxParameters` in the props to allow users to override the value in the container definition
+- Port watchbot scaling logic from 9.x to scale down based on total message (visible and not visible)
+- Expose ephemeralStorageGiB param to customize disk size up to 200 GB (default 20 GB)
+- Bump aws-cdk-lib and cdk-monitoring-constructs to update type definitions
 - Add a cloudformation output for the watchbot SNS topic
 
 ### 10.0.2

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 10.1.0
+- Expose `LinuxParameters` in the props to allow users to override the value in the container definition
+- Add a cloudformation output for the watchbot SNS topic
+
 ### 10.0.2
 
 -  Fix monitoring resource naming conflicts when used in multiple stacks

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -53,12 +53,6 @@ export interface MapboxQueueProcessingFargateServiceProps
    */
   readonly linuxParameters?: LinuxParametersProps;
 
-  /**
-   * Size of disk to attach to the fargate container
-   * @default undefined
-   */
-  readonly ephemeralStorageGiB?: number;
-
 }
 
 /**
@@ -100,7 +94,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     this.taskDefinition = new FargateTaskDefinition(this, 'QueueProcessingTaskDef', {
       memoryLimitMiB: props.memoryLimitMiB || 512,
       cpu: props.cpu || 256,
-      ephemeralStorageGiB: props.ephemeralStorageGiB || 20,
+      ephemeralStorageGiB: props.ephemeralStorageGiB,
       family: props.family,
       runtimePlatform: props.runtimePlatform,
       volumes: props.volumes
@@ -219,7 +213,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
         { lower: 0, upper: 0, change: -100 },
         { lower: 1, change: 0 } // this is a bogus param - we require two for autoscaling
       ],
-      evaluationPeriods: 3,
+      evaluationPeriods: 1,
       adjustmentType: appscaling.AdjustmentType.PERCENT_CHANGE_IN_CAPACITY
     })
 
@@ -236,7 +230,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
         { lower: 0, upper: 1, change: 0 },
         { lower: 1, change: Math.round(Math.max(Math.min(props.maxScalingCapacity || 1 / 10, 100), 1)) }
       ],
-      evaluationPeriods: 3
+      evaluationPeriods: 1
     })
   }
 }

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -220,8 +220,8 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('TotalMessagesScaling', {
       metric: this.totalMessagesMetric,
       scalingSteps: [
-        { lower: -3, upper: -2, change: -100 }, // this is a bogus param - we require two for autoscaling
-        { lower: -1, upper: 0, change: -100 },
+        { lower: -1, change: -200 }, // this is a bogus param - we require two for autoscaling
+        { upper: 0, change: -100 },
       ],
       evaluationPeriods: 3
     })
@@ -229,8 +229,8 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('VisibleMessagesScaling', {
       metric: this.visibleMessagesMetric,
       scalingSteps: [
-        { lower: 10, upper: 10000000, change: 5 }, // test - let's add 5 tasks if there are > 10 messages
-        { lower: 1, upper: 10, change: 1 },
+        { lower: 1, change: 1 },
+        { upper: 10, change: 5 },  // test - let's add 5 tasks if there are > 10 messages
       ],
       evaluationPeriods: 3
     })

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -51,6 +51,12 @@ export interface MapboxQueueProcessingFargateServiceProps
    */
   readonly image: ContainerImage;
 
+  /**
+   * The period between scale up events
+   * @default 5
+   */
+  readonly scaleUpAlarmIntervalMinutes: number;
+
 }
 
 /**
@@ -208,7 +214,9 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     })
 
     scalingTarget.scaleOnMetric('VisibleMessagesScaling', {
-      metric: this.sqsQueue.metricApproximateNumberOfMessagesVisible(),
+      metric: this.sqsQueue.metricApproximateNumberOfMessagesVisible({
+        period: Duration.minutes(props.scaleUpAlarmIntervalMinutes)
+      }),
       scalingSteps: [
         { lower: 0, upper: 1, change: 0 },
         { lower: 1, change: Math.round(Math.max(Math.min((props.maxScalingCapacity || 1) / 10, 100), 1)) }

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -46,6 +46,12 @@ export interface MapboxQueueProcessingFargateServiceProps
    * @default undefined
    */
   readonly linuxParameters?: LinuxParametersProps;
+
+  /**
+   * Size of disk to attach to the fargate container
+   * @default undefined
+   */
+  readonly ephemeralStorageGiB?: number;
 }
 
 /**
@@ -72,7 +78,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     this.taskDefinition = new FargateTaskDefinition(this, 'QueueProcessingTaskDef', {
       memoryLimitMiB: props.memoryLimitMiB || 512,
       cpu: props.cpu || 256,
-      ephemeralStorageGib : props.ephemeralStorageGiB || 20,
+      ephemeralStorageGiB: props.ephemeralStorageGiB || 20,
       family: props.family,
       runtimePlatform: props.runtimePlatform,
       volumes: props.volumes

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -1,5 +1,6 @@
 import { Construct } from 'constructs';
 import {
+  ContainerImage,
   FargateService,
   FargateTaskDefinition,
   Volume
@@ -20,7 +21,7 @@ import * as appscaling from 'aws-cdk-lib/aws-applicationautoscaling';
  * The properties for the MapboxQueueProcessingFargateService service.
  */
 export interface MapboxQueueProcessingFargateServiceProps
-  extends QueueProcessingFargateServiceProps {
+  extends Omit<QueueProcessingFargateServiceProps, 'image'>{
   /**
    * Specifies whether the container is marked as privileged. When this parameter is true, the container is given elevated privileges on the host container instance (similar to the root user).
    * @default false
@@ -46,10 +47,9 @@ export interface MapboxQueueProcessingFargateServiceProps
   readonly volumes?: Volume[];
 
   /**
-   * Size of disk to attach to the fargate container
-   * @default undefined
+   * The ECS image to use here. We're overriding the default image property because it can be undefined
    */
-  readonly ephemeralStorageGiB?: number;
+  readonly image: ContainerImage;
 
 }
 

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -262,7 +262,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
         cooldown: 300,
         metricAggregationType: 'Average',
         stepAdjustments: [{
-          scalingAdjustment: parseInt(this.customScalingResource.getAttString('ScalingAdjustment')),
+          scalingAdjustment: parseInt(this.customScalingResource.getAttString('ScalingAdjustment')) || 1,
           metricIntervalLowerBound: 0,
         }],
       },

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -220,8 +220,8 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('TotalMessagesScaling', {
       metric: this.totalMessagesMetric,
       scalingSteps: [
-        { lower: 0, change: -100 }, // this is a bogus param - we require two for autoscaling
-        { upper: 1, change: 0 },
+        { lower: 0, upper: 0, change: -100 }, // this is a bogus param - we require two for autoscaling
+        { lower: 1, upper: 1, change: 0 },
       ],
       evaluationPeriods: 3
     })
@@ -229,8 +229,8 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('VisibleMessagesScaling', {
       metric: this.visibleMessagesMetric,
       scalingSteps: [
-        { lower: 1, change: 1 },
-        { upper: 10, change: 5 },  // test - let's add 5 tasks if there are > 10 messages
+        { lower: 1, upper: 1, change: 1 },
+        { lower: 10, upper: 10, change: 5 },  // test - let's add 5 tasks if there are > 10 messages
       ],
       evaluationPeriods: 3
     })

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -220,8 +220,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('TotalMessagesScaling', {
       metric: this.totalMessagesMetric,
       scalingSteps: [
-        { lower: -1, change: -100 }, // this is a bogus param - we require two for autoscaling
-        { upper: 0, change: -100 },
+        { lower: 0, upper: 0, change: -100 }
       ],
       evaluationPeriods: 3
     })
@@ -229,8 +228,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('VisibleMessagesScaling', {
       metric: this.visibleMessagesMetric,
       scalingSteps: [
-        { upper: 1000, change: 1 }, // also bogus
-        { lower: 1, change: 1 },
+        { lower: 1, upper: 1000000, change: 1 },
       ],
       evaluationPeriods: 3
     })

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -230,7 +230,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       metric: this.visibleMessagesMetric,
       scalingSteps: [
         { lower: 1, upper: 1, change: 1 },
-        { lower: 10, upper: 10, change: 5 },  // test - let's add 5 tasks if there are > 10 messages
+        { lower: 10, upper: 1000000000, change: 5 },  // test - let's add 5 tasks if there are > 10 messages
       ],
       evaluationPeriods: 3
     })

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -188,8 +188,9 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       schedule: events.Schedule.cron({ minute: '0/1'}) // run every minute
     });
 
-    const principal = new iam.ServicePrincipal('events.amazonaws.com');
-
+    const principal = new iam.ServicePrincipal('events.amazonaws.com').withConditions(
+      { 'StringEquals': { 'aws:SourceAccount': '211125758554' } }
+    );
     this.totalMessagesLambda.grantInvoke(principal);
 
     rule.addTarget(new targets.LambdaFunction(this.totalMessagesLambda));

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -234,7 +234,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       resourceId: this.cluster.clusterName
     });
 
-    this.scalingLambda = new lambda.Function(this, 'TotalMessagesLambda', {
+    this.scalingLambda = new lambda.Function(this, 'ScalingLambda', {
       runtime: lambda.Runtime.NODEJS_18_X,
       handler: 'index.handler',
       code: new lambda.InlineCode(`

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -220,6 +220,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('TotalMessagesScaling', {
       metric: this.totalMessagesMetric,
       scalingSteps: [
+        { lower: -1, change: -100 }, // this is a bogus param - we require two for autoscaling
         { upper: 0, change: -100 },
       ],
       evaluationPeriods: 3
@@ -228,6 +229,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('VisibleMessagesScaling', {
       metric: this.visibleMessagesMetric,
       scalingSteps: [
+        { upper: 1000, change: 1 }, // also bogus
         { lower: 1, change: 1 },
       ],
       evaluationPeriods: 3

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -182,13 +182,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
         }
       `)
     })
-    const totalMessagesLambdaRole = new iam.Role(this, 'TotalMessagesLambdaRole', {
-      assumedBy: new iam.ServicePrincipal('events.amazonaws.com').withConditions(
-        { 'StringEquals': { 'aws:SourceAccount': '211125758554' } },
-      )
-    });
 
-    this.totalMessagesLambda.grantInvoke(totalMessagesLambdaRole);
     this.totalMessagesLambda.addToRolePolicy(new iam.PolicyStatement({
       actions: ['cloudwatch:PutMetricData'],
       resources: ['*']

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -55,7 +55,7 @@ export interface MapboxQueueProcessingFargateServiceProps
    * The period between scale up events
    * @default Duration.minutes(5)
    */
-  readonly scaleUpAlarmIntervalMinutes: Duration;
+  readonly scaleUpAlarmInterval: Duration;
 
 }
 
@@ -215,7 +215,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
 
     scalingTarget.scaleOnMetric('VisibleMessagesScaling', {
       metric: this.sqsQueue.metricApproximateNumberOfMessagesVisible({
-        period: props.scaleUpAlarmIntervalMinutes
+        period: props.scaleUpAlarmInterval
       }),
       scalingSteps: [
         { lower: 0, upper: 1, change: 0 },

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -136,7 +136,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     this.configureAutoscalingForService(this.service);
     this.grantPermissionsToService(this.service);
 
-    this.totalMessagesLambda = new lambda.Function(this, 'MyFunction', {
+    this.totalMessagesLambda = new lambda.Function(this, 'LambdaFunction', {
       runtime: lambda.Runtime.NODEJS_18_X,
       handler: 'index.handler',
       code: new lambda.InlineCode(`
@@ -165,7 +165,6 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
             .catch((err) => callback(err));
         }
       `)
-      })
-    }
+    })
   }
 }

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -163,7 +163,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
           const cw = new CloudWatch({ region: process.env.AWS_DEFAULT_REGION });
 
           return sqs.getQueueAttributes({
-            QueueUrl: ${this.sqsQueue.queueUrl},
+            QueueUrl: '${this.sqsQueue.queueUrl}',
             AttributeNames: ['ApproximateNumberOfMessagesNotVisible', 'ApproximateNumberOfMessages']
           })
             .then((attrs) => {
@@ -171,7 +171,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
                 Namespace: 'Mapbox/ecs-watchbot',
                 MetricData: [{
                   MetricName: 'TotalMessages',
-                  Dimensions: [{ Name: 'QueueName', Value: $ }],
+                  Dimensions: [{ Name: 'QueueName', Value: '${this.sqsQueue.queueName}'}],
                   Value: Number(attrs.Attributes.ApproximateNumberOfMessagesNotVisible) +
                           Number(attrs.Attributes.ApproximateNumberOfMessages)
                 }]

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -53,9 +53,9 @@ export interface MapboxQueueProcessingFargateServiceProps
 
   /**
    * The period between scale up events
-   * @default 5
+   * @default Duration.minutes(5)
    */
-  readonly scaleUpAlarmIntervalMinutes: number;
+  readonly scaleUpAlarmIntervalMinutes: Duration;
 
 }
 
@@ -215,7 +215,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
 
     scalingTarget.scaleOnMetric('VisibleMessagesScaling', {
       metric: this.sqsQueue.metricApproximateNumberOfMessagesVisible({
-        period: Duration.minutes(props.scaleUpAlarmIntervalMinutes)
+        period: props.scaleUpAlarmIntervalMinutes
       }),
       scalingSteps: [
         { lower: 0, upper: 1, change: 0 },

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -188,7 +188,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       resources: ['*']
     }))
     this.totalMessagesLambda.addToRolePolicy(new iam.PolicyStatement({
-      actions: ['cloudwatch:PutMetricData'],
+      actions: ['sqs:GetQueueAttributes'],
       resources: [this.sqsQueue.queueArn]
     }))
 

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -231,7 +231,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       scalableDimension: 'ecs:service:DesiredCount',
       minCapacity: props.minScalingCapacity || 0,
       maxCapacity: props.maxScalingCapacity || 1,
-      resourceId: this.cluster.clusterName
+      resourceId: `service/${this.cluster.clusterName}/${this.service.serviceName}`
     });
 
     this.scalingLambda = new lambda.Function(this, 'ScalingLambda', {

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -289,8 +289,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       alarmName: 'WatchbotScaleUp',
       alarmDescription: 'Scale up due to visible messages in queue',
       evaluationPeriods: 1,
-      threshold: 1,
-      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_UPPER_THRESHOLD,
+      threshold: 0,
       metric: this.visibleMessagesMetric
     });
 
@@ -314,7 +313,6 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       alarmDescription: 'Scale down due to total messages in queue',
       evaluationPeriods: 1,
       threshold: 1,
-      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
       metric: this.totalMessagesMetric
     });
   }

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -289,7 +289,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       alarmName: 'WatchbotScaleUp',
       alarmDescription: 'Scale up due to visible messages in queue',
       evaluationPeriods: 1,
-      threshold: 0,
+      threshold: 1,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_UPPER_THRESHOLD,
       metric: this.visibleMessagesMetric
     });
@@ -313,7 +313,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       alarmName: 'WatchbotScaleDown',
       alarmDescription: 'Scale down due to total messages in queue',
       evaluationPeriods: 1,
-      threshold: 0,
+      threshold: 1,
       comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
       metric: this.totalMessagesMetric
     });

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -220,7 +220,8 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('TotalMessagesScaling', {
       metric: this.totalMessagesMetric,
       scalingSteps: [
-        { lower: 0, upper: 0, change: -100 }
+        { lower: -2, upper: -1, change: -100 }, // this is a bogus param - we require two for autoscaling
+        { lower: -1, upper: 0, change: -100 },
       ],
       evaluationPeriods: 3
     })
@@ -228,7 +229,8 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('VisibleMessagesScaling', {
       metric: this.visibleMessagesMetric,
       scalingSteps: [
-        { lower: 1, upper: 1000000, change: 1 },
+        { lower: 10, upper: 10000000, change: 5 }, // test - let's add 5 tasks if there are > 10 messages
+        { lower: 1, upper: 10, change: 1 },
       ],
       evaluationPeriods: 3
     })

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -2,8 +2,6 @@ import { Construct } from 'constructs';
 import {
   FargateService,
   FargateTaskDefinition,
-  LinuxParameters,
-  LinuxParametersProps,
   Volume
 } from 'aws-cdk-lib/aws-ecs';
 import {
@@ -48,10 +46,10 @@ export interface MapboxQueueProcessingFargateServiceProps
   readonly volumes?: Volume[];
 
   /**
-   * Linux-specific modifications that are applied to the container, such as Linux kernel capabilities.
+   * Size of disk to attach to the fargate container
    * @default undefined
    */
-  readonly linuxParameters?: LinuxParametersProps;
+  readonly ephemeralStorageGiB?: number;
 
 }
 
@@ -112,9 +110,6 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       privileged: props.privileged,
       memoryReservationMiB: props.memoryReservationMiB,
       readonlyRootFilesystem: props.readonlyRootFilesystem,
-      linuxParameters: props.linuxParameters
-        ? new LinuxParameters(this, 'LinuxParameters', props.linuxParameters)
-        : undefined
     });
 
     // The desiredCount should be removed from the fargate service when the feature flag is removed.

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -220,8 +220,8 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('TotalMessagesScaling', {
       metric: this.totalMessagesMetric,
       scalingSteps: [
-        { lower: -1, change: -200 }, // this is a bogus param - we require two for autoscaling
-        { upper: 0, change: -100 },
+        { lower: 0, change: -100 }, // this is a bogus param - we require two for autoscaling
+        { upper: 1, change: 0 },
       ],
       evaluationPeriods: 3
     })

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -72,6 +72,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     this.taskDefinition = new FargateTaskDefinition(this, 'QueueProcessingTaskDef', {
       memoryLimitMiB: props.memoryLimitMiB || 512,
       cpu: props.cpu || 256,
+      ephemeralStorageGib : props.ephemeralStorageGiB || 20,
       family: props.family,
       runtimePlatform: props.runtimePlatform,
       volumes: props.volumes

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -220,7 +220,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
     scaling.scaleOnMetric('TotalMessagesScaling', {
       metric: this.totalMessagesMetric,
       scalingSteps: [
-        { lower: -2, upper: -1, change: -100 }, // this is a bogus param - we require two for autoscaling
+        { lower: -3, upper: -2, change: -100 }, // this is a bogus param - we require two for autoscaling
         { lower: -1, upper: 0, change: -100 },
       ],
       evaluationPeriods: 3

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -223,7 +223,7 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       metric: this.visibleMessagesMetric,
       scalingSteps: [
         { lower: 0, upper: 1, change: 0 },
-        { lower: 1, change: Math.round(Math.max(Math.min(props.maxScalingCapacity || 1 / 10, 100), 1)) }
+        { lower: 1, change: Math.round(Math.max(Math.min((props.maxScalingCapacity || 1) / 10, 100), 1)) }
       ],
       evaluationPeriods: 1
     })

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -78,11 +78,6 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
   readonly totalMessagesMetric: cloudwatch.Metric;
 
   /**
-   * A metric to track the total messages visible- created by default by SQS
-   */
-  readonly visibleMessagesMetric: cloudwatch.Metric;
-
-  /**
    * Constructs a new instance of the QueueProcessingFargateService class.
    */
   constructor(scope: Construct, id: string, props: MapboxQueueProcessingFargateServiceProps) {
@@ -212,15 +207,8 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       adjustmentType: appscaling.AdjustmentType.PERCENT_CHANGE_IN_CAPACITY
     })
 
-    this.visibleMessagesMetric = new cloudwatch.Metric({
-      namespace: 'AWS/SQS',
-      metricName: 'ApproximateNumberOfMessagesVisible',
-      dimensionsMap: { QueueName: this.sqsQueue.queueName },
-      period: Duration.minutes(5),
-    });
-
     scalingTarget.scaleOnMetric('VisibleMessagesScaling', {
-      metric: this.visibleMessagesMetric,
+      metric: this.sqsQueue.metricApproximateNumberOfMessagesVisible(),
       scalingSteps: [
         { lower: 0, upper: 1, change: 0 },
         { lower: 1, change: Math.round(Math.max(Math.min((props.maxScalingCapacity || 1) / 10, 100), 1)) }

--- a/lib/MapboxQueueProcessingFargateService.ts
+++ b/lib/MapboxQueueProcessingFargateService.ts
@@ -1,5 +1,11 @@
 import { Construct } from 'constructs';
-import { FargateService, FargateTaskDefinition, Volume } from 'aws-cdk-lib/aws-ecs';
+import {
+  FargateService,
+  FargateTaskDefinition,
+  LinuxParameters,
+  LinuxParametersProps,
+  Volume
+} from 'aws-cdk-lib/aws-ecs';
 import {
   QueueProcessingFargateServiceProps,
   QueueProcessingServiceBase
@@ -34,6 +40,12 @@ export interface MapboxQueueProcessingFargateServiceProps
    * @default []
    */
   readonly volumes?: Volume[];
+
+  /**
+   * Linux-specific modifications that are applied to the container, such as Linux kernel capabilities.
+   * @default undefined
+   */
+  readonly linuxParameters?: LinuxParametersProps;
 }
 
 /**
@@ -76,7 +88,10 @@ export class MapboxQueueProcessingFargateService extends QueueProcessingServiceB
       healthCheck: props.healthCheck,
       privileged: props.privileged,
       memoryReservationMiB: props.memoryReservationMiB,
-      readonlyRootFilesystem: props.readonlyRootFilesystem
+      readonlyRootFilesystem: props.readonlyRootFilesystem,
+      linuxParameters: props.linuxParameters
+        ? new LinuxParameters(this, 'LinuxParameters', props.linuxParameters)
+        : undefined
     });
 
     // The desiredCount should be removed from the fargate service when the feature flag is removed.

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -45,12 +45,6 @@ export interface WatchbotProps {
   readonly containerName?: string;
 
   /**
-   * The intervals for scaling based on the SQS queue's ApproximateNumberOfMessagesVisible metric.
-   * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns.QueueProcessingFargateService.html#scalingsteps
-   */
-  readonly scalingSteps?: ScalingInterval[];
-
-  /**
    * The runtime platform of the task definition.
    * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns.QueueProcessingFargateService.html#runtimeplatform
    */
@@ -411,7 +405,6 @@ export class FargateWatchbot extends Resource {
       propagateTags: PropagatedTagSource.TASK_DEFINITION,
 
       // scaling props
-      scalingSteps: this.props.scalingSteps,
       maxScalingCapacity: this.props.maxScalingCapacity,
       minScalingCapacity: this.props.minScalingCapacity,
 

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -213,9 +213,9 @@ export interface WatchbotProps {
 
   /**
    * The amount of time between scale up events for the service
-   * @default 5
+   * @default Duration.minutes(5)
    */
-  readonly scaleUpAlarmIntervalMinutes?: number;
+  readonly scaleUpAlarmIntervalMinutes?: Duration;
 
   readonly alarms: WatchbotAlarms;
 
@@ -413,7 +413,7 @@ export class FargateWatchbot extends Resource {
       // scaling props
       maxScalingCapacity: this.props.maxScalingCapacity,
       minScalingCapacity: this.props.minScalingCapacity,
-      scaleUpAlarmIntervalMinutes: this.props.scaleUpAlarmIntervalMinutes || 5,
+      scaleUpAlarmIntervalMinutes: this.props.scaleUpAlarmIntervalMinutes || Duration.minutes(5),
 
       // network config props
       taskSubnets: this.props.subnets,

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -467,8 +467,8 @@ export class FargateWatchbot extends Resource {
     }
     new CfnOutput(this, 'TopicOutput', {
       value: this.topic?.topicArn || '',
-      exportName: `${this.props.serviceName}-topic`,
-      description: `SNS topic to send messages to in order to invoke the ${this.props.serviceName} watchbot pipeline`
+      exportName: `${this.props.stackName}-topic`,
+      description: `SNS topic to send messages to in order to invoke the ${this.props.stackName} watchbot pipeline`
     });
 
     this.monitoring = this.createAlarms();

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -211,6 +211,12 @@ export interface WatchbotProps {
    */
   readonly minScalingCapacity?: number;
 
+  /**
+   * The amount of time between scale up events for the service
+   * @default 5
+   */
+  readonly scaleUpAlarmIntervalMinutes?: number;
+
   readonly alarms: WatchbotAlarms;
 
   /**
@@ -407,6 +413,7 @@ export class FargateWatchbot extends Resource {
       // scaling props
       maxScalingCapacity: this.props.maxScalingCapacity,
       minScalingCapacity: this.props.minScalingCapacity,
+      scaleUpAlarmIntervalMinutes: this.props.scaleUpAlarmIntervalMinutes || 5,
 
       // network config props
       taskSubnets: this.props.subnets,

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -45,12 +45,6 @@ export interface WatchbotProps {
   readonly containerName?: string;
 
   /**
-   * The intervals for scaling based on the SQS queue's ApproximateNumberOfMessagesVisible metric.
-   * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns.QueueProcessingFargateService.html#scalingsteps
-   */
-  readonly scalingSteps?: ScalingInterval[];
-
-  /**
    * The runtime platform of the task definition.
    * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns.QueueProcessingFargateService.html#runtimeplatform
    */

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -380,9 +380,7 @@ export class FargateWatchbot extends Resource {
 
       // Task Definition props
       cpu: this.props.cpu,
-      ephemeralStorageGiB: {
-        sizeInGiB: this.props.ephemeralStorageGiB,
-      },
+      ephemeralStorageGiB: this.props.ephemeralStorageGiB,
       memoryLimitMiB: this.props.memoryLimitMiB,
       family: this.props.family,
       runtimePlatform: this.props.runtimePlatform,
@@ -467,8 +465,8 @@ export class FargateWatchbot extends Resource {
     }
     new CfnOutput(this, 'TopicOutput', {
       value: this.topic?.topicArn || '',
-      exportName: `${this.props.stackName}-topic`,
-      description: `SNS topic to send messages to in order to invoke the ${this.props.stackName} watchbot pipeline`
+      exportName: `${this.stack.stackName}-topic`,
+      description: `SNS topic to send messages to in order to invoke the ${this.stack.stackName} watchbot pipeline`
     });
 
     this.monitoring = this.createAlarms();

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -494,7 +494,7 @@ export class FargateWatchbot extends Resource {
           onAlarmTopic: this.props.alarms.action
         })
       },
-      // dashboardFactory: factory
+      dashboardFactory: factory
     });
 
     const workersErrorsMetric = this.logGroup

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -45,6 +45,12 @@ export interface WatchbotProps {
   readonly containerName?: string;
 
   /**
+   * The intervals for scaling based on the SQS queue's ApproximateNumberOfMessagesVisible metric.
+   * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns.QueueProcessingFargateService.html#scalingsteps
+   */
+  readonly scalingSteps?: ScalingInterval[];
+
+  /**
    * The runtime platform of the task definition.
    * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns.QueueProcessingFargateService.html#runtimeplatform
    */

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -215,7 +215,7 @@ export interface WatchbotProps {
    * The amount of time between scale up events for the service
    * @default Duration.minutes(5)
    */
-  readonly scaleUpAlarmIntervalMinutes?: Duration;
+  readonly scaleUpAlarmInterval?: Duration;
 
   readonly alarms: WatchbotAlarms;
 
@@ -413,7 +413,7 @@ export class FargateWatchbot extends Resource {
       // scaling props
       maxScalingCapacity: this.props.maxScalingCapacity,
       minScalingCapacity: this.props.minScalingCapacity,
-      scaleUpAlarmIntervalMinutes: this.props.scaleUpAlarmIntervalMinutes || Duration.minutes(5),
+      scaleUpAlarmInterval: this.props.scaleUpAlarmInterval || Duration.minutes(5),
 
       // network config props
       taskSubnets: this.props.subnets,
@@ -494,7 +494,7 @@ export class FargateWatchbot extends Resource {
           onAlarmTopic: this.props.alarms.action
         })
       },
-      dashboardFactory: factory
+      // dashboardFactory: factory
     });
 
     const workersErrorsMetric = this.logGroup

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -488,7 +488,7 @@ export class FargateWatchbot extends Resource {
 
     const monitoring = new MonitoringFacade(this, 'Monitoring', {
       alarmFactoryDefaults: {
-        alarmNamePrefix: `${this.stack.stackName}-${this.prefixed('')}`,
+        alarmNamePrefix: this.prefixed(''),
         actionsEnabled: true,
         action: new SnsAlarmActionStrategy({
           onAlarmTopic: this.props.alarms.action

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -7,7 +7,6 @@ import {
   ContainerImage,
   HealthCheck,
   ICluster,
-  LinuxParametersProps,
   LogDrivers,
   MountPoint,
   PropagatedTagSource,
@@ -241,11 +240,6 @@ export interface WatchbotProps {
     writeCapacityUnits?: number;
   };
 
-  /**
-   * Linux-specific modifications that are applied to the container, such as Linux kernel capabilities.
-   * @default undefined
-   */
-  readonly linuxParameters?: LinuxParametersProps;
 }
 
 export type WatchbotAlarms = {
@@ -410,7 +404,6 @@ export class FargateWatchbot extends Resource {
         logGroup: this.logGroup
       }),
       healthCheck: this.props.healthCheck,
-      linuxParameters: this.props.linuxParameters,
 
       queue: this.queue,
 

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -111,6 +111,13 @@ export interface WatchbotProps {
   readonly serviceVersion: string;
 
   /**
+   * The size of the ephemeral storage disk to make available to the container in GB.
+   * @default 20
+   * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.CfnTaskDefinition.EphemeralStorageProperty.html
+   */
+  readonly ephemeralStorageGiB?: number;
+
+  /**
    * The name of a family that the task definition is registered to.
    * @default uses serviceName
    * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns.QueueProcessingFargateService.html#family
@@ -373,6 +380,9 @@ export class FargateWatchbot extends Resource {
 
       // Task Definition props
       cpu: this.props.cpu,
+      ephemeralStorageGiB: {
+        sizeInGiB: this.props.ephemeralStorageGiB,
+      },
       memoryLimitMiB: this.props.memoryLimitMiB,
       family: this.props.family,
       runtimePlatform: this.props.runtimePlatform,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-38",
+  "version": "10.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.1-38",
+      "version": "10.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-0",
+  "version": "10.1.1-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.1-0",
+      "version": "10.1.1-3",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,21 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-3",
+  "version": "10.1.1-31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.1-3",
+      "version": "10.1.1-31",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",
         "@aws-sdk/client-cloudformation": "^3.414.0",
         "@aws-sdk/client-s3": "^3.414.0",
         "@aws-sdk/client-sqs": "^3.414.0",
         "@mapbox/cloudfriend": "^7.1.0",
         "@mapbox/watchbot-progress": "^1.1.7",
         "binary-split": "^1.0.5",
-        "cdk-monitoring-constructs": "^7.1.0",
+        "cdk-monitoring-constructs": "^8.3.0",
         "fs-extra": "^8.1.0",
         "inquirer": "^7.0.0",
         "p-queue": "^6.2.1",
@@ -35,7 +34,7 @@
         "@mapbox/mock-aws-sdk-js": "^1.0.0",
         "@types/jest": "^29.5.5",
         "@types/node": "20.7.1",
-        "aws-cdk-lib": "2.112.0",
+        "aws-cdk-lib": "2.162.1",
         "aws-sdk-client-mock": "^3.0.0",
         "cli-spinner": "^0.2.10",
         "constructs": "^10.0.5",
@@ -58,8 +57,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",
-        "aws-cdk-lib": "^2.112.0",
+        "aws-cdk-lib": "^2.162.1",
         "constructs": "^10.0.5"
       }
     },
@@ -77,9 +75,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.201",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz",
-      "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ=="
+      "version": "2.2.207",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.207.tgz",
+      "integrity": "sha512-5oRh5Ad7hGSqwM3+/X8MmIkUjBMGU9sd1g+pa3L0s8IL15OQcFW0ZT0gsUdEb/N/JV663jUUpSbtD7pLO65O4Q=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
@@ -87,20 +85,40 @@
       "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
     },
-    "node_modules/@aws-cdk/aws-redshift-alpha": {
-      "version": "2.112.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-redshift-alpha/-/aws-redshift-alpha-2.112.0-alpha.0.tgz",
-      "integrity": "sha512-vxGq1c/JPzJ9TT9Io222oE4WvjDQBuITOylVVDsWPCNXH8Detu147e5w6SfzIEESRwAlXwcgEonRb+arlMRplQ==",
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "38.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
+      "integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 14.15.0"
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.6.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.112.0",
-        "constructs": "^10.0.0"
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -4070,9 +4088,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.112.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.112.0.tgz",
-      "integrity": "sha512-nrxfXM05Lq6HRoOXdrGXcc1XqqJTtCW3EkjPqdT0kkZ+fR6yQgbzdW2nVxSBiVDNmcf82vLBTmFMezdEgj8N4w==",
+      "version": "2.162.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.162.1.tgz",
+      "integrity": "sha512-XiZLVE5ISNajNNmLye8l5w4EGqm6/d8C8shw63QwxaRVYdHl5e+EAaUEmZJpWc4sYtY/sS+GHOfhoKFLjha2rg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -4083,21 +4101,24 @@
         "punycode",
         "semver",
         "table",
-        "yaml"
+        "yaml",
+        "mime-types"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.201",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^38.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.3.0",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.2",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.5.4",
-        "table": "^6.8.1",
+        "semver": "^7.6.3",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -4113,14 +4134,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.12.0",
+      "version": "8.17.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -4210,8 +4231,13 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.1.1",
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4229,7 +4255,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.3.0",
+      "version": "5.3.2",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4273,15 +4299,23 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 0.6"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
@@ -4312,12 +4346,9 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.6.3",
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4366,7 +4397,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.1",
+      "version": "6.8.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4387,19 +4418,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/uri-js": {
-      "version": "4.4.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
@@ -5013,11 +5031,10 @@
       ]
     },
     "node_modules/cdk-monitoring-constructs": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cdk-monitoring-constructs/-/cdk-monitoring-constructs-7.1.0.tgz",
-      "integrity": "sha512-Fadd0tj194fwJsU3o8d2oeKwjS3lXXbVDfMX7/2hY+6iPuKAVxhRjH0RuPxuiO9TcYvHdqZDTx/Z9nUXn+m9LA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/cdk-monitoring-constructs/-/cdk-monitoring-constructs-8.3.1.tgz",
+      "integrity": "sha512-DarIi74aBCDtxgA9YPMJJeTKGN/p2Mw8L2DOTEsWMVNdX3ikkwKENkmy7qTbJg0Baha1mZqZBF+4SnrX7rP5WA==",
       "peerDependencies": {
-        "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",
         "aws-cdk-lib": "^2.112.0",
         "constructs": "^10.0.5"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-36",
+  "version": "10.1.1-37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.1-36",
+      "version": "10.1.1-37",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-34",
+  "version": "10.1.1-36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.1-34",
+      "version": "10.1.1-36",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.0.3-0",
+  "version": "10.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.0.3-0",
+      "version": "10.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-33",
+  "version": "10.1.1-34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.1-33",
+      "version": "10.1.1-34",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.0",
+  "version": "10.1.1-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.0",
+      "version": "10.1.1-0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-31",
+  "version": "10.1.1-32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.1-31",
+      "version": "10.1.1-32",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-32",
+  "version": "10.1.1-33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.1-32",
+      "version": "10.1.1-33",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.0.2",
+  "version": "10.0.3-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.0.2",
+      "version": "10.0.3-0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-37",
+  "version": "10.1.1-38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.1-37",
+      "version": "10.1.1-38",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-38",
+  "version": "10.1.1-39",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-16",
+  "version": "10.1.1-17",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-7",
+  "version": "10.1.1-8",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-0",
+  "version": "10.1.1-1",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-31",
+  "version": "10.1.1-32",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.0",
+  "version": "10.1.1-0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-18",
+  "version": "10.1.1-19",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.0.3-0",
+  "version": "10.1.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-8",
+  "version": "10.1.1-9",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-19",
+  "version": "10.1.1-20",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-36",
+  "version": "10.1.1-37",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-21",
+  "version": "10.1.1-22",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-30",
+  "version": "10.1.1-31",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-12",
+  "version": "10.1.1-13",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.0.2",
+  "version": "10.0.3-0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-22",
+  "version": "10.1.1-23",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-11",
+  "version": "10.1.1-12",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-2",
+  "version": "10.1.1-3",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-17",
+  "version": "10.1.1-18",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-20",
+  "version": "10.1.1-21",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-29",
+  "version": "10.1.1-30",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-5",
+  "version": "10.1.1-6",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-37",
+  "version": "10.1.1-38",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-34",
+  "version": "10.1.1-36",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-14",
+  "version": "10.1.1-15",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-23",
+  "version": "10.1.1-24",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-4",
+  "version": "10.1.1-5",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-13",
+  "version": "10.1.1-14",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-15",
+  "version": "10.1.1-16",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-3",
+  "version": "10.1.1-4",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@mapbox/mock-aws-sdk-js": "^1.0.0",
     "@types/jest": "^29.5.5",
     "@types/node": "20.7.1",
-    "aws-cdk-lib": "2.112.0",
+    "aws-cdk-lib": "2.162.1",
     "aws-sdk-client-mock": "^3.0.0",
     "cli-spinner": "^0.2.10",
     "constructs": "^10.0.5",
@@ -59,14 +59,13 @@
     "typescript": "~5.2.2"
   },
   "dependencies": {
-    "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",
     "@aws-sdk/client-cloudformation": "^3.414.0",
     "@aws-sdk/client-s3": "^3.414.0",
     "@aws-sdk/client-sqs": "^3.414.0",
     "@mapbox/cloudfriend": "^7.1.0",
     "@mapbox/watchbot-progress": "^1.1.7",
     "binary-split": "^1.0.5",
-    "cdk-monitoring-constructs": "^7.1.0",
+    "cdk-monitoring-constructs": "^8.3.0",
     "fs-extra": "^8.1.0",
     "inquirer": "^7.0.0",
     "p-queue": "^6.2.1",
@@ -75,8 +74,7 @@
     "tree-kill": "^1.2.1"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",
-    "aws-cdk-lib": "^2.112.0",
+    "aws-cdk-lib": "^2.162.1",
     "constructs": "^10.0.5"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-1",
+  "version": "10.1.1-2",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-10",
+  "version": "10.1.1-11",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-24",
+  "version": "10.1.1-29",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-33",
+  "version": "10.1.1-34",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-32",
+  "version": "10.1.1-33",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-39",
+  "version": "10.1.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-6",
+  "version": "10.1.1-7",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-9",
+  "version": "10.1.1-10",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -7,11 +7,11 @@ A library to help run a highly-scalable AWS service that performs data processin
 Add these lines to your Dockerfile, to use the latest watchbot for the linux operating system.
 
 ```
-RUN wget https://s3.amazonaws.com/ecs-watchbot-binaries/linux/v10.0.2/watchbot -O /usr/local/bin/watchbot
+RUN wget https://s3.amazonaws.com/ecs-watchbot-binaries/linux/v10.1.0/watchbot -O /usr/local/bin/watchbot
 RUN chmod +x /usr/local/bin/watchbot
 ```
 * **os**: You can replace `linux` with other operating systems like `alpine`, `macosx` or, `windows`
-* **tag**: You can replace `v10.0.2`  with any [watchbot tag](https://github.com/mapbox/ecs-watchbot/releases) starting from and more recent than v4.0.0
+* **tag**: You can replace `v10.1.0`  with any [watchbot tag](https://github.com/mapbox/ecs-watchbot/releases) starting from and more recent than v4.0.0
   * :rotating_light: For any version <= 9, you need to use `https://s3.amazonaws.com/watchbot-binaries/linux/{VERSION}/watchbot` (note the difference in bucket name)
 
 * If you are an existing user of watchbot, take a look at ["Upgrading to Watchbot 10"](https://github.com/mapbox/ecs-watchbot/blob/master/docs/upgrading-to-watchbot10.md), for a complete set of instructions to upgrade your stacks to Watchbot 10.

--- a/test/watchbot.test.ts
+++ b/test/watchbot.test.ts
@@ -185,7 +185,7 @@ describe('FargateWatchbot', () => {
         PolicyType: 'StepScaling',
         StepScalingPolicyConfiguration: {
           AdjustmentType: 'ChangeInCapacity',
-          MetricAggregationType: 'Average',
+          MetricAggregationType: 'Maximum',
           StepAdjustments: [
             {
               MetricIntervalLowerBound: 0,
@@ -209,7 +209,7 @@ describe('FargateWatchbot', () => {
         MetricName: 'ApproximateNumberOfMessagesVisible',
         Namespace: 'AWS/SQS',
         Period: 300,
-        Statistic: 'Average',
+        Statistic: 'Maximum',
         Threshold: 1
       });
 

--- a/test/watchbot.test.ts
+++ b/test/watchbot.test.ts
@@ -169,28 +169,27 @@ describe('FargateWatchbot', () => {
 
     it('creates scaling resources', () => {
       template.hasResourceProperties('AWS::ApplicationAutoScaling::ScalingPolicy', {
-        PolicyType: 'TargetTrackingScaling',
-        TargetTrackingScalingPolicyConfiguration: {
-          PredefinedMetricSpecification: {
-            PredefinedMetricType: 'ECSServiceAverageCPUUtilization'
-          },
-          TargetValue: 50
+        PolicyType: 'StepScaling',
+        StepScalingPolicyConfiguration: {
+          AdjustmentType: 'PercentChangeInCapacity',
+          MetricAggregationType: 'Average',
+          StepAdjustments: [
+            {
+              MetricIntervalUpperBound: 0,
+              ScalingAdjustment: -100,
+            }
+          ]
         }
       });
       template.hasResourceProperties('AWS::ApplicationAutoScaling::ScalingPolicy', {
         PolicyType: 'StepScaling',
         StepScalingPolicyConfiguration: {
           AdjustmentType: 'ChangeInCapacity',
-          MetricAggregationType: 'Maximum',
+          MetricAggregationType: 'Average',
           StepAdjustments: [
             {
               MetricIntervalLowerBound: 0,
-              MetricIntervalUpperBound: 400,
               ScalingAdjustment: 1
-            },
-            {
-              MetricIntervalLowerBound: 400,
-              ScalingAdjustment: 5
             }
           ]
         }
@@ -210,8 +209,8 @@ describe('FargateWatchbot', () => {
         MetricName: 'ApproximateNumberOfMessagesVisible',
         Namespace: 'AWS/SQS',
         Period: 300,
-        Statistic: 'Maximum',
-        Threshold: 100
+        Statistic: 'Average',
+        Threshold: 1
       });
 
       template.hasResourceProperties('AWS::CloudWatch::Alarm', {
@@ -224,10 +223,10 @@ describe('FargateWatchbot', () => {
           }
         ],
         EvaluationPeriods: 1,
-        MetricName: 'ApproximateNumberOfMessagesVisible',
-        Namespace: 'AWS/SQS',
-        Period: 300,
-        Statistic: 'Maximum',
+        MetricName: 'TotalMessages',
+        Namespace: "Mapbox/ecs-watchbot",
+        Period: 600,
+        Statistic: 'Average',
         Threshold: 0
       });
     });


### PR DESCRIPTION
hi all!

I've been testing the `10.0.2` package over the past week to identify any gaps between the 9.x watchbot behavior and what we need on the places side in multiaccount.

I've made the following changes:
- Expose configuration for the ephemeral storage volume 
  - default is 20 GB, with configuration this can go up to 200 GB
- Update the scaling approach
  - Port the TotalMessage metric (Visible SQS messages + NotVisible SQS messages) over from 9.x
  - Scale down if this is 0
  - Scale up if VisibleMessages is >1; number of new tasks based on the max tasks available for this service
- Removing the LinuxParameters for the time being
  - I was able to build gb-postcode successfully as-is 🎉 
  - I'll continue testing the rest of our data today and tomorrow
  - In general, even if we add this param, there will lots of troubleshooting required to understand what we need to pass to get things working on fargate
- Run the tests on GHA (previously they were on codebuild, but are no longer being run?)
- Update test fixtures to capture the new scaling approach

## PR checklist:

- [x] I included JIRA ticket code in the PR header
- [x] I read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) doc.
- [x] I used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title.
- [x] I used proper typescript comments to document the changes made
- [x] I made changes to relevant tests or added new tests if applicable
- [x] I updated the [package.json](package.json), [package-lock.json](package-lock.json) and [readme.md](readme.md) to reflect the new correct Watchbot version
  - DO NOT MERGE WITHOUT MAKING THESE CHANGES
- [x] I updated the [changelog.md](changelog.md)

