### PR TITLE
Disambiguate worker, CPU and Memory alarms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### 10.1.2
+- Attach stack name to CPU, Memory and Worker errors alarms
+
 ### 10.1.0
 - Port watchbot scaling logic from 9.x to scale down based on total message (visible and not visible)
 - Expose ephemeralStorageGiB param to customize disk size up to 200 GB (default 20 GB)

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -554,13 +554,12 @@ export class FargateWatchbot extends Resource {
       })
       .monitorCustom({
         addToAlarmDashboard: true,
-        alarmFriendlyName: `worker-errors-${this.stack.stackName}`,
         metricGroups: [
           {
             title: 'Worker Errors',
             metrics: [
               {
-                alarmFriendlyName: `worker-errors-${this.stack.stackName}`,
+                alarmFriendlyName: 'worker-errors',
                 metric: workersErrorsMetric,
                 addAlarm: {
                   error: {

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -554,12 +554,13 @@ export class FargateWatchbot extends Resource {
       })
       .monitorCustom({
         addToAlarmDashboard: true,
+        alarmFriendlyName: `worker-errors-${this.stack.region}`,
         metricGroups: [
           {
             title: 'Worker Errors',
             metrics: [
               {
-                alarmFriendlyName: 'worker-errors',
+                alarmFriendlyName: `worker-errors-${this.stack.region}`,
                 metric: workersErrorsMetric,
                 addAlarm: {
                   error: {

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -554,13 +554,13 @@ export class FargateWatchbot extends Resource {
       })
       .monitorCustom({
         addToAlarmDashboard: true,
-        alarmFriendlyName: `worker-errors-${this.stack.region}`,
+        alarmFriendlyName: `worker-errors-${this.stack.stackName}`,
         metricGroups: [
           {
             title: 'Worker Errors',
             metrics: [
               {
-                alarmFriendlyName: `worker-errors-${this.stack.region}`,
+                alarmFriendlyName: `worker-errors-${this.stack.stackName}`,
                 metric: workersErrorsMetric,
                 addAlarm: {
                   error: {

--- a/lib/watchbot.ts
+++ b/lib/watchbot.ts
@@ -488,7 +488,7 @@ export class FargateWatchbot extends Resource {
 
     const monitoring = new MonitoringFacade(this, 'Monitoring', {
       alarmFactoryDefaults: {
-        alarmNamePrefix: this.prefixed(''),
+        alarmNamePrefix: this.stack.stackName,
         actionsEnabled: true,
         action: new SnsAlarmActionStrategy({
           onAlarmTopic: this.props.alarms.action

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.2-2",
+  "version": "10.1.2-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.2-2",
+      "version": "10.1.2-3",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-1",
+  "version": "10.1.2-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.1-1",
+      "version": "10.1.2-1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.2-3",
+  "version": "10.1.2-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.2-3",
+      "version": "10.1.2-4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.2-1",
+  "version": "10.1.2-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.2-1",
+      "version": "10.1.2-2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.2-5",
+  "version": "10.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.2-5",
+      "version": "10.1.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.2-4",
+  "version": "10.1.2-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.2-4",
+      "version": "10.1.2-5",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.0",
+  "version": "10.1.1-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/watchbot",
-      "version": "10.1.0",
+      "version": "10.1.1-1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.414.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.1-1",
+  "version": "10.1.2-1",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.2-2",
+  "version": "10.1.2-3",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.2-4",
+  "version": "10.1.2-5",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.2-5",
+  "version": "10.1.2",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.2-1",
+  "version": "10.1.2-2",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.0",
+  "version": "10.1.1-1",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/watchbot",
-  "version": "10.1.2-3",
+  "version": "10.1.2-4",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -7,11 +7,11 @@ A library to help run a highly-scalable AWS service that performs data processin
 Add these lines to your Dockerfile, to use the latest watchbot for the linux operating system.
 
 ```
-RUN wget https://s3.amazonaws.com/ecs-watchbot-binaries/linux/v10.1.0/watchbot -O /usr/local/bin/watchbot
+RUN wget https://s3.amazonaws.com/ecs-watchbot-binaries/linux/v10.1.2/watchbot -O /usr/local/bin/watchbot
 RUN chmod +x /usr/local/bin/watchbot
 ```
 * **os**: You can replace `linux` with other operating systems like `alpine`, `macosx` or, `windows`
-* **tag**: You can replace `v10.1.0`  with any [watchbot tag](https://github.com/mapbox/ecs-watchbot/releases) starting from and more recent than v4.0.0
+* **tag**: You can replace `v10.1.2` with any [watchbot tag](https://github.com/mapbox/ecs-watchbot/releases) starting from and more recent than v4.0.0
   * :rotating_light: For any version <= 9, you need to use `https://s3.amazonaws.com/watchbot-binaries/linux/{VERSION}/watchbot` (note the difference in bucket name)
 
 * If you are an existing user of watchbot, take a look at ["Upgrading to Watchbot 10"](https://github.com/mapbox/ecs-watchbot/blob/master/docs/upgrading-to-watchbot10.md), for a complete set of instructions to upgrade your stacks to Watchbot 10.


### PR DESCRIPTION
This PR attaches the stack name to worker, CPU and Memory alarms to allow for multiple watchbot stacks in a given AWS account.

There's no JIRA ticket for this - @macro-shen identified it when building a stack in an account that had already had a watchbot v10 stack in it.

Resource name changes:
- Watchbot-QueueProcessingFargateService-CPU-Usage-cpu ➡️ mapbox-places-charlie-QueueProcessingFargateService-CPU-Usage-cpu
- Watchbot-QueueProcessingFargateService-Memory-Usage-memoryUsage ➡️ mapbox-places-charlie-QueueProcessingFargateService-Memory-Usage-memoryUsage
- Watchbot-worker-errors-us-east-1-error ➡️ mapbox-places-charlie-worker-errors-us-east-1-error

### Checklist
Complete the steps below before merge where applicable:

- [ ] I included JIRA ticket code in the PR header
- [x] I read and understood the [CONTRIBUTING.md](CONTRIBUTING.md) doc.
- [x] I used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title.
- [x] I used proper typescript comments to document the changes made
- [x] I made changes to relevant tests or added new tests if applicable
- [x] I updated the [package.json](package.json), [package-lock.json](package-lock.json) and [readme.md](readme.md) to reflect the new correct Watchbot version
  - DO NOT MERGE WITHOUT MAKING THESE CHANGES
- [x] I updated the [changelog.md](changelog.md)
